### PR TITLE
Create textfile_inputs directory during install

### DIFF
--- a/installer/wmi_exporter.wxs
+++ b/installer/wmi_exporter.wxs
@@ -27,20 +27,25 @@
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="$(var.PlatformProgramFiles)">
-        <Directory Id="APPLICATIONROOTDIRECTORY" Name="wmi_exporter" />
+        <Directory Id="APPLICATIONROOTDIRECTORY" Name="wmi_exporter">
+          <Directory Id="textfile_inputs" Name="textfile_inputs" />
+        </Directory>
       </Directory>
     </Directory>
 
     <Property Id="TEXTFILE_DIR" Secure="yes"/>
     <SetProperty Id="TextfileDirFlag" After="InstallFiles" Sequence="execute" Value="--collector.textfile.directory [TEXTFILE_DIR]">TEXTFILE_DIR</SetProperty>
 
-    <ComponentGroup Id="Files" Directory="APPLICATIONROOTDIRECTORY">
-      <Component>
+    <ComponentGroup Id="Files">
+      <Component Directory="APPLICATIONROOTDIRECTORY">
         <File Id="wmi_exporter.exe" Name="wmi_exporter.exe" Source="Work\wmi_exporter.exe" KeyPath="yes">
           <fw:FirewallException Id="MetricsEndpoint" Name="WMI Exporter (HTTP [LISTEN_PORT])" Description="WMI Exporter HTTP endpoint" Port="[LISTEN_PORT]" Protocol="tcp" Scope="any" IgnoreFailure="yes" />
         </File>
         <ServiceInstall Id="InstallExporterService" Name="wmi_exporter" DisplayName="WMI exporter" Description="Exports Prometheus metrics from WMI queries" ErrorControl="normal" Start="auto" Type="ownProcess" Arguments="--log.format logger:eventlog?name=wmi_exporter [CollectorsFlag] [ListenFlag] [MetricsPathFlag] [TextfileDirFlag]" />
         <ServiceControl Id="ServiceStateControl" Name="wmi_exporter" Remove="uninstall" Start="install" Stop="both" />
+      </Component>
+      <Component Id="CreateTextfileDirectory" Directory="textfile_inputs" Guid="d03ef58a-9cbf-4165-ad39-d143e9b27e14">
+        <CreateFolder />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
Fixes #184.

It does not handle the case where the user overrides the textfile directory, but I think we can leave that as the users' responsibility for now.