### PR TITLE
feat (service): added support for service StartName

### DIFF
--- a/collector/service.go
+++ b/collector/service.go
@@ -45,7 +45,7 @@ func NewserviceCollector() (Collector, error) {
 		Information: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "info"),
 			"A metric with a constant '1' value labeled with service information",
-			[]string{"name", "display_name", "process_id"},
+			[]string{"name", "display_name", "process_id", "start_name"},
 			nil,
 		),
 		State: prometheus.NewDesc(
@@ -89,6 +89,7 @@ type Win32_Service struct {
 	State       string
 	Status      string
 	StartMode   string
+	StartName   *string
 }
 
 var (
@@ -131,9 +132,13 @@ func (c *serviceCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Des
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}
-
 	for _, service := range dst {
 		pid := strconv.FormatUint(uint64(service.ProcessId), 10)
+
+		startName := ""
+		if service.StartName != nil {
+			startName = *service.StartName
+		}
 		ch <- prometheus.MustNewConstMetric(
 			c.Information,
 			prometheus.GaugeValue,
@@ -141,6 +146,7 @@ func (c *serviceCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Des
 			strings.ToLower(service.Name),
 			service.DisplayName,
 			pid,
+			startName,
 		)
 
 		for _, state := range allStates {

--- a/collector/service.go
+++ b/collector/service.go
@@ -45,7 +45,7 @@ func NewserviceCollector() (Collector, error) {
 		Information: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "info"),
 			"A metric with a constant '1' value labeled with service information",
-			[]string{"name", "display_name", "process_id", "start_name"},
+			[]string{"name", "display_name", "process_id", "run_as"},
 			nil,
 		),
 		State: prometheus.NewDesc(
@@ -135,9 +135,9 @@ func (c *serviceCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Des
 	for _, service := range dst {
 		pid := strconv.FormatUint(uint64(service.ProcessId), 10)
 
-		startName := ""
+		runAs := ""
 		if service.StartName != nil {
-			startName = *service.StartName
+			runAs = *service.StartName
 		}
 		ch <- prometheus.MustNewConstMetric(
 			c.Information,
@@ -146,7 +146,7 @@ func (c *serviceCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Des
 			strings.ToLower(service.Name),
 			service.DisplayName,
 			pid,
-			startName,
+			runAs,
 		)
 
 		for _, state := range allStates {

--- a/docs/collector.service.md
+++ b/docs/collector.service.md
@@ -20,12 +20,12 @@ Example: `--collector.service.services-where="Name='windows_exporter'"`
 
 Name | Description | Type | Labels
 -----|-------------|------|-------
-`windows_service_info` | Contains service information in labels, constant 1 | gauge | name, display_name, process_id
+`windows_service_info` | Contains service information in labels, constant 1 | gauge | name, display_name, process_id, run_as
 `windows_service_state` | The state of the service, 1 if the current state, 0 otherwise | gauge | name, state
 `windows_service_start_mode` | The start mode of the service, 1 if the current start mode, 0 otherwise | gauge | name, start_mode
 `windows_service_status` | The status of the service, 1 if the current status, 0 otherwise | gauge | name, status
 
-For the values of the `state`, `start_mode` and `status` labels, see below.
+For the values of the `state`, `start_mode`, `status` and `run_as` labels, see below.
 
 ### States
 
@@ -65,6 +65,13 @@ A service can have any of the following statuses:
 - `lost comm`
 
 Note that there is some overlap with service state.
+
+### Run As
+
+Account name under which a service runs. Depending on the service type, the account name may be in the form of "DomainName\Username" or UPN format ("Username@DomainName").
+
+It corresponds to the `StartName` attribute of the `Win32_Service` class.
+`StartName` attribute can be NULL and in such case the label is reported as an empty string. Notice that if the attribute is NULL the service is logged on as the `LocalSystem` account or, for kernel or system-level drive, it runs with a default object name created by the I/O system based on the service name, for example, DWDOM\Admin.
 
 ### Example metric
 Lists the services that have a 'disabled' start mode.


### PR DESCRIPTION

Adding support for the `startName` (the name of the service account) creating the service.
 
 - In case it is not available the lablel is left empty

Quoting from [the documentation](https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-service?redirectedfrom=MSDN) the explanation of the added label
>StartName:
>Account name under which a service runs. Depending on the service type, the account name may be in the form of "DomainName\Username" or UPN format ("*Username@DomainName*"). 

>The service process is logged by using one of these two forms when it runs. If the account belongs to the built-in domain, then ".\Username" can be specified. For kernel or system-level drivers, StartName contains the driver object name (that is, "\FileSystem\Rdr" or "\Driver\Xns") which the I/O system uses to load the device driver.

>Additionally, if NULL is specified, the driver runs with a default object name created by the I/O system based on the service name.```