### PR TITLE
Revert fsrm struct removal

### DIFF
--- a/collector/fsrmquota.go
+++ b/collector/fsrmquota.go
@@ -7,10 +7,23 @@ import (
 )
 
 func init() {
-	registerCollector("fsrmquota",newFSRMQuotaCollector)
+	registerCollector("fsrmquota", newFSRMQuotaCollector)
 }
 
-// NewSRMQuotaCollector ...
+type FSRMQuotaCollector struct {
+	QuotasCount *prometheus.Desc
+	Path        *prometheus.Desc
+	PeakUsage   *prometheus.Desc
+	Size        *prometheus.Desc
+	Usage       *prometheus.Desc
+
+	Description     *prometheus.Desc
+	Disabled        *prometheus.Desc
+	MatchesTemplate *prometheus.Desc
+	SoftLimit       *prometheus.Desc
+	Template        *prometheus.Desc
+}
+
 func newFSRMQuotaCollector() (Collector, error) {
 	const subsystem = "fsrmquota"
 	return &FSRMQuotaCollector{


### PR DESCRIPTION
The actual collector struct was accidentally removed in [c23ae31](https://github.com/prometheus-community/windows_exporter/pull/437/commits/c23ae3176f970208085713d06e152a968eae34d7), and this was somehow missed in the last review