### PR TITLE
Set Windows versioninfo on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ VERSION
 output/
 .vscode
 .idea
+*.syso

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
   - ps: |
       $env:GO111MODULE="off"
       go get -u github.com/prometheus/promu
+      go get -u github.com/josephspurrier/goversioninfo/cmd/goversioninfo
       $env:GO111MODULE="on"
 
 test_script:
@@ -37,8 +38,13 @@ build_script:
       # so we need to run it before setting the preference.
       go mod download
       $ErrorActionPreference = "Stop"
+
       gitversion /output json /showvariable FullSemVer | Set-Content VERSION -PassThru
       $Version = Get-Content VERSION
+      # Windows versioninfo resources need the file version by parts (but product version is free text)
+      $VersionParts = ($Version -replace '^v?([0-9\.]+).*$','$1').Split(".")
+      goversioninfo.exe -ver-major $VersionParts[0] -ver-minor $VersionParts[1] -ver-patch $VersionParts[2] -product-version $Version -platform-specific
+
       make crossbuild
       # GH requires all files to have different names, so add version/arch to differentiate
       foreach($Arch in "amd64","386") {

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -1,0 +1,7 @@
+{
+    "StringFileInfo": {
+        "CompanyName": "prometheus-community",
+        "LegalCopyright": "Copyright 2020 The Prometheus Authors",
+        "ProductName": "windows_exporter"
+    }
+}


### PR DESCRIPTION
This PR adds versioninfo generation for the .exe to the build steps, meaning checking the file properties will now look like this:
![image](https://user-images.githubusercontent.com/214867/86519679-506fad00-be3d-11ea-8621-8670712b4687.png)

I also had a moment of inspiration when I saw the field for the icon, so I also threw together the below and if people think it looks okay, it will be the icon for the exe and in Add/Remove programs:
![logo-small](https://user-images.githubusercontent.com/214867/86519694-8dd43a80-be3d-11ea-8cc6-08c90d4a340b.png)
(@brian-brazil - I couldn't find any separate license/usage guidelines for the Prometheus logo and my understanding is that this type of derivative work is fine, correct?)

Fixes #561 