### PR TITLE
Fixed generator for single performance counter

### DIFF
--- a/tools/collector-generator/New-Collector.ps1
+++ b/tools/collector-generator/New-Collector.ps1
@@ -21,11 +21,11 @@ $members = $wmiObject `
     | Get-Member -MemberType Properties `
     | Where-Object { $_.Definition -Match '^u?int' -and $_.Name -NotMatch '_' } `
     | Select-Object Name, @{Name="Type";Expression={$_.Definition.Split(" ")[0]}}
-$input = @{
+$input = ConvertTo-Json @{
     "Class"=$Class;
     "CollectorName"=$CollectorName;
-    "Members"=$members
-} | ConvertTo-Json
+    "Members"=@($members)
+}
 $outFileName = "..\..\collector\$CollectorName.go".ToLower()
 $input | .\collector-generator.exe | Out-File -NoClobber -Encoding UTF8 $outFileName
 go fmt $outFileName


### PR DESCRIPTION
When you wanted to create a generator for an performance counter that had just one counter, you would get this error `panic: json: cannot unmarshal object into Go struct field TemplateData.Members of type []main.Member`.

This was caused because the powershell “unboxed” the single element from the list.