### PR TITLE
Enable the use of remote ip addresses in Windows Firewall exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Name | Description
 `LISTEN_PORT` | The port to bind to. Defaults to 9182.
 `METRICS_PATH` | The path at which to serve metrics. Defaults to `/metrics`
 `TEXTFILE_DIR` | As the `--collector.textfile.directory` flag, provide a directory to read text files with metrics from
+`REMOTE_ADDR` | Allows setting comma separated remote IP addresses for the Windows Firewall exception (whitelist). Defaults to an empty string (any remote address).
 `EXTRA_FLAGS` | Allows passing full CLI flags. Defaults to an empty string.
 
 Parameters are sent to the installer via `msiexec`. Example invocations:

--- a/installer/windows_exporter.wxs
+++ b/installer/windows_exporter.wxs
@@ -28,6 +28,9 @@
 
     <Property Id="METRICS_PATH" Secure="yes"/>
     <SetProperty Id="MetricsPathFlag" After="InstallFiles" Sequence="execute" Value="--telemetry.path [METRICS_PATH]">METRICS_PATH</SetProperty>
+     
+    <Property Id="REMOTE_ADDR" Secure="yes" />
+    <SetProperty Id="RemoteAddressFlag" After="InstallFiles" Sequence="execute" Value="[REMOTE_ADDR]">REMOTE_ADDR</SetProperty> 
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="$(var.PlatformProgramFiles)">
@@ -43,7 +46,9 @@
     <ComponentGroup Id="Files">
       <Component Directory="APPLICATIONROOTDIRECTORY">
         <File Id="windows_exporter.exe" Name="windows_exporter.exe" Source="Work\windows_exporter.exe" KeyPath="yes">
-          <fw:FirewallException Id="MetricsEndpoint" Name="windows_exporter (HTTP [LISTEN_PORT])" Description="windows_exporter HTTP endpoint" Port="[LISTEN_PORT]" Protocol="tcp" Scope="any" IgnoreFailure="yes" />
+          <fw:FirewallException Id="MetricsEndpoint" Name="windows_exporter (HTTP [LISTEN_PORT])" Description="windows_exporter HTTP endpoint" Port="[LISTEN_PORT]" Protocol="tcp" IgnoreFailure="yes">
+            <fw:RemoteAddress>[REMOTE_ADDR]</fw:RemoteAddress>
+          </fw:FirewallException> 
         </File>
         <ServiceInstall Id="InstallExporterService" Name="windows_exporter" DisplayName="windows_exporter" Description="Exports Prometheus metrics from WMI queries" ErrorControl="normal" Start="auto" Type="ownProcess" Arguments="--log.format logger:eventlog?name=windows_exporter [CollectorsFlag] [ListenFlag] [MetricsPathFlag] [TextfileDirFlag] [ExtraFlags]">
           <util:ServiceConfig FirstFailureActionType="restart" SecondFailureActionType="restart" ThirdFailureActionType="restart" RestartServiceDelayInSeconds="5" />


### PR DESCRIPTION
I was looking for a way to limit the Windows Firewall exception (added by the installer) to the remote IP address of our prometheus server to prevent uninvolved systems from accessing the metrics endpoint. This could also be of interest to other users who want to roll out windows_exporter on a large number of machines (e.g. SCCM).

I've never used WiX before but found the `<fw:RemoteAddress>` tag and added a CLI property. I have successfully tested the following cases:

- `msiexec /i <path-to-msi-file> REMOTE_ADDR=<ip-address-1>`: Adds one IP address to `Remote IP address` in FW rule
- `msiexec /i <path-to-msi-file> REMOTE_ADDR=<ip-address-1>,<ip-address-2>`: Adds two IP addresses to `Remote IP address` in FW rule
- `msiexec /i <path-to-msi-file>`: Leaves the option `Any IP address` activated 
