### PR TITLE
Use perflib to gather metrics for netframework collectors

### DIFF
--- a/collector/netframework.go
+++ b/collector/netframework.go
@@ -1,0 +1,40 @@
+package collector
+
+import (
+	"fmt"
+	"regexp"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	netframeworkWhitelist = kingpin.Flag(
+		"collector.netframework.whitelist",
+		"Regexp of processes to include. Process name must both match whitelist and not match blacklist to be included.",
+	).Default(".*").String()
+	netframeworkBlacklist = kingpin.Flag(
+		"collector.netframework.blacklist",
+		"Regexp of processes to exclude. Process name must both match whitelist and not match blacklist to be included.",
+	).Default("").String()
+)
+
+// A NETFrameworkFlags stores common flags for the netframework family of collectors.
+type NETFrameworkFlags struct {
+	whitelist       *string
+	blacklist       *string
+	whitelistRegexp *regexp.Regexp
+	blacklistRegexp *regexp.Regexp
+}
+
+var netframeworkFlags NETFrameworkFlags
+
+// GetNETFrameworkFlags provides access to common flags for the netframework family of collectors.
+func GetNETFrameworkFlags() *NETFrameworkFlags {
+	if netframeworkFlags.whitelist == nil {
+		netframeworkFlags.whitelist = netframeworkWhitelist
+		netframeworkFlags.blacklist = netframeworkBlacklist
+		netframeworkFlags.whitelistRegexp = regexp.MustCompile(fmt.Sprintf("^(?:%s)$", *netframeworkWhitelist))
+		netframeworkFlags.blacklistRegexp = regexp.MustCompile(fmt.Sprintf("^(?:%s)$", *netframeworkBlacklist))
+	}
+	return &netframeworkFlags
+}

--- a/collector/netframework_clrexceptions.go
+++ b/collector/netframework_clrexceptions.go
@@ -97,8 +97,8 @@ func (c *NETFrameworkCLRExceptionsCollector) collect(ctx *ScrapeContext, ch chan
 		name := process.Name
 		procnum, exists := names[name]
 		if exists {
-			name = fmt.Sprintf("%s#%d", name, procnum)
 			names[name]++
+			name = fmt.Sprintf("%s#%d", name, procnum)
 		} else {
 			names[name] = 1
 		}

--- a/collector/netframework_clrinterop.go
+++ b/collector/netframework_clrinterop.go
@@ -90,8 +90,8 @@ func (c *NETFrameworkCLRInteropCollector) collect(ctx *ScrapeContext, ch chan<- 
 		name := process.Name
 		procnum, exists := names[name]
 		if exists {
-			name = fmt.Sprintf("%s#%d", name, procnum)
 			names[name]++
+			name = fmt.Sprintf("%s#%d", name, procnum)
 		} else {
 			names[name] = 1
 		}

--- a/collector/netframework_clrjit.go
+++ b/collector/netframework_clrjit.go
@@ -99,8 +99,8 @@ func (c *NETFrameworkCLRJitCollector) collect(ctx *ScrapeContext, ch chan<- prom
 		name := process.Name
 		procnum, exists := names[name]
 		if exists {
-			name = fmt.Sprintf("%s#%d", name, procnum)
 			names[name]++
+			name = fmt.Sprintf("%s#%d", name, procnum)
 		} else {
 			names[name] = 1
 		}

--- a/collector/netframework_clrjit.go
+++ b/collector/netframework_clrjit.go
@@ -4,6 +4,7 @@ package collector
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
@@ -19,11 +20,15 @@ type NETFrameworkCLRJitCollector struct {
 	TimeinJit                  *prometheus.Desc
 	StandardJitFailures        *prometheus.Desc
 	TotalNumberofILBytesJitted *prometheus.Desc
+
+	processWhitelistPattern *regexp.Regexp
+	processBlacklistPattern *regexp.Regexp
 }
 
 // NewNETFrameworkCLRJitCollector ...
 func NewNETFrameworkCLRJitCollector() (Collector, error) {
 	const subsystem = "netframework_clrjit"
+	commonFlags := GetNETFrameworkFlags()
 	return &NETFrameworkCLRJitCollector{
 		NumberofMethodsJitted: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "jit_methods_total"),
@@ -49,6 +54,8 @@ func NewNETFrameworkCLRJitCollector() (Collector, error) {
 			[]string{"process"},
 			nil,
 		),
+		processWhitelistPattern: commonFlags.whitelistRegexp,
+		processBlacklistPattern: commonFlags.blacklistRegexp,
 	}, nil
 }
 
@@ -96,6 +103,13 @@ func (c *NETFrameworkCLRJitCollector) collect(ctx *ScrapeContext, ch chan<- prom
 			names[name]++
 		} else {
 			names[name] = 1
+		}
+
+		// The pattern matching against the whitelist and blacklist has to occur
+		// after appending #N above to be consistent with other collectors.
+		if c.processBlacklistPattern.MatchString(name) ||
+			!c.processWhitelistPattern.MatchString(name) {
+			continue
 		}
 
 		ch <- prometheus.MustNewConstMetric(

--- a/collector/netframework_clrloading.go
+++ b/collector/netframework_clrloading.go
@@ -143,8 +143,8 @@ func (c *NETFrameworkCLRLoadingCollector) collect(ctx *ScrapeContext, ch chan<- 
 		name := process.Name
 		procnum, exists := names[name]
 		if exists {
-			name = fmt.Sprintf("%s#%d", name, procnum)
 			names[name]++
+			name = fmt.Sprintf("%s#%d", name, procnum)
 		} else {
 			names[name] = 1
 		}

--- a/collector/netframework_clrlocksandthreads.go
+++ b/collector/netframework_clrlocksandthreads.go
@@ -123,8 +123,8 @@ func (c *NETFrameworkCLRLocksAndThreadsCollector) collect(ctx *ScrapeContext, ch
 		name := process.Name
 		procnum, exists := names[name]
 		if exists {
-			name = fmt.Sprintf("%s#%d", name, procnum)
 			names[name]++
+			name = fmt.Sprintf("%s#%d", name, procnum)
 		} else {
 			names[name] = 1
 		}

--- a/collector/netframework_clrmemory.go
+++ b/collector/netframework_clrmemory.go
@@ -175,8 +175,8 @@ func (c *NETFrameworkCLRMemoryCollector) collect(ctx *ScrapeContext, ch chan<- p
 		name := process.Name
 		procnum, exists := names[name]
 		if exists {
-			name = fmt.Sprintf("%s#%d", name, procnum)
 			names[name]++
+			name = fmt.Sprintf("%s#%d", name, procnum)
 		} else {
 			names[name] = 1
 		}

--- a/collector/netframework_clrremoting.go
+++ b/collector/netframework_clrremoting.go
@@ -113,8 +113,8 @@ func (c *NETFrameworkCLRRemotingCollector) collect(ctx *ScrapeContext, ch chan<-
 		name := process.Name
 		procnum, exists := names[name]
 		if exists {
-			name = fmt.Sprintf("%s#%d", name, procnum)
 			names[name]++
+			name = fmt.Sprintf("%s#%d", name, procnum)
 		} else {
 			names[name] = 1
 		}

--- a/collector/netframework_clrsecurity.go
+++ b/collector/netframework_clrsecurity.go
@@ -98,8 +98,8 @@ func (c *NETFrameworkCLRSecurityCollector) collect(ctx *ScrapeContext, ch chan<-
 		name := process.Name
 		procnum, exists := names[name]
 		if exists {
-			name = fmt.Sprintf("%s#%d", name, procnum)
 			names[name]++
+			name = fmt.Sprintf("%s#%d", name, procnum)
 		} else {
 			names[name] = 1
 		}


### PR DESCRIPTION
The netframework_* collectors are updated to use perflib rather than WMI
to read metric data from Windows. In addition, flags named
collector.netframework.whitelist and collector.netframework.blacklist
are added to allow processes to be included and excluded by name,
respectively, in the netframework collectors.

Reported metric values are consistent with the WMI implementation,
except for windows_netframework_clrjit_jit_time_percent and
windows_netframework_clrmemory_gc_time_percent. The values reported
by this implementation are consistent with those reported by Windows
Performance Monitor.