### PR TITLE
Bump Go version from 1.13 to 1.15 for CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,7 @@
 version: "{build}"
 
-os: Visual Studio 2017
+os: Visual Studio 2019
 build: off
-stack: go 1.13
 
 environment:
   GOPATH: c:\gopath
@@ -13,7 +12,7 @@ clone_folder: c:\gopath\src\github.com\prometheus-community\windows_exporter
 install:
   - mkdir %GOPATH%\bin
   - set PATH=%GOPATH%\bin;%PATH%
-  - set PATH=%PATH%;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin
+  - set PATH=%PATH%;C:\msys64\mingw64\bin
   - choco install gitversion.portable make -y
   - ps: |
       appveyor DownloadFile https://github.com/golangci/golangci-lint/releases/download/v1.21.0/golangci-lint-1.21.0-windows-amd64.zip


### PR DESCRIPTION
Fixes #629, by including bugfix for
https://github.com/golang/go/issues/35447