### PR TITLE
Fix panic in HyperV collector on input format mismatch

### DIFF
--- a/collector/hyperv.go
+++ b/collector/hyperv.go
@@ -1001,8 +1001,17 @@ func (c *HyperVCollector) collectVmCpuUsage(ch chan<- prometheus.Metric) (*prome
 		}
 		// The name format is <VM Name>:Hv VP <vcore id>
 		parts := strings.Split(obj.Name, ":")
+		if len(parts) != 2 {
+			log.Warnf("Unexpected format of Name in collectVmCpuUsage: %q, expected %q. Skipping.", obj.Name, "<VM Name>:Hv VP <vcore id>")
+			continue
+		}
+		coreParts := strings.Split(parts[1], " ")
+		if len(coreParts) != 3 {
+			log.Warnf("Unexpected format of core identifier in collectVmCpuUsage: %q, expected %q. Skipping.", parts[1], "Hv VP <vcore id>")
+			continue
+		}
 		vmName := parts[0]
-		coreId := strings.Split(parts[1], " ")[2]
+		coreId := coreParts[2]
 
 		ch <- prometheus.MustNewConstMetric(
 			c.VMGuestRunTime,


### PR DESCRIPTION
Apparently the format of the WMI object names returned for Hyper-V Virtual Processors doesn't always follow assumptions, leading to a panic. This PR changes this to a warning and a skip, to follow how the Host CPU metrics works. 

At a later point it would be good to discuss if this should be a failure instead.

Fixes #613