### PR TITLE
Set mssql transactions_active to Gauge.

### DIFF
--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -387,7 +387,7 @@ type MSSQLCollector struct {
 	TransactionsLongestTransactionRunningSeconds *prometheus.Desc
 	TransactionsNonSnapshotVersionActiveTotal    *prometheus.Desc
 	TransactionsSnapshotActiveTotal              *prometheus.Desc
-	TransactionsActiveTotal                      *prometheus.Desc
+	TransactionsActive                           *prometheus.Desc
 	TransactionsUpdateConflictsTotal             *prometheus.Desc
 	TransactionsUpdateSnapshotActiveTotal        *prometheus.Desc
 	TransactionsVersionCleanupRateBytes          *prometheus.Desc
@@ -1749,8 +1749,8 @@ func NewMSSQLCollector() (Collector, error) {
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsActiveTotal: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "transactions_active_total"),
+		TransactionsActive: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "transactions_active"),
 			"(Transactions.Transactions)",
 			[]string{"instance"},
 			nil,
@@ -3832,8 +3832,8 @@ func (c *MSSQLCollector) collectTransactions(ctx *ScrapeContext, ch chan<- prome
 		)
 
 		ch <- prometheus.MustNewConstMetric(
-			c.TransactionsActiveTotal,
-			prometheus.CounterValue,
+			c.TransactionsActive,
+			prometheus.GaugeValue,
 			v.Transactions,
 			sqlInstance,
 		)

--- a/docs/collector.mssql.md
+++ b/docs/collector.mssql.md
@@ -235,7 +235,7 @@ Name | Description | Type | Labels
 `windows_mssql_transactions_longest_transaction_running_seconds` | The length of time (in seconds) since the start of the transaction that has been active longer than any other current transaction | gauge | `instance`
 `windows_mssql_transactions_nonsnapshot_version_active_total` | The number of currently active transactions that are not using snapshot isolation level and have made data modifications that have generated row versions in the tempdb version store | counter | `instance`
 `windows_mssql_transactions_snapshot_active_total` | The number of currently active transactions using the snapshot isolation level | counter | `instance`
-`windows_mssql_transactions_active_total` | The number of currently active transactions of all types | counter | `instance`
+`windows_mssql_transactions_active` | The number of currently active transactions of all types | gauge | `instance`
 `windows_mssql_transactions_update_conflicts_total` | The percentage of those transactions using the snapshot isolation level that have encountered update conflicts within the last second | counter | `instance`
 `windows_mssql_transactions_update_snapshot_active_total` | The number of currently active transactions using the snapshot isolation level and have modified data | counter | `instance`
 `windows_mssql_transactions_version_cleanup_rate_bytes` | The rate (in kilobytes per second) at which row versions are removed from the snapshot isolation version store in tempdb | gauge | `instance`


### PR DESCRIPTION
Change also renames metric to avoid confusion, so will need to be mentioned as a breaking change for next release.
Fixes #634.