### PR TITLE
Configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,36 @@ The prometheus metrics will be exposed on [localhost:9182](http://localhost:9182
 
 When there are multiple processes with the same name, WMI represents those after the first instance as `process-name#index`. So to get them all, rather than just the first one, the [regular expression](https://en.wikipedia.org/wiki/Regular_expression) must use `.+`. See [process](docs/collector.process.md) for more information.
 
+### Using a configuration file
+
+YAML configuration files can be specified with the `--config.file` flag. E.G. `.\windows_exporter.exe --config.file=config.yml`
+
+```yaml
+collectors:
+  enabled: cpu,cs,net,service
+collector:
+  service:
+    services-where: "Name='windows_exporter'"
+log:
+  level: warn
+```
+
+An example configuration file can be found [here](docs/example_config.yml).
+
+#### Configuration file notes
+
+If the `--config.file` flag is not specified, `windows_exporter` will look for a file located at `%programfiles\windows_exporter\config.yml` by default. If no file is found, CLI flags are processed as per normal.
+
+Configuration file values can be mixed with CLI flags. E.G.
+
+`.\windows_exporter.exe --collectors.enabled=cpu,logon`
+
+```yaml
+log:
+  level: debug
+```
+
+CLI flags enjoy a higher priority over values specified in the configuration file.
 
 ## License
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,82 @@
+// Copyright 2018 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/prometheus/common/log"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/yaml.v2"
+)
+
+type getFlagger interface {
+	GetFlag(name string) *kingpin.FlagClause
+}
+
+// Resolver represents a configuration file resolver for kingpin.
+type Resolver struct {
+	flags map[string]string
+}
+
+// NewResolver returns a Resolver structure.
+func NewResolver(file string) (*Resolver, error) {
+	flags := map[string]string{}
+	log.Infof("Loading configuration file: %v", file)
+	if _, err := os.Stat(file); err != nil {
+		return nil, err
+	}
+	b, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	var m map[string]string
+	err = yaml.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range m {
+		if _, ok := flags[k]; !ok {
+			flags[k] = v
+		}
+	}
+	return &Resolver{flags: flags}, nil
+}
+
+func (c *Resolver) setDefault(v getFlagger) {
+	for name, value := range c.flags {
+		f := v.GetFlag(name)
+		if f != nil {
+			f.Default(value)
+		}
+	}
+}
+
+// Bind sets active flags with their default values from the configuration file(s).
+func (c *Resolver) Bind(app *kingpin.Application, args []string) error {
+	// Parse the command line arguments to get the selected command.
+	pc, err := app.ParseContext(args)
+	if err != nil {
+		return err
+	}
+
+	c.setDefault(app)
+	if pc.SelectedCommand != nil {
+		c.setDefault(pc.SelectedCommand)
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -43,12 +43,14 @@ func NewResolver(file string) (*Resolver, error) {
 		return nil, err
 	}
 
-	var m map[string]string
-	err = yaml.Unmarshal(b, &m)
+	var rawValues map[string]interface{}
+	err = yaml.Unmarshal(b, &rawValues)
 	if err != nil {
 		return nil, err
 	}
-	for k, v := range m {
+	// Flatten nested YAML values
+	flattenedValues := flatten(rawValues)
+	for k, v := range flattenedValues {
 		if _, ok := flags[k]; !ok {
 			flags[k] = v
 		}

--- a/config/flatten.go
+++ b/config/flatten.go
@@ -1,0 +1,61 @@
+package config
+
+import "fmt"
+
+// flatten flattens the nested struct.
+//
+// All keys will be joined by dot
+// e.g. {"a": {"b":"c"}} => {"a.b":"c"}
+// or {"a": {"b":[1,2]}} => {"a.b.0":1, "a.b.1": 2}
+func flatten(data map[string]interface{}) map[string]string {
+	ret := make(map[string]string)
+	for k, v := range data {
+		switch typed := v.(type) {
+		case map[interface{}]interface{}:
+			for fk, fv := range flatten(convertMap(typed)) {
+				ret[fmt.Sprintf("%s.%s", k, fk)] = fv
+			}
+		case map[string]interface{}:
+			for fk, fv := range flatten(typed) {
+				ret[fmt.Sprintf("%s.%s", k, fk)] = fv
+			}
+		case []interface{}:
+			for fk, fv := range flattenSlice(typed) {
+				ret[fmt.Sprintf("%s.%s", k, fk)] = fv
+			}
+		default:
+			ret[k] = fmt.Sprint(typed)
+		}
+	}
+	return ret
+}
+func flattenSlice(data []interface{}) map[string]string {
+	ret := make(map[string]string)
+	for idx, v := range data {
+		switch typed := v.(type) {
+		case map[interface{}]interface{}:
+			for fk, fv := range flatten(convertMap(typed)) {
+				ret[fmt.Sprintf("%d,%s", idx, fk)] = fv
+			}
+		case map[string]interface{}:
+			for fk, fv := range flatten(typed) {
+				ret[fmt.Sprintf("%d,%s", idx, fk)] = fv
+			}
+		case []interface{}:
+			for fk, fv := range flattenSlice(typed) {
+				ret[fmt.Sprintf("%d,%s", idx, fk)] = fv
+			}
+		default:
+			ret[fmt.Sprint(idx)] = fmt.Sprint(typed)
+		}
+	}
+	return ret
+}
+
+func convertMap(originalMap map[interface{}]interface{}) map[string]interface{} {
+	convertedMap := map[string]interface{}{}
+	for key, value := range originalMap {
+		convertedMap[key.(string)] = value
+	}
+	return convertedMap
+}

--- a/config/flatten_test.go
+++ b/config/flatten_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"gopkg.in/yaml.v2"
+	"reflect"
+	"testing"
+)
+
+// Unmarshal good configuration file and confirm data is flattened correctly
+func TestConfigFlattening(t *testing.T) {
+	goodYamlConfig := []byte(`---
+
+    collectors:
+      enabled: cpu,net,service
+
+    log:
+      level: debug`)
+	var data map[string]interface{}
+	err := yaml.Unmarshal(goodYamlConfig, &data)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedResult := map[string]string{
+		"collectors.enabled": "cpu,net,service",
+		"log.level":          "debug",
+	}
+	flattenedValues := flatten(data)
+
+	if !reflect.DeepEqual(expectedResult, flattenedValues) {
+		t.Errorf("Flattened values do not match!\nExpected result: %s\nActual result: %s", expectedResult, flattenedValues)
+	}
+}

--- a/docs/example_config.yml
+++ b/docs/example_config.yml
@@ -1,0 +1,15 @@
+---
+# Note this is not an exhaustive list of all configuration values
+collectors:
+  enabled: cpu,cs,logical_disk,net,os,service,system,textfile
+collector:
+  service:
+    services-where: Name='windows_exporter'
+log:
+  level: debug
+scrape:
+  timeout-margin: 0.5
+telemetry:
+  addr: ":9182"
+  path: /metrics
+  max-requests: 5

--- a/exporter.go
+++ b/exporter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -268,36 +269,37 @@ func initWbem() {
 
 func main() {
 	var (
-		listenAddress = kingpin.Flag(
+		app           = kingpin.New("windows_exporter", "")
+		listenAddress = app.Flag(
 			"telemetry.addr",
 			"host:port for exporter.",
 		).Default(":9182").String()
-		metricsPath = kingpin.Flag(
+		metricsPath = app.Flag(
 			"telemetry.path",
 			"URL path for surfacing collected metrics.",
 		).Default("/metrics").String()
-		maxRequests = kingpin.Flag(
+		maxRequests = app.Flag(
 			"telemetry.max-requests",
 			"Maximum number of concurrent requests. 0 to disable.",
 		).Default("5").Int()
-		enabledCollectors = kingpin.Flag(
+		enabledCollectors = app.Flag(
 			"collectors.enabled",
 			"Comma-separated list of collectors to use. Use '[defaults]' as a placeholder for all the collectors enabled by default.").
 			Default(defaultCollectors).String()
-		printCollectors = kingpin.Flag(
+		printCollectors = app.Flag(
 			"collectors.print",
 			"If true, print available collectors and exit.",
 		).Bool()
-		timeoutMargin = kingpin.Flag(
+		timeoutMargin = app.Flag(
 			"scrape.timeout-margin",
 			"Seconds to subtract from the timeout allowed by the client. Tune to allow for overhead or high loads.",
 		).Default("0.5").Float64()
 	)
 
-	log.AddFlags(kingpin.CommandLine)
-	kingpin.Version(version.Print("windows_exporter"))
-	kingpin.HelpFlag.Short('h')
-	kingpin.Parse()
+	log.AddFlags(app)
+	app.Version(version.Print("windows_exporter"))
+	app.HelpFlag.Short('h')
+	app.Parse(os.Args[1:])
 
 	if *printCollectors {
 		collectors := collector.Available()

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,5 @@ require (
 	github.com/prometheus/common v0.2.0
 	golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/yaml.v2 v2.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -69,4 +69,5 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Initial implementation for configuration file support in windows_exporter.
Currently, the exporter supports reading from multiple YAML configuration files specified with the argument `--config.files=file1.yml,file2.yml`.
Values defined in these configuration files have a higher priority than values defined via command line arguments.

This will need testing and documentation once we're happy with the method/syntax of reading the files, and the config file structure.
Once merged, this will resolve #600.