### PR TITLE
adds whitelist for exchange collectors

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -119,3 +119,12 @@ func boolToFloat(b bool) float64 {
 	}
 	return 0.0
 }
+
+func find(slice []string, val string) bool {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}

--- a/collector/exchange.go
+++ b/collector/exchange.go
@@ -174,7 +174,7 @@ func newExchangeCollector() (Collector, error) {
 		}
 	} else {
 		for _, collectorName := range strings.Split(*argExchangeCollectorsWhitelist, ",") {
-			if _, exists := find(exchangeAllCollectorNames, collectorName); exists {
+			if find(exchangeAllCollectorNames, collectorName) {
 				collectorWhitelist = append(collectorWhitelist, collectorName)
 			} else {
 				return nil, fmt.Errorf("Unknown exchange collector: %s", collectorName)
@@ -632,11 +632,11 @@ func (c *exchangeCollector) msToSec(t float64) float64 {
 	return t / 1000
 }
 
-func find(slice []string, val string) (int, bool) {
-	for i, item := range slice {
+func find(slice []string, val string) bool {
+	for _, item := range slice {
 		if item == val {
-			return i, true
+			return true
 		}
 	}
-	return -1, false
+	return false
 }

--- a/docs/collector.exchange.md
+++ b/docs/collector.exchange.md
@@ -16,7 +16,7 @@ Enabled by default? | No
 Lists the Perflib Objects that are queried for data along with the perlfib object id
 
 ### `--collectors.exchange.whitelist`
-Comma-separated list of collectors to use, for example: `--collectors.exchange.list=AvailabilityService,OutlookWebAccess`. Matching is case-sensetive. Depending on the exchange installation not all performance counters are available. Use `--collectors.exchange.list` to obtain a list of supported collectors.
+Comma-separated list of collectors to use, for example: `--collectors.exchange.whitelist=AvailabilityService,OutlookWebAccess`. Matching is case-sensetive. Depending on the exchange installation not all performance counters are available. Use `--collectors.exchange.list` to obtain a list of supported collectors.
 
 ## Metrics
 Name          | Description

--- a/docs/collector.exchange.md
+++ b/docs/collector.exchange.md
@@ -16,7 +16,7 @@ Enabled by default? | No
 Lists the Perflib Objects that are queried for data along with the perlfib object id
 
 ### `--collectors.exchange.whitelist`
-Comma-separated list of collectors to use. Depending on the exchange installation not all performance counters are available. Use `--collectors.exchange.list` to obtain a list of available collectors.
+Comma-separated list of collectors to use, for example: `--collectors.exchange.list=AvailabilityService,OutlookWebAccess`. Matching is case-sensetive. Depending on the exchange installation not all performance counters are available. Use `--collectors.exchange.list` to obtain a list of supported collectors.
 
 ## Metrics
 Name          | Description

--- a/docs/collector.exchange.md
+++ b/docs/collector.exchange.md
@@ -15,6 +15,9 @@ Enabled by default? | No
 ### `--collectors.exchange.list`
 Lists the Perflib Objects that are queried for data along with the perlfib object id
 
+### `--collectors.exchange.whitelist`
+Comma-separated list of collectors to use. Depending on the exchange installation not all performance counters are available. Use `--collectors.exchange.list` to obtain a list of available collectors.
+
 ## Metrics
 Name          | Description
 --------------|---------------

--- a/docs/collector.exchange.md
+++ b/docs/collector.exchange.md
@@ -15,8 +15,8 @@ Enabled by default? | No
 ### `--collectors.exchange.list`
 Lists the Perflib Objects that are queried for data along with the perlfib object id
 
-### `--collectors.exchange.whitelist`
-Comma-separated list of collectors to use, for example: `--collectors.exchange.whitelist=AvailabilityService,OutlookWebAccess`. Matching is case-sensetive. Depending on the exchange installation not all performance counters are available. Use `--collectors.exchange.list` to obtain a list of supported collectors.
+### `--collectors.exchange.enabled`
+Comma-separated list of collectors to use, for example: `--collectors.exchange.enabled=AvailabilityService,OutlookWebAccess`. Matching is case-sensetive. Depending on the exchange installation not all performance counters are available. Use `--collectors.exchange.list` to obtain a list of supported collectors.
 
 ## Metrics
 Name          | Description


### PR DESCRIPTION
related to #614 and #569 

The flag enables the windows_exporter to work with different exchange installations where not all performance counters are available. Detecting the installed roles would be even nicer, but is much more work. Either way this is a nice way of customizing the exporter.

As a side effect of this PR, the order in which the collectors are called is now fixed. As a result, if one of the sub collectors fails the returned metrics are now consistent.