### PR TITLE
End-to-end testing script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 export GOOS=windows
 
-build:
+.PHONY: build
+build: windows_exporter.exe
+windows_exporter.exe: **/*.go
 	promu build -v
 
 test:
@@ -10,7 +12,7 @@ lint:
 	golangci-lint -c .golangci.yaml run
 
 .PHONY: e2e-test
-e2e-test: build
+e2e-test: windows_exporter.exe
 	powershell -NonInteractive -ExecutionPolicy Bypass -File .\tools\end-to-end-test.ps1
 
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ test:
 lint:
 	golangci-lint -c .golangci.yaml run
 
+.PHONY: e2e-test
+e2e-test: build
+	powershell -NonInteractive -ExecutionPolicy Bypass -File .\tools\end-to-end-test.ps1
+
 fmt:
 	gofmt -l -w -s .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ test_script:
 
 after_test:
   - make lint
+  - make e2e-test
 
 build_script:
   - ps: |

--- a/tools/e2e-output.txt
+++ b/tools/e2e-output.txt
@@ -1,0 +1,220 @@
+﻿# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
+# TYPE go_gc_duration_seconds summary
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
+# TYPE go_memstats_gc_cpu_fraction gauge
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+# HELP windows_cpu_clock_interrupts_total Total number of received and serviced clock tick interrupts
+# TYPE windows_cpu_clock_interrupts_total counter
+# HELP windows_cpu_core_frequency_mhz Core frequency in megahertz
+# TYPE windows_cpu_core_frequency_mhz gauge
+# HELP windows_cpu_cstate_seconds_total Time spent in low-power idle state
+# TYPE windows_cpu_cstate_seconds_total counter
+# HELP windows_cpu_dpcs_total Total number of received and serviced deferred procedure calls (DPCs)
+# TYPE windows_cpu_dpcs_total counter
+# HELP windows_cpu_idle_break_events_total Total number of time processor was woken from idle
+# TYPE windows_cpu_idle_break_events_total counter
+# HELP windows_cpu_interrupts_total Total number of received and serviced hardware interrupts
+# TYPE windows_cpu_interrupts_total counter
+# HELP windows_cpu_parking_status Parking Status represents whether a processor is parked or not
+# TYPE windows_cpu_parking_status gauge
+# HELP windows_cpu_processor_performance Processor Performance is the average performance of the processor while it is executing instructions, as a percentage of the nominal performance of the processor. On some processors, Processor Performance may exceed 100%
+# TYPE windows_cpu_processor_performance gauge
+# HELP windows_cpu_time_total Time that processor spent in different modes (idle, user, system, ...)
+# TYPE windows_cpu_time_total counter
+# HELP windows_cs_hostname Labeled system hostname information as provided by ComputerSystem.DNSHostName and ComputerSystem.Domain
+# TYPE windows_cs_hostname gauge
+# HELP windows_cs_logical_processors ComputerSystem.NumberOfLogicalProcessors
+# TYPE windows_cs_logical_processors gauge
+# HELP windows_cs_physical_memory_bytes ComputerSystem.TotalPhysicalMemory
+# TYPE windows_cs_physical_memory_bytes gauge
+# HELP windows_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which windows_exporter was built.
+# TYPE windows_exporter_build_info gauge
+# HELP windows_exporter_collector_duration_seconds windows_exporter: Duration of a collection.
+# TYPE windows_exporter_collector_duration_seconds gauge
+# HELP windows_exporter_collector_success windows_exporter: Whether the collector was successful.
+# TYPE windows_exporter_collector_success gauge
+windows_exporter_collector_success{collector="cpu"} 1
+windows_exporter_collector_success{collector="cs"} 1
+windows_exporter_collector_success{collector="logical_disk"} 1
+windows_exporter_collector_success{collector="net"} 1
+windows_exporter_collector_success{collector="os"} 1
+windows_exporter_collector_success{collector="service"} 1
+windows_exporter_collector_success{collector="system"} 1
+windows_exporter_collector_success{collector="textfile"} 1
+# HELP windows_exporter_collector_timeout windows_exporter: Whether the collector timed out.
+# TYPE windows_exporter_collector_timeout gauge
+windows_exporter_collector_timeout{collector="cpu"} 0
+windows_exporter_collector_timeout{collector="cs"} 0
+windows_exporter_collector_timeout{collector="logical_disk"} 0
+windows_exporter_collector_timeout{collector="net"} 0
+windows_exporter_collector_timeout{collector="os"} 0
+windows_exporter_collector_timeout{collector="service"} 0
+windows_exporter_collector_timeout{collector="system"} 0
+windows_exporter_collector_timeout{collector="textfile"} 0
+# HELP windows_exporter_perflib_snapshot_duration_seconds Duration of perflib snapshot capture
+# TYPE windows_exporter_perflib_snapshot_duration_seconds gauge
+# HELP windows_logical_disk_free_bytes Free space in bytes (LogicalDisk.PercentFreeSpace)
+# TYPE windows_logical_disk_free_bytes gauge
+# HELP windows_logical_disk_idle_seconds_total Seconds that the disk was idle (LogicalDisk.PercentIdleTime)
+# TYPE windows_logical_disk_idle_seconds_total counter
+# HELP windows_logical_disk_read_bytes_total The number of bytes transferred from the disk during read operations (LogicalDisk.DiskReadBytesPerSec)
+# TYPE windows_logical_disk_read_bytes_total counter
+# HELP windows_logical_disk_read_latency_seconds_total Shows the average time, in seconds, of a read operation from the disk (LogicalDisk.AvgDiskSecPerRead)
+# TYPE windows_logical_disk_read_latency_seconds_total counter
+# HELP windows_logical_disk_read_seconds_total Seconds that the disk was busy servicing read requests (LogicalDisk.PercentDiskReadTime)
+# TYPE windows_logical_disk_read_seconds_total counter
+# HELP windows_logical_disk_read_write_latency_seconds_total Shows the time, in seconds, of the average disk transfer (LogicalDisk.AvgDiskSecPerTransfer)
+# TYPE windows_logical_disk_read_write_latency_seconds_total counter
+# HELP windows_logical_disk_reads_total The number of read operations on the disk (LogicalDisk.DiskReadsPerSec)
+# TYPE windows_logical_disk_reads_total counter
+# HELP windows_logical_disk_requests_queued The number of requests queued to the disk (LogicalDisk.CurrentDiskQueueLength)
+# TYPE windows_logical_disk_requests_queued gauge
+# HELP windows_logical_disk_size_bytes Total space in bytes (LogicalDisk.PercentFreeSpace_Base)
+# TYPE windows_logical_disk_size_bytes gauge
+# HELP windows_logical_disk_split_ios_total The number of I/Os to the disk were split into multiple I/Os (LogicalDisk.SplitIOPerSec)
+# TYPE windows_logical_disk_split_ios_total counter
+# HELP windows_logical_disk_write_bytes_total The number of bytes transferred to the disk during write operations (LogicalDisk.DiskWriteBytesPerSec)
+# TYPE windows_logical_disk_write_bytes_total counter
+# HELP windows_logical_disk_write_latency_seconds_total Shows the average time, in seconds, of a write operation to the disk (LogicalDisk.AvgDiskSecPerWrite)
+# TYPE windows_logical_disk_write_latency_seconds_total counter
+# HELP windows_logical_disk_write_seconds_total Seconds that the disk was busy servicing write requests (LogicalDisk.PercentDiskWriteTime)
+# TYPE windows_logical_disk_write_seconds_total counter
+# HELP windows_logical_disk_writes_total The number of write operations on the disk (LogicalDisk.DiskWritesPerSec)
+# TYPE windows_logical_disk_writes_total counter
+# HELP windows_net_bytes_received_total (Network.BytesReceivedPerSec)
+# TYPE windows_net_bytes_received_total counter
+# HELP windows_net_bytes_sent_total (Network.BytesSentPerSec)
+# TYPE windows_net_bytes_sent_total counter
+# HELP windows_net_bytes_total (Network.BytesTotalPerSec)
+# TYPE windows_net_bytes_total counter
+# HELP windows_net_current_bandwidth (Network.CurrentBandwidth)
+# TYPE windows_net_current_bandwidth gauge
+# HELP windows_net_packets_outbound_discarded_total (Network.PacketsOutboundDiscarded)
+# TYPE windows_net_packets_outbound_discarded_total counter
+# HELP windows_net_packets_outbound_errors_total (Network.PacketsOutboundErrors)
+# TYPE windows_net_packets_outbound_errors_total counter
+# HELP windows_net_packets_received_discarded_total (Network.PacketsReceivedDiscarded)
+# TYPE windows_net_packets_received_discarded_total counter
+# HELP windows_net_packets_received_errors_total (Network.PacketsReceivedErrors)
+# TYPE windows_net_packets_received_errors_total counter
+# HELP windows_net_packets_received_total (Network.PacketsReceivedPerSec)
+# TYPE windows_net_packets_received_total counter
+# HELP windows_net_packets_received_unknown_total (Network.PacketsReceivedUnknown)
+# TYPE windows_net_packets_received_unknown_total counter
+# HELP windows_net_packets_sent_total (Network.PacketsSentPerSec)
+# TYPE windows_net_packets_sent_total counter
+# HELP windows_net_packets_total (Network.PacketsPerSec)
+# TYPE windows_net_packets_total counter
+# HELP windows_os_info OperatingSystem.Caption, OperatingSystem.Version
+# TYPE windows_os_info gauge
+# HELP windows_os_paging_free_bytes OperatingSystem.FreeSpaceInPagingFiles
+# TYPE windows_os_paging_free_bytes gauge
+# HELP windows_os_paging_limit_bytes OperatingSystem.SizeStoredInPagingFiles
+# TYPE windows_os_paging_limit_bytes gauge
+# HELP windows_os_physical_memory_free_bytes OperatingSystem.FreePhysicalMemory
+# TYPE windows_os_physical_memory_free_bytes gauge
+# HELP windows_os_process_memory_limix_bytes OperatingSystem.MaxProcessMemorySize
+# TYPE windows_os_process_memory_limix_bytes gauge
+# HELP windows_os_processes OperatingSystem.NumberOfProcesses
+# TYPE windows_os_processes gauge
+# HELP windows_os_processes_limit OperatingSystem.MaxNumberOfProcesses
+# TYPE windows_os_processes_limit gauge
+# HELP windows_os_time OperatingSystem.LocalDateTime
+# TYPE windows_os_time gauge
+# HELP windows_os_timezone OperatingSystem.LocalDateTime
+# TYPE windows_os_timezone gauge
+# HELP windows_os_users OperatingSystem.NumberOfUsers
+# TYPE windows_os_users gauge
+# HELP windows_os_virtual_memory_bytes OperatingSystem.TotalVirtualMemorySize
+# TYPE windows_os_virtual_memory_bytes gauge
+# HELP windows_os_virtual_memory_free_bytes OperatingSystem.FreeVirtualMemory
+# TYPE windows_os_virtual_memory_free_bytes gauge
+# HELP windows_os_visible_memory_bytes OperatingSystem.TotalVisibleMemorySize
+# TYPE windows_os_visible_memory_bytes gauge
+# HELP windows_service_info A metric with a constant '1' value labeled with service information
+# TYPE windows_service_info gauge
+# HELP windows_service_start_mode The start mode of the service (StartMode)
+# TYPE windows_service_start_mode gauge
+# HELP windows_service_state The state of the service (State)
+# TYPE windows_service_state gauge
+# HELP windows_service_status The status of the service (Status)
+# TYPE windows_service_status gauge
+# HELP windows_system_context_switches_total Total number of context switches (WMI source: PerfOS_System.ContextSwitchesPersec)
+# TYPE windows_system_context_switches_total counter
+# HELP windows_system_exception_dispatches_total Total number of exceptions dispatched (WMI source: PerfOS_System.ExceptionDispatchesPersec)
+# TYPE windows_system_exception_dispatches_total counter
+# HELP windows_system_processor_queue_length Length of processor queue (WMI source: PerfOS_System.ProcessorQueueLength)
+# TYPE windows_system_processor_queue_length gauge
+# HELP windows_system_system_calls_total Total number of system calls (WMI source: PerfOS_System.SystemCallsPersec)
+# TYPE windows_system_system_calls_total counter
+# HELP windows_system_system_up_time System boot time (WMI source: PerfOS_System.SystemUpTime)
+# TYPE windows_system_system_up_time gauge
+# HELP windows_system_threads Current number of threads (WMI source: PerfOS_System.Threads)
+# TYPE windows_system_threads gauge
+# HELP windows_textfile_scrape_error 1 if there was an error opening or reading a file, 0 otherwise
+# TYPE windows_textfile_scrape_error gauge
+windows_textfile_scrape_error 0
+

--- a/tools/e2e-output.txt
+++ b/tools/e2e-output.txt
@@ -66,6 +66,9 @@
 # TYPE process_start_time_seconds gauge
 # HELP process_virtual_memory_bytes Virtual memory size in bytes.
 # TYPE process_virtual_memory_bytes gauge
+# HELP test_alpha_total Some random metric.
+# TYPE test_alpha_total counter
+test_alpha_total 42
 # HELP windows_cpu_clock_interrupts_total Total number of received and serviced clock tick interrupts
 # TYPE windows_cpu_clock_interrupts_total counter
 # HELP windows_cpu_core_frequency_mhz Core frequency in megahertz
@@ -214,6 +217,8 @@ windows_exporter_collector_timeout{collector="textfile"} 0
 # TYPE windows_system_system_up_time gauge
 # HELP windows_system_threads Current number of threads (WMI source: PerfOS_System.Threads)
 # TYPE windows_system_threads gauge
+# HELP windows_textfile_mtime_seconds Unixtime mtime of textfiles successfully read.
+# TYPE windows_textfile_mtime_seconds gauge
 # HELP windows_textfile_scrape_error 1 if there was an error opening or reading a file, 0 otherwise
 # TYPE windows_textfile_scrape_error gauge
 windows_textfile_scrape_error 0

--- a/tools/e2e-textfile.prom
+++ b/tools/e2e-textfile.prom
@@ -1,0 +1,4 @@
+# HELP test_alpha_total Some random metric.
+# TYPE test_alpha_total counter
+test_alpha_total 42
+

--- a/tools/end-to-end-test.ps1
+++ b/tools/end-to-end-test.ps1
@@ -12,15 +12,20 @@ Push-Location $working_dir
 
 $temp_dir = Join-Path $env:TEMP $(New-Guid) | ForEach-Object { mkdir $_ }
 
+# Create temporary directory for textfile collector
+$textfile_dir = "$($temp_dir)/textfile"
+mkdir $textfile_dir | Out-Null
+Copy-Item 'e2e-textfile.prom' -Destination "$($textfile_dir)/e2e-textfile.prom"
+
 # Omit dynamic collector information that will change after each run
-$skip_re = "^(go_|windows_exporter_build_info|windows_exporter_collector_duration_seconds|windows_exporter_perflib_snapshot_duration_seconds|process_|windows_textfile_mtime_seconds|windows_cpu|windows_cs|windows_logical_disk|windows_net|windows_os|windows_service|windows_system)"
+$skip_re = "^(go_|windows_exporter_build_info|windows_exporter_collector_duration_seconds|windows_exporter_perflib_snapshot_duration_seconds|process_|windows_textfile_mtime_seconds|windows_cpu|windows_cs|windows_logical_disk|windows_net|windows_os|windows_service|windows_system|windows_textfile_mtime_seconds)"
 
 # Start process in background, awaiting HTTP requests.
 # Use default collectors, port and address: http://localhost:9182/metrics
 $exporter_proc = Start-Process `
     -PassThru `
     -FilePath .\windows_exporter.exe `
-    -ArgumentList '--log.level=debug' `
+    -ArgumentList "--log.level=debug --collector.textfile.directory=$($textfile_dir)" `
     -WindowStyle Hidden `
     -RedirectStandardOutput "$($temp_dir)/windows_exporter.log" `
     -RedirectStandardError "$($temp_dir)/windows_exporter_error.log"

--- a/tools/end-to-end-test.ps1
+++ b/tools/end-to-end-test.ps1
@@ -1,0 +1,41 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3
+
+if (-not (Test-Path -Path '.\windows_exporter.exe')) {
+    Write-Output ".\windows_exporter.exe not found. Consider running \`go build\` first"
+}
+
+# cd to location of script
+$script_path = $MyInvocation.MyCommand.Path
+$working_dir = Split-Path $script_path
+Push-Location $working_dir
+
+$temp_dir = Join-Path $env:TEMP $(New-Guid) | ForEach-Object { mkdir $_ }
+
+# Omit dynamic collector information that will change after each run
+$skip_re = "^(go_|windows_exporter_build_info|windows_exporter_collector_duration_seconds|windows_exporter_perflib_snapshot_duration_seconds|process_|windows_textfile_mtime_seconds|windows_cpu|windows_cs|windows_logical_disk|windows_net|windows_os|windows_service|windows_system)"
+
+# Start process in background, awaiting HTTP requests.
+# Use default collectors, port and address: http://localhost:9182/metrics
+$exporter_proc = Start-Process `
+    -PassThru `
+    -FilePath .\windows_exporter.exe `
+    -ArgumentList '--log.level=debug' `
+    -WindowStyle Hidden `
+    -RedirectStandardOutput "$($temp_dir)/windows_exporter.log" `
+    -RedirectStandardError "$($temp_dir)/windows_exporter_error.log"
+
+# Give exporter some time to start
+Start-Sleep 3
+
+$response = Invoke-WebRequest -UseBasicParsing -URI http://127.0.0.1:9182/metrics
+# Response output must be split and saved as UTF-8.
+$response.content -split "[`r`n]"| Select-String -NotMatch $skip_re | Set-Content -Encoding utf8 "$($temp_dir)/e2e-output.txt"
+Stop-Process $exporter_proc
+$output_diff = Compare-Object (Get-Content 'e2e-output.txt') (Get-Content "$($temp_dir)/e2e-output.txt")
+
+# Fail if differences in output are detected
+if (-not ($null -eq $output_diff)) {
+    $output_diff | Format-Table
+    exit 1
+}


### PR DESCRIPTION
Add an end-to-end testing script for use in CI, to compare changes in windows_exporter output.
I've tested this in a local Windows 10 VM, so I'm unsure how Appveyor would handle this.

A downside of this change is that the `e2e-output.txt` file would need to be modified on any metric change to the default exporters.