### PR TITLE
Migrate log library to go-kit/kit/log

### DIFF
--- a/collector/ad.go
+++ b/collector/ad.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -456,7 +456,7 @@ func NewADCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *ADCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting ad metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting ad metrics", "description", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/cpu.go
+++ b/collector/cpu.go
@@ -9,14 +9,14 @@ import (
 )
 
 func init() {
-	var deps string
-	// See below for 6.05 magic value
-	if getWindowsVersion() > 6.05 {
-		deps = "Processor Information"
-	} else {
-		deps = "Processor"
-	}
-	registerCollector("cpu", newCPUCollector, deps)
+	// var deps string
+	// // See below for 6.05 magic value
+	// if getWindowsVersion() > 6.05 {
+	// 	deps = "Processor Information"
+	// } else {
+	// 	deps = "Processor"
+	// }
+	registerCollector("cpu", newCPUCollector, "Processor Information", "Processor")
 }
 
 type cpuCollectorBasic struct {

--- a/collector/cs.go
+++ b/collector/cs.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -54,7 +54,7 @@ func NewCSCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *CSCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting cs metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting cs metrics", "description", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/dfsr.go
+++ b/collector/dfsr.go
@@ -3,15 +3,14 @@
 package collector
 
 import (
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var dfsrEnabledCollectors = kingpin.Flag("collectors.dfsr.sources-enabled", "Comma-seperated list of DFSR Perflib sources to use.").Default("connection,folder,volume").String()
 
 func init() {
-	log.Info("dfsr collector is in an experimental state! Metrics for this collector have not been tested.")
 	// Perflib sources are dynamic, depending on the enabled child collectors
 	var perflibDependencies []string
 	for _, source := range expandEnabledChildCollectors(*dfsrEnabledCollectors) {
@@ -98,6 +97,7 @@ func dfsrGetPerfObjectName(collector string) string {
 
 // NewDFSRCollector is registered
 func NewDFSRCollector() (Collector, error) {
+	level.Info(logger).Log("msg", "dfsr collector is in an experimental state! Metrics for this collector have not been tested.")
 	const subsystem = "dfsr"
 
 	enabled := expandEnabledChildCollectors(*dfsrEnabledCollectors)

--- a/collector/dns.go
+++ b/collector/dns.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -183,7 +183,7 @@ func NewDNSCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *DNSCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting dns metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting dns metrics", "description", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/exchange.go
+++ b/collector/exchange.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -202,7 +202,7 @@ func (c *exchangeCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Met
 
 	for _, collectorName := range c.enabledCollectors {
 		if err := collectorFuncs[collectorName](ctx, ch); err != nil {
-			log.Errorf("Error in %s: %s", collectorName, err)
+			level.Error(logger).Log("msg", "Error in ", "collector_name", collectorName, "err", err)
 			return err
 		}
 	}

--- a/collector/fsrmquota.go
+++ b/collector/fsrmquota.go
@@ -2,8 +2,8 @@ package collector
 
 import (
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -88,7 +88,7 @@ func newFSRMQuotaCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *FSRMQuotaCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting fsrmquota metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting fsrmquota metrics:", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/hyperv.go
+++ b/collector/hyperv.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -599,52 +599,52 @@ func NewHyperVCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *HyperVCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collectVmHealth(ch); err != nil {
-		log.Error("failed collecting hyperV health status metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting hyperV health status metrics", "desc", desc, "err", err)
 		return err
 	}
 
 	if desc, err := c.collectVmVid(ch); err != nil {
-		log.Error("failed collecting hyperV pages metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting hyperV pages metrics", "desc", desc, "err", err)
 		return err
 	}
 
 	if desc, err := c.collectVmHv(ch); err != nil {
-		log.Error("failed collecting hyperV hv status metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting hyperV hv status metrics", "desc", desc, "err", err)
 		return err
 	}
 
 	if desc, err := c.collectVmProcessor(ch); err != nil {
-		log.Error("failed collecting hyperV processor metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting hyperV processor metrics", "desc", desc, "err", err)
 		return err
 	}
 
 	if desc, err := c.collectHostCpuUsage(ch); err != nil {
-		log.Error("failed collecting hyperV host CPU metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting hyperV host CPU metrics", "desc", desc, "err", err)
 		return err
 	}
 
 	if desc, err := c.collectVmCpuUsage(ch); err != nil {
-		log.Error("failed collecting hyperV VM CPU metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting hyperV VM CPU metrics", "desc", desc, "err", err)
 		return err
 	}
 
 	if desc, err := c.collectVmSwitch(ch); err != nil {
-		log.Error("failed collecting hyperV switch metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting hyperV switch metrics", "desc", desc, "err", err)
 		return err
 	}
 
 	if desc, err := c.collectVmEthernet(ch); err != nil {
-		log.Error("failed collecting hyperV ethernet metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting hyperV ethernet metrics", "desc", desc, "err", err)
 		return err
 	}
 
 	if desc, err := c.collectVmStorage(ch); err != nil {
-		log.Error("failed collecting hyperV virtual storage metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting hyperV virtual storage metrics", "desc", desc, "err", err)
 		return err
 	}
 
 	if desc, err := c.collectVmNetwork(ch); err != nil {
-		log.Error("failed collecting hyperV virtual network metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting hyperV virtual network metrics", "desc", desc, "err", err)
 		return err
 	}
 
@@ -941,7 +941,7 @@ func (c *HyperVCollector) collectHostCpuUsage(ch chan<- prometheus.Metric) (*pro
 		// The name format is Root VP <core id>
 		parts := strings.Split(obj.Name, " ")
 		if len(parts) != 3 {
-			log.Warnf("Unexpected format of Name in collectHostCpuUsage: %q", obj.Name)
+			level.Warn(logger).Log("msg", "Unexpected format of Name in collectHostCpuUsage", "name", obj.Name)
 			continue
 		}
 		coreId := parts[2]
@@ -1002,12 +1002,12 @@ func (c *HyperVCollector) collectVmCpuUsage(ch chan<- prometheus.Metric) (*prome
 		// The name format is <VM Name>:Hv VP <vcore id>
 		parts := strings.Split(obj.Name, ":")
 		if len(parts) != 2 {
-			log.Warnf("Unexpected format of Name in collectVmCpuUsage: %q, expected %q. Skipping.", obj.Name, "<VM Name>:Hv VP <vcore id>")
+			level.Warn(logger).Log("msg", "Unexpected format of Name in collectVmCpuUsage. Skipping.", "name", obj.Name, "expected", "<VM Name>:Hv VP <vcore id>")
 			continue
 		}
 		coreParts := strings.Split(parts[1], " ")
 		if len(coreParts) != 3 {
-			log.Warnf("Unexpected format of core identifier in collectVmCpuUsage: %q, expected %q. Skipping.", parts[1], "Hv VP <vcore id>")
+			level.Warn(logger).Log("msg", "Unexpected format of core identifier in collectVmCpuUsage. Skipping.", "name", parts[1], "expected", "Hv VP <vcore id>")
 			continue
 		}
 		vmName := parts[0]

--- a/collector/logical_disk.go
+++ b/collector/logical_disk.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -159,7 +159,7 @@ func NewLogicalDiskCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *LogicalDiskCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ctx, ch); err != nil {
-		log.Error("failed collecting logical_disk metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting logical_disk metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/logon.go
+++ b/collector/logon.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -37,7 +37,7 @@ func NewLogonCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *LogonCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting user metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting user metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/memory.go
+++ b/collector/memory.go
@@ -6,8 +6,8 @@
 package collector
 
 import (
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -257,7 +257,7 @@ func NewMemoryCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *MemoryCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ctx, ch); err != nil {
-		log.Error("failed collecting memory metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting memory metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -34,7 +34,7 @@ func NewMSMQCollector() (Collector, error) {
 	const subsystem = "msmq"
 
 	if *msmqWhereClause == "" {
-		log.Warn("No where-clause specified for msmq collector. This will generate a very large number of metrics!")
+		level.Warn(logger).Log("msg", "No where-clause specified for msmq collector. This will generate a very large number of metrics!")
 	}
 
 	return &Win32_PerfRawData_MSMQ_MSMQQueueCollector{
@@ -70,7 +70,7 @@ func NewMSMQCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *Win32_PerfRawData_MSMQ_MSMQQueueCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting msmq metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting msmq metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"golang.org/x/sys/windows/registry"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -40,19 +40,19 @@ func getMSSQLInstances() mssqlInstancesType {
 	regkey := `Software\Microsoft\Microsoft SQL Server\Instance Names\SQL`
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, regkey, registry.QUERY_VALUE)
 	if err != nil {
-		log.Warn("Couldn't open registry to determine SQL instances:", err)
+		level.Warn(logger).Log("msg", "Couldn't open registry to determine SQL instances:", "err", err)
 		return sqlDefaultInstance
 	}
 	defer func() {
 		err = k.Close()
 		if err != nil {
-			log.Warnf("Failed to close registry key: %v", err)
+			level.Warn(logger).Log("msg", "Failed to close registry key", "err", err)
 		}
 	}()
 
 	instanceNames, err := k.ReadValueNames(0)
 	if err != nil {
-		log.Warnf("Can't ReadSubKeyNames %#v", err)
+		level.Warn(logger).Log("msg", "Can't ReadSubKeyNames", "err", err)
 		return sqlDefaultInstance
 	}
 
@@ -62,7 +62,7 @@ func getMSSQLInstances() mssqlInstancesType {
 		}
 	}
 
-	log.Debugf("Detected MSSQL Instances: %#v\n", sqlInstances)
+	level.Debug(logger).Log("msg", "Detected MSSQL Instances", "instances", sqlInstances)
 
 	return sqlInstances
 }
@@ -1818,11 +1818,11 @@ func (c *MSSQLCollector) execute(ctx *ScrapeContext, name string, fn mssqlCollec
 	var success float64
 
 	if err != nil {
-		log.Errorf("mssql class collector %s failed after %fs: %s", name, duration.Seconds(), err)
+		level.Error(logger).Log("msg", "mssql class collector failed", "name", name, "duration", duration.Seconds(), "err", err)
 		success = 0
 		c.mssqlChildCollectorFailure++
 	} else {
-		log.Debugf("mssql class collector %s succeeded after %fs.", name, duration.Seconds())
+		level.Debug(logger).Log("msg", "mssql class collector succeeded", "name", name, "duration", duration.Seconds())
 		success = 1
 	}
 	ch <- prometheus.MustNewConstMetric(
@@ -1913,7 +1913,7 @@ type mssqlAccessMethods struct {
 
 func (c *MSSQLCollector) collectAccessMethods(ctx *ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
 	var dst []mssqlAccessMethods
-	log.Debugf("mssql_accessmethods collector iterating sql instance %s.", sqlInstance)
+	level.Debug(logger).Log("msg", "mssql_accessmethods collector iterating sql instance.", "instance", sqlInstance)
 
 	if err := unmarshalObject(ctx.perfObjects[mssqlGetPerfObjectName(sqlInstance, "accessmethods")], &dst); err != nil {
 		return nil, err
@@ -2248,7 +2248,7 @@ type mssqlAvailabilityReplica struct {
 
 func (c *MSSQLCollector) collectAvailabilityReplica(ctx *ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
 	var dst []mssqlAvailabilityReplica
-	log.Debugf("mssql_availreplica collector iterating sql instance %s.", sqlInstance)
+	level.Debug(logger).Log("msg", "mssql_availreplica collector iterating sql instance.", "instance", sqlInstance)
 
 	if err := unmarshalObject(ctx.perfObjects[mssqlGetPerfObjectName(sqlInstance, "availreplica")], &dst); err != nil {
 		return nil, err
@@ -2356,7 +2356,7 @@ type mssqlBufferManager struct {
 
 func (c *MSSQLCollector) collectBufferManager(ctx *ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
 	var dst []mssqlBufferManager
-	log.Debugf("mssql_bufman collector iterating sql instance %s.", sqlInstance)
+	level.Debug(logger).Log("msg", "mssql_bufman collector iterating sql instance.", "instance", sqlInstance)
 
 	if err := unmarshalObject(ctx.perfObjects[mssqlGetPerfObjectName(sqlInstance, "bufman")], &dst); err != nil {
 		return nil, err
@@ -2560,7 +2560,7 @@ type mssqlDatabaseReplica struct {
 
 func (c *MSSQLCollector) collectDatabaseReplica(ctx *ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
 	var dst []mssqlDatabaseReplica
-	log.Debugf("mssql_dbreplica collector iterating sql instance %s.", sqlInstance)
+	level.Debug(logger).Log("msg", "mssql_dbreplica collector iterating sql instance.", "instance", sqlInstance)
 
 	if err := unmarshalObject(ctx.perfObjects[mssqlGetPerfObjectName(sqlInstance, "dbreplica")], &dst); err != nil {
 		return nil, err
@@ -2799,7 +2799,7 @@ type mssqlDatabases struct {
 
 func (c *MSSQLCollector) collectDatabases(ctx *ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
 	var dst []mssqlDatabases
-	log.Debugf("mssql_databases collector iterating sql instance %s.", sqlInstance)
+	level.Debug(logger).Log("msg", "mssql_databases collector iterating sql instance.", "instance", sqlInstance)
 
 	if err := unmarshalObject(ctx.perfObjects[mssqlGetPerfObjectName(sqlInstance, "databases")], &dst); err != nil {
 		return nil, err
@@ -3181,7 +3181,7 @@ type mssqlGeneralStatistics struct {
 
 func (c *MSSQLCollector) collectGeneralStatistics(ctx *ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
 	var dst []mssqlGeneralStatistics
-	log.Debugf("mssql_genstats collector iterating sql instance %s.", sqlInstance)
+	level.Debug(logger).Log("msg", "mssql_genstats collector iterating sql instance.", "instance", sqlInstance)
 
 	if err := unmarshalObject(ctx.perfObjects[mssqlGetPerfObjectName(sqlInstance, "genstats")], &dst); err != nil {
 		return nil, err
@@ -3376,7 +3376,7 @@ type mssqlLocks struct {
 
 func (c *MSSQLCollector) collectLocks(ctx *ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
 	var dst []mssqlLocks
-	log.Debugf("mssql_locks collector iterating sql instance %s.", sqlInstance)
+	level.Debug(logger).Log("msg", "mssql_locks collector iterating sql instance.", "instance", sqlInstance)
 
 	if err := unmarshalObject(ctx.perfObjects[mssqlGetPerfObjectName(sqlInstance, "locks")], &dst); err != nil {
 		return nil, err
@@ -3474,7 +3474,7 @@ type mssqlMemoryManager struct {
 
 func (c *MSSQLCollector) collectMemoryManager(ctx *ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
 	var dst []mssqlMemoryManager
-	log.Debugf("mssql_memmgr collector iterating sql instance %s.", sqlInstance)
+	level.Debug(logger).Log("msg", "mssql_memmgr collector iterating sql instance.", "instance", sqlInstance)
 
 	if err := unmarshalObject(ctx.perfObjects[mssqlGetPerfObjectName(sqlInstance, "memmgr")], &dst); err != nil {
 		return nil, err
@@ -3643,7 +3643,7 @@ type mssqlSQLStatistics struct {
 
 func (c *MSSQLCollector) collectSQLStats(ctx *ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
 	var dst []mssqlSQLStatistics
-	log.Debugf("mssql_sqlstats collector iterating sql instance %s.", sqlInstance)
+	level.Debug(logger).Log("msg", "mssql_sqlstats collector iterating sql instance.", "instance", sqlInstance)
 
 	if err := unmarshalObject(ctx.perfObjects[mssqlGetPerfObjectName(sqlInstance, "sqlstats")], &dst); err != nil {
 		return nil, err
@@ -3740,7 +3740,7 @@ type mssqlSQLErrors struct {
 // - https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-sql-errors-object
 func (c *MSSQLCollector) collectSQLErrors(ctx *ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
 	var dst []mssqlSQLErrors
-	log.Debugf("mssql_sqlerrors collector iterating sql instance %s.", sqlInstance)
+	level.Debug(logger).Log("msg", "mssql_sqlerrors collector iterating sql instance.", "instance", sqlInstance)
 
 	if err := unmarshalObject(ctx.perfObjects[mssqlGetPerfObjectName(sqlInstance, "sqlerrors")], &dst); err != nil {
 		return nil, err
@@ -3783,7 +3783,7 @@ type mssqlTransactions struct {
 // - https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-transactions-object
 func (c *MSSQLCollector) collectTransactions(ctx *ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
 	var dst []mssqlTransactions
-	log.Debugf("mssql_transactions collector iterating sql instance %s.", sqlInstance)
+	level.Debug(logger).Log("msg", "mssql_transactions collector iterating sql instance.", "instance", sqlInstance)
 
 	if err := unmarshalObject(ctx.perfObjects[mssqlGetPerfObjectName(sqlInstance, "transactions")], &dst); err != nil {
 		return nil, err

--- a/collector/net.go
+++ b/collector/net.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -133,7 +133,7 @@ func NewNetworkCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NetworkCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ctx, ch); err != nil {
-		log.Error("failed collecting net metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting net metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrexceptions.go
+++ b/collector/netframework_clrexceptions.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -55,7 +55,7 @@ func NewNETFramework_NETCLRExceptionsCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRExceptionsCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting win32_perfrawdata_netframework_netclrexceptions metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting netclrexceptions metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrinterop.go
+++ b/collector/netframework_clrinterop.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -48,7 +48,7 @@ func NewNETFramework_NETCLRInteropCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRInteropCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting win32_perfrawdata_netframework_netclrinterop metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting netclrinterop metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrjit.go
+++ b/collector/netframework_clrjit.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -55,7 +55,7 @@ func NewNETFramework_NETCLRJitCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRJitCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting win32_perfrawdata_netframework_netclrjit metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting netclrjit metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrloading.go
+++ b/collector/netframework_clrloading.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -90,7 +90,7 @@ func NewNETFramework_NETCLRLoadingCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRLoadingCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting win32_perfrawdata_netframework_netclrloading metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting netclrloading metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrlocksandthreads.go
+++ b/collector/netframework_clrlocksandthreads.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -76,7 +76,7 @@ func NewNETFramework_NETCLRLocksAndThreadsCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRLocksAndThreadsCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting win32_perfrawdata_netframework_netclrlocksandthreads metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting netclrlocksandthreads metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrmemory.go
+++ b/collector/netframework_clrmemory.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -114,7 +114,7 @@ func NewNETFramework_NETCLRMemoryCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRMemoryCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting win32_perfrawdata_netframework_netclrmemory metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting netclrmemory metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrremoting.go
+++ b/collector/netframework_clrremoting.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -69,7 +69,7 @@ func NewNETFramework_NETCLRRemotingCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRRemotingCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting win32_perfrawdata_netframework_netclrremoting metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting netclrremoting metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrsecurity.go
+++ b/collector/netframework_clrsecurity.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -55,7 +55,7 @@ func NewNETFramework_NETCLRSecurityCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRSecurityCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting win32_perfrawdata_netframework_netclrsecurity metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting netclrsecurity metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/os.go
+++ b/collector/os.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -122,7 +122,7 @@ func NewOSCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *OSCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting os metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting cpu metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/perflib.go
+++ b/collector/perflib.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 	"strconv"
 
+	"github.com/go-kit/kit/log/level"
 	perflibCollector "github.com/leoluk/perflib_exporter/collector"
 	"github.com/leoluk/perflib_exporter/perflib"
-	"github.com/prometheus/common/log"
 )
 
 var nametable = perflib.QueryNameTable("Counter 009") // Reads the names in English TODO: validate that the English names are always present
@@ -70,7 +70,7 @@ func unmarshalObject(obj *perflib.PerfObject, vs interface{}) error {
 
 			ctr, found := counters[tag]
 			if !found {
-				log.Debugf("missing counter %q, have %v", tag, counterMapKeys(counters))
+				level.Debug(logger).Log("msg", "missing counter", "counter", tag, "have", counterMapKeys(counters))
 				continue
 			}
 			if !target.Field(i).CanSet() {

--- a/collector/perflib_test.go
+++ b/collector/perflib_test.go
@@ -6,6 +6,7 @@ import (
 
 	perflibCollector "github.com/leoluk/perflib_exporter/collector"
 	"github.com/leoluk/perflib_exporter/perflib"
+	"github.com/prometheus/common/promlog"
 )
 
 type simple struct {
@@ -106,6 +107,12 @@ func TestUnmarshalPerflib(t *testing.T) {
 			expectError:    false,
 		},
 	}
+
+	// Initialise logger object. Required by unmarshalObject() for debugging output
+	promlogConfig := &promlog.Config{}
+	logger := promlog.New(promlogConfig)
+	SetLogger(logger)
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			output := make([]simple, 0)

--- a/collector/process.go
+++ b/collector/process.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -53,7 +53,7 @@ func newProcessCollector() (Collector, error) {
 	const subsystem = "process"
 
 	if *processWhitelist == ".*" && *processBlacklist == "" {
-		log.Warn("No filters specified for process collector. This will generate a very large number of metrics!")
+		level.Warn(logger).Log("msg", "No filters specified for process collector. This will generate a very large number of metrics!")
 	}
 
 	return &processCollector{
@@ -187,7 +187,7 @@ func (c *processCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metr
 	var dst_wp []WorkerProcess
 	q_wp := queryAll(&dst_wp)
 	if err := wmi.QueryNamespace(q_wp, &dst_wp, "root\\WebAdministration"); err != nil {
-		log.Debugf("Could not query WebAdministration namespace for IIS worker processes: %v. Skipping", err)
+		level.Debug(logger).Log("msg", "Could not query WebAdministration namespace for IIS worker processes. Skipping.", "err", err)
 	}
 
 	for _, process := range data {

--- a/collector/remote_fx.go
+++ b/collector/remote_fx.go
@@ -5,8 +5,8 @@ package collector
 import (
 	"strings"
 
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -157,11 +157,11 @@ func NewRemoteFx() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *RemoteFxCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collectRemoteFXNetworkCount(ctx, ch); err != nil {
-		log.Error("failed collecting terminal services session count metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting terminal services session count metrics", "desc", desc, "err", err)
 		return err
 	}
 	if desc, err := c.collectRemoteFXGraphicsCounters(ctx, ch); err != nil {
-		log.Error("failed collecting terminal services session count metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting terminal services session count metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/service.go
+++ b/collector/service.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -38,7 +38,7 @@ func NewserviceCollector() (Collector, error) {
 	const subsystem = "service"
 
 	if *serviceWhereClause == "" {
-		log.Warn("No where-clause specified for service collector. This will generate a very large number of metrics!")
+		level.Warn(logger).Log("msg", "No where-clause specified for service collector. This will generate a very large number of metrics!")
 	}
 
 	return &serviceCollector{
@@ -74,7 +74,7 @@ func NewserviceCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *serviceCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting service metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting service metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/smtp.go
+++ b/collector/smtp.go
@@ -4,14 +4,13 @@ package collector
 
 import (
 	"fmt"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"regexp"
 )
 
 func init() {
-	log.Info("smtp collector is in an experimental state! Metrics for this collector have not been tested.")
 	registerCollector("smtp", NewSMTPCollector, "SMTP Server")
 }
 
@@ -69,6 +68,7 @@ type SMTPCollector struct {
 }
 
 func NewSMTPCollector() (Collector, error) {
+	level.Info(logger).Log("msg", "smtp collector is in an experimental state! Metrics for this collector have not been tested.")
 	const subsystem = "smtp"
 
 	return &SMTPCollector{
@@ -334,7 +334,7 @@ func NewSMTPCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *SMTPCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ctx, ch); err != nil {
-		log.Error("failed collecting smtp metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting smtp metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/system.go
+++ b/collector/system.go
@@ -3,8 +3,8 @@
 package collector
 
 import (
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -69,7 +69,7 @@ func NewSystemCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *SystemCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ctx, ch); err != nil {
-		log.Error("failed collecting system metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting system metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/tcp.go
+++ b/collector/tcp.go
@@ -3,8 +3,8 @@
 package collector
 
 import (
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -90,7 +90,7 @@ func NewTCPCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *TCPCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ctx, ch); err != nil {
-		log.Error("failed collecting tcp metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting tcp metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/thermalzone.go
+++ b/collector/thermalzone.go
@@ -2,8 +2,8 @@ package collector
 
 import (
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -52,7 +52,7 @@ func NewThermalZoneCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *thermalZoneCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Error("failed collecting thermalzone metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting thermalzone metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/time.go
+++ b/collector/time.go
@@ -3,8 +3,8 @@
 package collector
 
 import (
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -68,7 +68,7 @@ func newTimeCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *TimeCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ctx, ch); err != nil {
-		log.Error("failed collecting time metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting time metrics", "description", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/vmware.go
+++ b/collector/vmware.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 
 	"github.com/StackExchange/wmi"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -164,11 +164,11 @@ func NewVmwareCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *VmwareCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
 	if desc, err := c.collectMem(ch); err != nil {
-		log.Error("failed collecting vmware memory metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting vmware memory metrics", "desc", desc, "err", err)
 		return err
 	}
 	if desc, err := c.collectCpu(ch); err != nil {
-		log.Error("failed collecting vmware cpu metrics:", desc, err)
+		level.Error(logger).Log("msg", "Failed collecting vmware cpu metrics", "desc", desc, "err", err)
 		return err
 	}
 	return nil

--- a/collector/wmi.go
+++ b/collector/wmi.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"reflect"
 
-	"github.com/prometheus/common/log"
+	"github.com/go-kit/kit/log/level"
 )
 
 func className(src interface{}) string {
@@ -21,7 +21,7 @@ func queryAll(src interface{}) string {
 	b.WriteString("SELECT * FROM ")
 	b.WriteString(className(src))
 
-	log.Debugf("Generated WMI query %s", b.String())
+	level.Debug(logger).Log("msg", "Generated WMI query", "query", b.String())
 	return b.String()
 }
 
@@ -30,7 +30,7 @@ func queryAllForClass(src interface{}, class string) string {
 	b.WriteString("SELECT * FROM ")
 	b.WriteString(class)
 
-	log.Debugf("Generated WMI query %s", b.String())
+	level.Debug(logger).Log("msg", "Generated WMI query", "query", b.String())
 	return b.String()
 }
 
@@ -44,7 +44,7 @@ func queryAllWhere(src interface{}, where string) string {
 		b.WriteString(where)
 	}
 
-	log.Debugf("Generated WMI query %s", b.String())
+	level.Debug(logger).Log("msg", "Generated WMI query", "query", b.String())
 	return b.String()
 }
 
@@ -58,6 +58,6 @@ func queryAllForClassWhere(src interface{}, class string, where string) string {
 		b.WriteString(where)
 	}
 
-	log.Debugf("Generated WMI query %s", b.String())
+	level.Debug(logger).Log("msg", "Generated WMI query", "query", b.String())
 	return b.String()
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Microsoft/hcsshim v0.8.6
 	github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f
 	github.com/dimchansky/utfbom v1.1.0
+	github.com/go-kit/kit v0.10.0
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/google/go-cmp v0.5.1 // indirect
 	github.com/leoluk/perflib_exporter v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -72,13 +72,16 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.10.0 h1:dXFJfIHVvUcpSgDOV+Ne6t7jXri8Tfv2uOLHUZ2XNuo=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-ole/go-ole v1.2.1 h1:2lOsA72HgjxAuMlKpFiCbHTvu44PIVkZ5hqm3RSdI/E=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -221,6 +224,7 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
`prometheus/common/log` library is deprecated. Migration to `go-kit/kit/log` library will allow importing of the shared TLS library for prometheus exporters in the future (see #680 for context).

This can't be merged until support for Windows Event Log is added to the `go-kit` logging library, so this pull request is merely a draft for review/discussion.