### PR TITLE
Document version requirement for time collector

### DIFF
--- a/collector/time.go
+++ b/collector/time.go
@@ -3,6 +3,8 @@
 package collector
 
 import (
+	"errors"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 )
@@ -22,6 +24,10 @@ type TimeCollector struct {
 }
 
 func newTimeCollector() (Collector, error) {
+	if getWindowsVersion() <= 6.1 {
+		return nil, errors.New("Windows version older than Server 2016 detected. The time collector will not run and should be disabled via CLI flags or configuration file")
+
+	}
 	const subsystem = "time"
 
 	return &TimeCollector{

--- a/docs/collector.time.md
+++ b/docs/collector.time.md
@@ -3,6 +3,8 @@
 The time collector exposes the Windows Time Service metrics. Note that the Windows Time Service must be running, else metric collection will fail.
 If the Windows Time Service is stopped after collection has started, collector metric values will reset to 0.
 
+Please note the Time Service perflib counters are only available on [Windows Server 2016 or newer](https://docs.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-server-2016-improvements).
+
 |||
 -|-
 Metric name prefix  | `time`


### PR DESCRIPTION
Windows Server 2016 or newer is required for the collector, as the
perflib counters were not exposed in previous versions.

Resolves #658 