### PR TITLE
Remove "total" suffix from dns_memory_used_bytes

### DIFF
--- a/collector/dns.go
+++ b/collector/dns.go
@@ -81,8 +81,8 @@ func NewDNSCollector() (Collector, error) {
 			nil,
 		),
 		MemoryUsedBytes: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "memory_used_bytes_total"),
-			"Total memory used by DNS server",
+			prometheus.BuildFQName(Namespace, subsystem, "memory_used_bytes"),
+			"Current memory used by DNS server",
 			[]string{"area"},
 			nil,
 		),


### PR DESCRIPTION
Metric is a gauge and therefore should not have the "total" suffix.

Resolves #284 