### PR TITLE
Add  terminal_service_gateway_collector

### DIFF
--- a/.github/workflows/shiftleft.yml
+++ b/.github/workflows/shiftleft.yml
@@ -1,0 +1,57 @@
+---
+# This workflow integrates ShiftLeft NG SAST with GitHub
+# Visit https://docs.shiftleft.io for help
+name: ShiftLeft
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  NextGen-Static-Analysis:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.14'
+    - name: Build
+      run: |
+        go build ./...
+    - name: Download ShiftLeft CLI
+      run: |
+        curl https://cdn.shiftleft.io/download/sl > ${GITHUB_WORKSPACE}/sl && chmod a+rx ${GITHUB_WORKSPACE}/sl
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+    - name: NextGen Static Analysis
+      run: |
+        ${GITHUB_WORKSPACE}/sl --version
+        ${GITHUB_WORKSPACE}/sl analyze --wait --app windows_exporter --tag branch=${{ github.head_ref || steps.extract_branch.outputs.branch }} --go --cpg $(pwd)
+      env:
+        SHIFTLEFT_ACCESS_TOKEN: ${{ secrets.SHIFTLEFT_ACCESS_TOKEN }}
+        
+   
+  ## Uncomment the following section to enable build rule checking and enforcing.
+  #Build-Rules: 
+    #runs-on: ubuntu-latest
+    #needs: NextGen-Static-Analysis
+    #steps:
+    #- uses: actions/checkout@v2
+    #- name: Download ShiftLeft CLI
+    #  run: |
+    #    curl https://cdn.shiftleft.io/download/sl > ${GITHUB_WORKSPACE}/sl && chmod a+rx ${GITHUB_WORKSPACE}/sl
+    #- name: Validate Build Rules
+    #  run: |
+    #    ${GITHUB_WORKSPACE}/sl check-analysis --app windows_exporter \
+    #       --source 'tag.branch=${{ github.event.pull_request.base.ref }}' \
+    #       --target "tag.branch=${{ github.head_ref || steps.extract_branch.outputs.branch }}" \
+    #       --report \
+    #       --github-pr-number=${{github.event.number}} \
+    #       --github-pr-user=${{ github.repository_owner }} \
+    #       --github-pr-repo=${{ github.event.repository.name }} \
+    #       --github-token=${{ secrets.GITHUB_TOKEN }}
+    #  env:
+        #SHIFTLEFT_ACCESS_TOKEN: ${{ secrets.SHIFTLEFT_ACCESS_TOKEN }}
+        

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Name     | Description | Enabled by default
 [smtp](docs/collector.smtp.md) | IIS SMTP Server |
 [system](docs/collector.system.md) | System calls | &#10003;
 [tcp](docs/collector.tcp.md) | TCP connections |
-[terminal_service_gateway](docs/collector.terminal_service_gateway.md) | Terminal Service Gateway |
 [time](docs/collector.time.md) | Windows Time Service |
 [thermalzone](docs/collector.thermalzone.md) | Thermal information
+[terminal_service_gateway](docs/collector.terminal_service_gateway.md) | Terminal Service Gateway |
 [terminal_services](docs/collector.terminal_services.md) | Terminal services (RDS)
 [textfile](docs/collector.textfile.md) | Read prometheus metrics from a text file | &#10003;
 [vmware](docs/collector.vmware.md) | Performance counters installed by the Vmware Guest agent |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Name     | Description | Enabled by default
 [smtp](docs/collector.smtp.md) | IIS SMTP Server |
 [system](docs/collector.system.md) | System calls | &#10003;
 [tcp](docs/collector.tcp.md) | TCP connections |
+[terminal_service_gateway](docs/collector.terminal_service_gateway.md) | Terminal Service Gateway |
 [time](docs/collector.time.md) | Windows Time Service |
 [thermalzone](docs/collector.thermalzone.md) | Thermal information
 [terminal_services](docs/collector.terminal_services.md) | Terminal services (RDS)

--- a/collector/terminal_services_gateway.go
+++ b/collector/terminal_services_gateway.go
@@ -1,0 +1,124 @@
+package collector
+
+import (
+	"github.com/StackExchange/wmi"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func init() {
+	registerCollector("terminal_service_gateway", newTerminalServiceGatewayCollector) // TODO: Add any perflib dependencies here
+}
+
+// A TerminalServiceGatewayCollector is a Prometheus collector for WMI Win32_PerfRawData_TSGateway_TerminalServiceGateway metrics
+// see https://wutils.com/wmi/root/cimv2/win32_perfrawdata_tsgateway_terminalservicegateway/
+type TerminalServiceGatewayCollector struct {
+	ConnectionRequestAuthorizationTime *prometheus.Desc
+	CurrentConnections                 *prometheus.Desc
+	FailedConnectionAuthorization      *prometheus.Desc
+	FailedConnections                  *prometheus.Desc
+	FailedResourceAuthorization        *prometheus.Desc
+	SuccessfulConnections              *prometheus.Desc
+}
+
+func newTerminalServiceGatewayCollector() (Collector, error) {
+	const subsystem = "terminal_service_gateway"
+	return &TerminalServiceGatewayCollector{
+		ConnectionRequestAuthorizationTime: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "connection_request_authorization_time_seconds"),
+			"Shows the average connection request authentication and authorization times in seconds",
+			nil,
+			nil,
+		),
+		CurrentConnections: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "current_connections_count"),
+			"Shows the total number of active/inactive connections to the RDG server at any given moment",
+			nil,
+			nil,
+		),
+		FailedConnectionAuthorization: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "failed_connection_authorization_total"),
+			"Shows the total number of requests that failed due to insufficient connection authorization privilege",
+			nil,
+			nil,
+		),
+		FailedConnections: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "failed_connections_total"),
+			"Shows the number of connection requests that are all failed due to errors and authorization failure",
+			nil,
+			nil,
+		),
+		FailedResourceAuthorization: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "failed_resource_authorization_total"),
+			"Shows the total number of requests that failed due to insufficient resource authorization privilege",
+			nil,
+			nil,
+		),
+		SuccessfulConnections: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "successful_connections_total"),
+			"Shows the number of requests that were successfully processed and connected",
+			nil,
+			nil,
+		),
+	}, nil
+}
+
+// Win32_PerfRawData_TSGateway_TerminalServiceGateway docs:
+// - <add link to documentation here>
+type Win32_PerfRawData_TSGateway_TerminalServiceGateway struct {
+	Name string
+
+	ConnectionRequestAuthorizationTime uint32
+	CurrentConnections                 uint32
+	FailedConnectionAuthorization      uint32
+	FailedConnections                  uint32
+	FailedResourceAuthorization        uint32
+	SuccessfulConnections              uint32
+}
+
+// Collect sends the metric values for each metric
+// to the provided prometheus Metric channel.
+func (c *TerminalServiceGatewayCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
+	var dst []Win32_PerfRawData_TSGateway_TerminalServiceGateway
+	q := queryAll(&dst)
+	if err := wmi.Query(q, &dst); err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.ConnectionRequestAuthorizationTime,
+		prometheus.GaugeValue,
+		float64(dst[0].ConnectionRequestAuthorizationTime),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.CurrentConnections,
+		prometheus.GaugeValue,
+		float64(dst[0].CurrentConnections),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.FailedConnectionAuthorization,
+		prometheus.GaugeValue,
+		float64(dst[0].FailedConnectionAuthorization),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.FailedConnections,
+		prometheus.GaugeValue,
+		float64(dst[0].FailedConnections),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.FailedResourceAuthorization,
+		prometheus.GaugeValue,
+		float64(dst[0].FailedResourceAuthorization),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.SuccessfulConnections,
+		prometheus.GaugeValue,
+		float64(dst[0].SuccessfulConnections),
+	)
+
+	return nil
+}

--- a/docs/collector.terminal_service_gateway.md
+++ b/docs/collector.terminal_service_gateway.md
@@ -1,0 +1,34 @@
+# terminal_service_gateway collector
+
+The terminal_service_gateway collector exposes terminal service gateway performance metrics.
+
+|||
+-|-
+Metric name prefix  | `terminal_service_gateway`
+Data source         | Perflib/WMI
+Classes             | [`Win32_PerfRawData_TSGateway_TerminalServiceGateway`](https://wutils.com/wmi/root/cimv2/win32_perfrawdata_tsgateway_terminalservicegateway/)
+Enabled by default? | No
+
+## Flags
+
+None
+
+## Metrics
+
+Name | Description | Type | Labels
+-----|-------------|------|-------
+`windows_terminal_service_gateway_connection_request_authorization_time_seconds` | gauge | Shows the average connection request authentication and authorization times in seconds
+`windows_terminal_service_gateway_current_connections_count` | gauge | Shows the total number of active/inactive connections to the RDG server at any given moment
+`windows_terminal_service_gateway_failed_connection_authorization_total` | gauge | Shows the total number of requests that failed due to insufficient connection authorization privilege
+`windows_terminal_service_gateway_failed_connections_total` | gauge | Shows the number of connection requests that are all failed due to errors and authorization failure
+`windows_terminal_service_gateway_failed_resource_authorization_total` | gauge | Shows the total number of requests that failed due to insufficient resource authorization privilege
+`windows_terminal_service_gateway_successful_connections_total` | gauge | Shows the number of requests that were successfully processed and connected
+
+### Example metric
+_This collector does not yet have explained examples, we would appreciate your help adding them!_
+
+## Useful queries
+_This collector does not yet have any useful queries added, we would appreciate your help adding them!_
+
+## Alerting examples
+_This collector does not yet have alerting examples, we would appreciate your help adding them!_

--- a/shiftleft.yml
+++ b/shiftleft.yml
@@ -1,0 +1,12 @@
+build_rules:
+  - id: allow-zero-findings
+    finding_types:
+      - vuln
+      - secret
+      - insight
+      - "*"
+    severity:
+      - SEVERITY_MEDIUM_IMPACT
+      - SEVERITY_HIGH_IMPACT
+      - SEVERITY_LOW_IMPACT
+    threshold: 0


### PR DESCRIPTION
Hey,

this adds a collector for scraping performance metrics of the windows terminal service gateway.
I've updated the documentation accordingly.

Feedback is welcome, thanks
Fluepke