### PR TITLE
Add coretemp collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Name     | Description | Enabled by default
 [cpu](docs/collector.cpu.md) | CPU usage | &#10003;
 [cs](docs/collector.cs.md) | "Computer System" metrics (system properties, num cpus/total memory) | &#10003;
 [container](docs/collector.container.md) | Container metrics |
+[coretemp](docs/collector.coretemp.md) | Core Temp metrics |
 [dfsr](docs/collector.dfsr.md) | DFSR metrics |
 [dhcp](docs/collector.dhcp.md) | DHCP Server |
 [dns](docs/collector.dns.md) | DNS Server |
@@ -75,7 +76,7 @@ Flag     | Description | Default value
 `--telemetry.path` | URL path for surfacing collected metrics. | `/metrics`
 `--telemetry.max-requests` | Maximum number of concurrent requests. 0 to disable. | `5`
 `--collectors.enabled` | Comma-separated list of collectors to use. Use `[defaults]` as a placeholder for all the collectors enabled by default." | `[defaults]`
-`--collectors.print` | If true, print available collectors and exit. | 
+`--collectors.print` | If true, print available collectors and exit. |
 `--scrape.timeout-margin` | Seconds to subtract from the timeout allowed by the client. Tune to allow for overhead or high loads. | `0.5`
 
 ## Installation

--- a/collector/coretemp.go
+++ b/collector/coretemp.go
@@ -1,0 +1,154 @@
+package collector
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+	"golang.org/x/sys/windows"
+)
+
+// technical documentation for the shared memory structure: https://www.alcpu.com/CoreTemp/developers.html
+
+var (
+	kernel32         = syscall.NewLazyDLL("KERNEL32.dll")
+	msvcrt           = syscall.NewLazyDLL("msvcrt.dll")
+	createMutexW     = kernel32.NewProc("CreateMutexW")
+	releaseMutex     = kernel32.NewProc("ReleaseMutex")
+	openFileMappingW = kernel32.NewProc("OpenFileMappingW")
+	closeHandle      = kernel32.NewProc("CloseHandle")
+	mapViewOfFile    = kernel32.NewProc("MapViewOfFile")
+	unmapViewOfFile  = kernel32.NewProc("UnmapViewOfFile")
+	memcpy_s         = msvcrt.NewProc("memcpy_s")
+)
+
+func init() {
+	registerCollector("coretemp", NewCoreTempCollector)
+}
+
+// A coreTempCollector is a Prometheus collector for CoreTemp shared data metrics
+type coreTempCollector struct {
+	Temperature *prometheus.Desc
+	Load        *prometheus.Desc
+}
+
+// NewCoreTempCollector ...
+func NewCoreTempCollector() (Collector, error) {
+	const subsystem = "coretemp"
+	return &coreTempCollector{
+
+		Temperature: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "temperature_celsius"),
+			"(Temperature)",
+			[]string{"name", "core"},
+			nil,
+		),
+
+		Load: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "load"),
+			"(Load)",
+			[]string{"name", "core"},
+			nil,
+		),
+	}, nil
+}
+
+// Collect sends the metric values for each metric
+// to the provided prometheus Metric channel.
+func (c *coreTempCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) error {
+	if desc, err := c.collect(ch); err != nil {
+		log.Error("failed collecting coretemp metrics:", desc, err)
+		return err
+	}
+	return nil
+}
+
+func (c *coreTempCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+
+	s, err := readCoreTempSharedData()
+	if err != nil {
+		return nil, err
+	}
+
+	cpuName := s.GetCPUName()
+
+	for i := uint32(0); i < s.CoreCount; i++ {
+
+		// convert to celsius if internal unit is fahrenheit
+		temp := float64(s.Temp[i])
+		if s.IsFahrenheit {
+			temp = (temp - 32) * 5 / 9
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			c.Temperature,
+			prometheus.GaugeValue,
+			temp,
+			cpuName,
+			fmt.Sprintf("%d", i),
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.Load,
+			prometheus.GaugeValue,
+			float64(s.Load[i]),
+			cpuName,
+			fmt.Sprintf("%d", i),
+		)
+	}
+
+	return nil, nil
+}
+
+// read memory from CoreTemp to fetch cpu data
+func readCoreTempSharedData() (*coreTempSharedData, error) {
+
+	mutexName, _ := windows.UTF16PtrFromString("CoreTempMutexObject")
+	mutexObject, _, err := createMutexW.Call(0, 0, uintptr(unsafe.Pointer(mutexName)))
+	if err == nil {
+		return nil, fmt.Errorf("CoreTempMutexObject not found. make sure Core Temp is running")
+	}
+	defer releaseMutex.Call(mutexObject)
+
+	mappingName, _ := windows.UTF16PtrFromString("CoreTempMappingObject")
+	mappingObject, _, err := openFileMappingW.Call(4, 1, uintptr(unsafe.Pointer(mappingName)))
+	if mappingObject == uintptr(0) {
+		return nil, err
+	}
+	defer closeHandle.Call(mappingObject)
+
+	mapView, _, err := mapViewOfFile.Call(mappingObject, 4, 0, 0, 0)
+	if mapView == uintptr(0) {
+		return nil, err
+	}
+	defer unmapViewOfFile.Call(mapView)
+
+	data := coreTempSharedData{}
+	_, _, _ = memcpy_s.Call(uintptr(unsafe.Pointer(&data)), 0xa80, mapView, 0xa80)
+
+	return &data, nil
+}
+
+type coreTempSharedData struct {
+	Load           [256]uint32
+	TjMax          [128]uint32
+	CoreCount      uint32
+	CPUCount       uint32
+	Temp           [256]float32
+	VID            float32
+	CPUSpeed       float32
+	FSBSpeed       float32
+	Multipier      float32
+	CPUName        [100]byte
+	IsFahrenheit   bool // if true, true, the temperature is reported in Fahrenheit
+	IsDeltaToTjMax bool // if true, the temperature reported represents the distance from TjMax
+}
+
+func (s *coreTempSharedData) GetCPUName() string {
+	n := bytes.IndexByte(s.CPUName[:], 0)
+	return strings.TrimSpace(string(s.CPUName[:n]))
+}

--- a/docs/collector.coretemp.md
+++ b/docs/collector.coretemp.md
@@ -1,0 +1,34 @@
+# coretemp collector
+
+The coretemp collector exposes CPU temperature and CPU load metrics from Core Temp.
+
+In order for this collector to work correctly, you must first install [Core Temp](https://www.alcpu.com/CoreTemp/) and make sure it is running.
+
+|||
+-|-
+Metric name prefix  | `coretemp`
+Enabled by default? | No
+
+## Flags
+
+None
+
+## Metrics
+
+Name | Description | Type | Labels
+-----|-------------|------|-------
+`windows_coretemp_load` | CPU core load | gauge | name, core
+`windows_coretemp_temperature` | CPU core temperature | gauge | name, core
+
+### Example metric
+
+_windows_coretemp_temperature_celsius{core="0",name="Intel Core i7 6700K (Skylake)"} 37_
+
+This metric shows the temperature for CPU core 0 is 37 °C
+
+
+## Useful queries
+_This collector does not yet have any useful queries added, we would appreciate your help adding them!_
+
+## Alerting examples
+_This collector does not yet have alerting examples, we would appreciate your help adding them!_


### PR DESCRIPTION
Hello!
I have been digging around trying to get proper CPU temperature readings.

Here's what I learned:
- thermalzone collector mostly does not export anything. No driver seems to be available by default and where is even one for Intel CPU:s?
- Intel and AMD cpu:s report core temperatures in different ways. Implementations exist but most is closed source. I did find some information about how to read this, for example openhardwaremonitor (C#) has some code here: https://github.com/openhardwaremonitor/openhardwaremonitor/tree/master/Hardware/CPU
- Reading CPU temperatures directly requires program to run as Administrator, complicating setup
- Reading CPU temperatures directly requires writing a bunch of code I'm not committed enough to put more time into.

Eventually I figured out that the software Core Temp (https://www.alcpu.com/CoreTemp/) has an API of sorts, and instead built a collector directly using it.
This has the following advantages:
- no administrator required
- CoreTemp reports temperature & core load data in a uniform way for both Intel and AMD cpu:s

And the following disadvantages:
- CoreTemp must also be installed and running on the machine to monitor
- No direct golang implementation of temperature scraping
- Coretemp is not free for commercial use

And probably more I didn't think about.

Anyway, this is sort of a hack but works well and exports cpu data such as this:

```
# HELP windows_coretemp_load (Load)
# TYPE windows_coretemp_load gauge
windows_coretemp_load{core="0",name="Intel Core i7 6700K (Skylake)"} 4
windows_coretemp_load{core="1",name="Intel Core i7 6700K (Skylake)"} 3
windows_coretemp_load{core="2",name="Intel Core i7 6700K (Skylake)"} 5
windows_coretemp_load{core="3",name="Intel Core i7 6700K (Skylake)"} 2
# HELP windows_coretemp_temperature_celsius (Temperature)
# TYPE windows_coretemp_temperature_celsius gauge
windows_coretemp_temperature_celsius{core="0",name="Intel Core i7 6700K (Skylake)"} 36
windows_coretemp_temperature_celsius{core="1",name="Intel Core i7 6700K (Skylake)"} 39
windows_coretemp_temperature_celsius{core="2",name="Intel Core i7 6700K (Skylake)"} 35
windows_coretemp_temperature_celsius{core="3",name="Intel Core i7 6700K (Skylake)"} 35
```

So lets have a discussion about if this is a reasonable approach at all.

I also see the lack of proper temperature reporting has been discussed a number of times already: #495, #560, #650, #539
