### PR TITLE
Move experimental warnings from init()

### DIFF
--- a/collector/dfsr.go
+++ b/collector/dfsr.go
@@ -11,7 +11,6 @@ import (
 var dfsrEnabledCollectors = kingpin.Flag("collectors.dfsr.sources-enabled", "Comma-seperated list of DFSR Perflib sources to use.").Default("connection,folder,volume").String()
 
 func init() {
-	log.Info("dfsr collector is in an experimental state! Metrics for this collector have not been tested.")
 	// Perflib sources are dynamic, depending on the enabled child collectors
 	var perflibDependencies []string
 	for _, source := range expandEnabledChildCollectors(*dfsrEnabledCollectors) {
@@ -94,6 +93,7 @@ func dfsrGetPerfObjectName(collector string) string {
 
 // NewDFSRCollector is registered
 func NewDFSRCollector() (Collector, error) {
+	log.Info("dfsr collector is in an experimental state! Metrics for this collector have not been tested.")
 	const subsystem = "dfsr"
 
 	enabled := expandEnabledChildCollectors(*dfsrEnabledCollectors)

--- a/collector/smtp.go
+++ b/collector/smtp.go
@@ -11,7 +11,6 @@ import (
 )
 
 func init() {
-	log.Info("smtp collector is in an experimental state! Metrics for this collector have not been tested.")
 	registerCollector("smtp", NewSMTPCollector, "SMTP Server")
 }
 
@@ -69,6 +68,7 @@ type SMTPCollector struct {
 }
 
 func NewSMTPCollector() (Collector, error) {
+	log.Info("smtp collector is in an experimental state! Metrics for this collector have not been tested.")
 	const subsystem = "smtp"
 
 	return &SMTPCollector{


### PR DESCRIPTION
`init()` causes warnings to be emitted despite collectors not being enabled.