### PR TITLE
Add benchmark for each collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ windows_exporter.exe: **/*.go
 test:
 	go test -v ./...
 
+bench:
+	go test -v -bench='benchmark(cpu|logicaldisk|logon|memory|net|process|service|system|tcp|time)collector' ./...
+
 lint:
 	golangci-lint -c .golangci.yaml run
 

--- a/collector/ad_test.go
+++ b/collector/ad_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkADCollector(b *testing.B) {
+	benchmarkCollector(b, "ad", NewADCollector)
+}

--- a/collector/adfs_test.go
+++ b/collector/adfs_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkADFSCollector(b *testing.B) {
+	benchmarkCollector(b, "adfs", newADFSCollector)
+}

--- a/collector/container_test.go
+++ b/collector/container_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkContainerCollector(b *testing.B) {
+	benchmarkCollector(b, "container", NewContainerMetricsCollector)
+}

--- a/collector/cpu_test.go
+++ b/collector/cpu_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkCPUCollector(b *testing.B) {
+	benchmarkCollector(b, "cpu", newCPUCollector)
+}

--- a/collector/cs_test.go
+++ b/collector/cs_test.go
@@ -2,22 +2,8 @@ package collector
 
 import (
 	"testing"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
-func BenchmarkCsCollect(b *testing.B) {
-	c, err := NewCSCollector()
-	if err != nil {
-		b.Error(err)
-	}
-	metrics := make(chan prometheus.Metric)
-	go func() {
-		for {
-			<-metrics
-		}
-	}()
-	for i := 0; i < b.N; i++ {
-		c.Collect(&ScrapeContext{}, metrics)
-	}
+func BenchmarkCsCollector(b *testing.B) {
+	benchmarkCollector(b, "cs", NewCSCollector)
 }

--- a/collector/dfsr_test.go
+++ b/collector/dfsr_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkDFSRCollector(b *testing.B) {
+	benchmarkCollector(b, "dfsr", NewDFSRCollector)
+}

--- a/collector/dhcp_test.go
+++ b/collector/dhcp_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkDHCPCollector(b *testing.B) {
+	benchmarkCollector(b, "dhcp", NewDhcpCollector)
+}

--- a/collector/dns_test.go
+++ b/collector/dns_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkDNSCollector(b *testing.B) {
+	benchmarkCollector(b, "dns", NewDNSCollector)
+}

--- a/collector/exchange_test.go
+++ b/collector/exchange_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkExchangeCollector(b *testing.B) {
+	benchmarkCollector(b, "exchange", newExchangeCollector)
+}

--- a/collector/fsrmquota_test.go
+++ b/collector/fsrmquota_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkFsrmQuotaCollector(b *testing.B) {
+	benchmarkCollector(b, "fsrmquota", newFSRMQuotaCollector)
+}

--- a/collector/hyperv_test.go
+++ b/collector/hyperv_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkHypervCollector(b *testing.B) {
+	benchmarkCollector(b, "hyperv", NewHyperVCollector)
+}

--- a/collector/iis_test.go
+++ b/collector/iis_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkIISCollector(b *testing.B) {
+	benchmarkCollector(b, "iis", NewIISCollector)
+}

--- a/collector/logical_disk_test.go
+++ b/collector/logical_disk_test.go
@@ -1,0 +1,13 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkLogicalDiskCollector(b *testing.B) {
+	// Whitelist is not set in testing context (kingpin flags not parsed), causing the collector to skip all disks.
+	localVolumeWhitelist := ".+"
+	volumeWhitelist = &localVolumeWhitelist
+
+	benchmarkCollector(b, "logical_disk", NewLogicalDiskCollector)
+}

--- a/collector/logon_test.go
+++ b/collector/logon_test.go
@@ -1,0 +1,10 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkLogonCollector(b *testing.B) {
+	// No context name required as collector source is WMI
+	benchmarkCollector(b, "", NewLogonCollector)
+}

--- a/collector/memory_test.go
+++ b/collector/memory_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkMemoryCollector(b *testing.B) {
+	benchmarkCollector(b, "memory", NewMemoryCollector)
+}

--- a/collector/msmq_test.go
+++ b/collector/msmq_test.go
@@ -1,0 +1,10 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkMsmqCollector(b *testing.B) {
+	// No context name required as collector source is WMI
+	benchmarkCollector(b, "", NewMSMQCollector)
+}

--- a/collector/mssql_test.go
+++ b/collector/mssql_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkMSSQLCollector(b *testing.B) {
+	benchmarkCollector(b, "mssql", NewMSSQLCollector)
+}

--- a/collector/net_test.go
+++ b/collector/net_test.go
@@ -2,7 +2,9 @@
 
 package collector
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestNetworkToInstanceName(t *testing.T) {
 	data := map[string]string{
@@ -14,4 +16,11 @@ func TestNetworkToInstanceName(t *testing.T) {
 			t.Error("expected", out, "got", got)
 		}
 	}
+}
+
+func BenchmarkNetCollector(b *testing.B) {
+	// Whitelist is not set in testing context (kingpin flags not parsed), causing the collector to skip all interfaces.
+	localNicWhitelist := ".+"
+	nicWhitelist = &localNicWhitelist
+	benchmarkCollector(b, "net", NewNetworkCollector)
 }

--- a/collector/netframework_clrexceptions_test.go
+++ b/collector/netframework_clrexceptions_test.go
@@ -1,0 +1,10 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkNetFrameworkNETCLRExceptionsCollector(b *testing.B) {
+	// No context name required as collector source is WMI
+	benchmarkCollector(b, "", NewNETFramework_NETCLRExceptionsCollector)
+}

--- a/collector/netframework_clrinterop_test.go
+++ b/collector/netframework_clrinterop_test.go
@@ -1,0 +1,10 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkNETFrameworkNETCLRInteropCollector(b *testing.B) {
+	// No context name required as collector source is WMI
+	benchmarkCollector(b, "", NewNETFramework_NETCLRInteropCollector)
+}

--- a/collector/netframework_clrjit_test.go
+++ b/collector/netframework_clrjit_test.go
@@ -1,0 +1,10 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkNETFrameworkNETCLRJitCollector(b *testing.B) {
+	// No context name required as collector source is WMI
+	benchmarkCollector(b, "", NewNETFramework_NETCLRJitCollector)
+}

--- a/collector/netframework_clrloading_test.go
+++ b/collector/netframework_clrloading_test.go
@@ -1,0 +1,10 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkNETFrameworkNETCLRLoadingCollector(b *testing.B) {
+	// No context name required as collector source is WMI
+	benchmarkCollector(b, "", NewNETFramework_NETCLRLoadingCollector)
+}

--- a/collector/netframework_clrlocksandthreads_test.go
+++ b/collector/netframework_clrlocksandthreads_test.go
@@ -1,0 +1,10 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkNETFrameworkNETCLRLocksAndThreadsCollector(b *testing.B) {
+	// No context name required as collector source is WMI
+	benchmarkCollector(b, "", NewNETFramework_NETCLRLocksAndThreadsCollector)
+}

--- a/collector/netframework_clrmemory_test.go
+++ b/collector/netframework_clrmemory_test.go
@@ -1,0 +1,10 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkNETFrameworkNETCLRMemoryCollector(b *testing.B) {
+	// No context name required as collector source is WMI
+	benchmarkCollector(b, "", NewNETFramework_NETCLRMemoryCollector)
+}

--- a/collector/netframework_clrremoting_test.go
+++ b/collector/netframework_clrremoting_test.go
@@ -1,0 +1,10 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkNETFrameworkNETCLRRemotingCollector(b *testing.B) {
+	// No context name required as collector source is WMI
+	benchmarkCollector(b, "", NewNETFramework_NETCLRRemotingCollector)
+}

--- a/collector/netframework_clrsecurity_test.go
+++ b/collector/netframework_clrsecurity_test.go
@@ -1,0 +1,10 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkNETFrameworkNETCLRSecurityCollector(b *testing.B) {
+	// No context name required as collector source is WMI
+	benchmarkCollector(b, "", NewNETFramework_NETCLRSecurityCollector)
+}

--- a/collector/os_test.go
+++ b/collector/os_test.go
@@ -2,23 +2,8 @@ package collector
 
 import (
 	"testing"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
-func BenchmarkOsCollect(b *testing.B) {
-	o, err := NewOSCollector()
-	if err != nil {
-		b.Error(err)
-	}
-	metrics := make(chan prometheus.Metric)
-	go func() {
-		for {
-			<-metrics
-		}
-	}()
-	s, err := PrepareScrapeContext([]string{"os"})
-	for i := 0; i < b.N; i++ {
-		o.Collect(s, metrics)
-	}
+func BenchmarkOSCollector(b *testing.B) {
+	benchmarkCollector(b, "os", NewOSCollector)
 }

--- a/collector/process_test.go
+++ b/collector/process_test.go
@@ -1,0 +1,14 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkProcessCollector(b *testing.B) {
+	// Whitelist is not set in testing context (kingpin flags not parsed), causing the collector to skip all processes.
+	localProcessWhitelist := ".+"
+	processWhitelist = &localProcessWhitelist
+
+	// No context name required as collector source is WMI
+	benchmarkCollector(b, "", newProcessCollector)
+}

--- a/collector/remote_fx_test.go
+++ b/collector/remote_fx_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkRemoteFXCollector(b *testing.B) {
+	benchmarkCollector(b, "remote_fx", NewRemoteFx)
+}

--- a/collector/service_test.go
+++ b/collector/service_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkServiceCollector(b *testing.B) {
+	benchmarkCollector(b, "service", NewserviceCollector)
+}

--- a/collector/smtp_test.go
+++ b/collector/smtp_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkSmtpCollector(b *testing.B) {
+	benchmarkCollector(b, "smtp", NewSMTPCollector)
+}

--- a/collector/system_test.go
+++ b/collector/system_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkSystemCollector(b *testing.B) {
+	benchmarkCollector(b, "system", NewSystemCollector)
+}

--- a/collector/tcp_test.go
+++ b/collector/tcp_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkTCPCollector(b *testing.B) {
+	benchmarkCollector(b, "tcp", NewTCPCollector)
+}

--- a/collector/terminal_services_test.go
+++ b/collector/terminal_services_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkTerminalServicesCollector(b *testing.B) {
+	benchmarkCollector(b, "terminal_services", NewTerminalServicesCollector)
+}

--- a/collector/thermalzone_test.go
+++ b/collector/thermalzone_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkThermalZoneCollector(b *testing.B) {
+	benchmarkCollector(b, "thermalzone", NewThermalZoneCollector)
+}

--- a/collector/time_test.go
+++ b/collector/time_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkTimeCollector(b *testing.B) {
+	benchmarkCollector(b, "time", newTimeCollector)
+}

--- a/collector/vmware_test.go
+++ b/collector/vmware_test.go
@@ -1,0 +1,9 @@
+package collector
+
+import (
+	"testing"
+)
+
+func BenchmarkVmwareCollector(b *testing.B) {
+	benchmarkCollector(b, "vmware", NewVmwareCollector)
+}


### PR DESCRIPTION
Benchmarks will allow for easier identification of slow collectors.
Additionally, they increase test coverage of the collectors, with some
collectors now reaching 80-95% coverage with this change.

Collector benchmarks have been structed so that common functionality is
present in `collector/collector_test.go` as is done with non-test
functionality in `collector/collector.go`.
Test logic that is specific to individual collectors is present in the
collector test file (E.G. `collector/process_test.go` for the Process
collector).

Signed-off-by: Ben Reedy <breed808@breed808.com>