### PR TITLE
Adds netConnectionId label to the net collector

### DIFF
--- a/collector/net.go
+++ b/collector/net.go
@@ -158,7 +158,6 @@ type networkInterface struct {
 	BytesSentPerSec          float64 `perflib:"Bytes Sent/sec"`
 	BytesTotalPerSec         float64 `perflib:"Bytes Total/sec"`
 	Name                     string
-	NetConnectionID          string
 	PacketsOutboundDiscarded float64 `perflib:"Packets Outbound Discarded"`
 	PacketsOutboundErrors    float64 `perflib:"Packets Outbound Errors"`
 	PacketsPerSec            float64 `perflib:"Packets/sec"`

--- a/docs/collector.net.md
+++ b/docs/collector.net.md
@@ -23,18 +23,18 @@ If given, an interface name needs to *not* match the blacklist regexp in order f
 
 Name | Description | Type | Labels
 -----|-------------|------|-------
-`windows_net_bytes_received_total` | Total bytes received by interface | counter | `nic`
-`windows_net_bytes_sent_total` | Total bytes transmitted by interface | counter | `nic`
-`windows_net_bytes_total` | Total bytes received and transmitted by interface | counter | `nic`
-`windows_net_packets_outbound_discarded_total` | Total outbound packets that were chosen to be discarded even though no errors had been detected to prevent transmission | counter | `nic`
-`windows_net_packets_outbound_errors_total` | Total packets that could not be transmitted due to errors | counter | `nic`
-`windows_net_packets_received_discarded_total` | Total inbound packets that were chosen to be discarded even though no errors had been detected to prevent delivery | counter | `nic`
-`windows_net_packets_received_errors_total` | Total packets that could not be received due to errors  | counter | `nic`
-`windows_net_packets_received_total_total` | Total packets received by interface | counter | `nic`
-`windows_net_packets_received_unknown_total` | Total packets received by interface that were discarded because of an unknown or unsupported protocol | counter | `nic`
-`windows_net_packets_total` | Total packets received and transmitted by interface | counter | `nic`
-`windows_net_packets_sent_total` | Total packets transmitted by interface | counter | `nic`
-`windows_net_current_bandwidth` | Estimate of the interface's current bandwidth in bits per second (bps) | gauge | `nic`
+`windows_net_bytes_received_total` | Total bytes received by interface | counter | `nic`, `netConnectionId`
+`windows_net_bytes_sent_total` | Total bytes transmitted by interface | counter | `nic`, `netConnectionId`
+`windows_net_bytes_total` | Total bytes received and transmitted by interface | counter | `nic`, `netConnectionId`
+`windows_net_packets_outbound_discarded_total` | Total outbound packets that were chosen to be discarded even though no errors had been detected to prevent transmission | counter | `nic`, `netConnectionId`
+`windows_net_packets_outbound_errors_total` | Total packets that could not be transmitted due to errors | counter | `nic`, `netConnectionId`
+`windows_net_packets_received_discarded_total` | Total inbound packets that were chosen to be discarded even though no errors had been detected to prevent delivery | counter | `nic`, `netConnectionId`
+`windows_net_packets_received_errors_total` | Total packets that could not be received due to errors  | counter | `nic`, `netConnectionId`
+`windows_net_packets_received_total_total` | Total packets received by interface | counter | `nic`, `netConnectionId`
+`windows_net_packets_received_unknown_total` | Total packets received by interface that were discarded because of an unknown or unsupported protocol | counter | `nic`, `netConnectionId`
+`windows_net_packets_total` | Total packets received and transmitted by interface | counter | `nic`, `netConnectionId`
+`windows_net_packets_sent_total` | Total packets transmitted by interface | counter | `nic`, `netConnectionId`
+`windows_net_current_bandwidth` | Estimate of the interface's current bandwidth in bits per second (bps) | gauge | `nic`, `netConnectionId`
 
 ### Example metric
 Query the rate of transmitted network traffic


### PR DESCRIPTION
This PR addresses an issue raised in #570 which we've also encountered - we'd like to be able to identify the network adapters based on their "Windows" name rather than the hardware NIC name. 

We often see Hyper-V switching which NIC is first/second when provisioning a new VM, so by adding this we're able to identify them based on name.

This is the first time I've ever written any go, so I've borrowed concepts from the `cpu` collector executing a wmi query. Happy to make whatever changes necessary to make this able to be merged 👍 