### PR TITLE
Correct layout of SystemInfo structs

### DIFF
--- a/headers/sysinfoapi/sysinfoapi.go
+++ b/headers/sysinfoapi/sysinfoapi.go
@@ -36,8 +36,8 @@ type MemoryStatus struct {
 // wProcessorArchitecture is a wrapper for the union found in LP_SYSTEM_INFO
 // https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info
 type wProcessorArchitecture struct {
-	WReserved              uint16
 	WProcessorArchitecture uint16
+	WReserved              uint16
 }
 
 // ProcessorArchitecture is an idiomatic wrapper for wProcessorArchitecture
@@ -60,7 +60,7 @@ type lpSystemInfo struct {
 	DwPageSize                  uint32
 	LpMinimumApplicationAddress uintptr
 	LpMaximumApplicationAddress uintptr
-	DwActiveProcessorMask       uint32
+	DwActiveProcessorMask       uint
 	DwNumberOfProcessors        uint32
 	DwProcessorType             uint32
 	DwAllocationGranularity     uint32
@@ -74,7 +74,7 @@ type SystemInfo struct {
 	PageSize                  uint32
 	MinimumApplicationAddress uintptr
 	MaximumApplicationAddress uintptr
-	ActiveProcessorMask       uint32
+	ActiveProcessorMask       uint
 	NumberOfProcessors        uint32
 	ProcessorType             uint32
 	AllocationGranularity     uint32


### PR DESCRIPTION
This corrects the layout of the SystemInfo structs which previously had a field that was too small, causing the struct to return the wrong values after being modified by the WinAPI function. 

Signed-off-by: Ben Ridley <benridley29@gmail.com>