### PR TITLE
Fixes #776

### DIFF
--- a/docs/collector.container.md
+++ b/docs/collector.container.md
@@ -1,10 +1,11 @@
 # container collector
 
-The container collector exposes metrics about containers running on system
+The container collector exposes metrics about containers running on a Hyper-V system
 
 |||
 -|-
 Metric name prefix  | `container`
+Data source         | [hcsshim](https://github.com/Microsoft/hcsshim)
 Enabled by default? | No
 
 ## Flags


### PR DESCRIPTION
Added a 'data source' field to specify hcsshim of Host Compute Services in Hyper-V is used.
Fixes #776 