### PR TITLE
Export CurrentBandwidth as bytes

### DIFF
--- a/collector/net.go
+++ b/collector/net.go
@@ -118,7 +118,7 @@ func NewNetworkCollector() (Collector, error) {
 			nil,
 		),
 		CurrentBandwidth: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "current_bandwidth"),
+			prometheus.BuildFQName(Namespace, subsystem, "current_bandwidth_bytes"),
 			"(Network.CurrentBandwidth)",
 			[]string{"nic"},
 			nil,
@@ -251,7 +251,7 @@ func (c *NetworkCollector) collect(ctx *ScrapeContext, ch chan<- prometheus.Metr
 		ch <- prometheus.MustNewConstMetric(
 			c.CurrentBandwidth,
 			prometheus.GaugeValue,
-			nic.CurrentBandwidth,
+			nic.CurrentBandwidth/8,
 			name,
 		)
 	}

--- a/docs/collector.net.md
+++ b/docs/collector.net.md
@@ -34,7 +34,7 @@ Name | Description | Type | Labels
 `windows_net_packets_received_unknown_total` | Total packets received by interface that were discarded because of an unknown or unsupported protocol | counter | `nic`
 `windows_net_packets_total` | Total packets received and transmitted by interface | counter | `nic`
 `windows_net_packets_sent_total` | Total packets transmitted by interface | counter | `nic`
-`windows_net_current_bandwidth` | Estimate of the interface's current bandwidth in bits per second (bps) | gauge | `nic`
+`windows_net_current_bandwidth_bytes` | Estimate of the interface's current bandwidth in bytes per second | gauge | `nic`
 
 ### Example metric
 Query the rate of transmitted network traffic
@@ -45,14 +45,14 @@ rate(windows_net_bytes_sent_total{instance="localhost"}[2m])
 ## Useful queries
 Get total utilisation of network interface as a percentage
 ```
-rate(windows_net_bytes_total{instance="localhost", nic="Microsoft_Hyper_V_Network_Adapter__1"}[2m]) * 8 / windows_net_current_bandwidth{instance="locahost", nic="Microsoft_Hyper_V_Network_Adapter__1"} * 100
+rate(windows_net_bytes_total{instance="localhost", nic="Microsoft_Hyper_V_Network_Adapter__1"}[2m]) / windows_net_current_bandwidth_bytes{instance="localhost", nic="Microsoft_Hyper_V_Network_Adapter__1"} * 100
 ```
 
 ## Alerting examples
 **prometheus.rules**
 ```yaml
 - alert: NetInterfaceUsage
-  expr: rate(windows_net_bytes_total[2m]) * 8 / windows_net_current_bandwidth * 100 > 95
+  expr: rate(windows_net_bytes_total[2m]) / windows_net_current_bandwidth_bytes * 100 > 95
   for: 10m
   labels:
     severity: high

--- a/tools/e2e-output.txt
+++ b/tools/e2e-output.txt
@@ -153,8 +153,8 @@ windows_exporter_collector_timeout{collector="textfile"} 0
 # TYPE windows_net_bytes_sent_total counter
 # HELP windows_net_bytes_total (Network.BytesTotalPerSec)
 # TYPE windows_net_bytes_total counter
-# HELP windows_net_current_bandwidth (Network.CurrentBandwidth)
-# TYPE windows_net_current_bandwidth gauge
+# HELP windows_net_current_bandwidth_bytes (Network.CurrentBandwidth)
+# TYPE windows_net_current_bandwidth_bytes gauge
 # HELP windows_net_packets_outbound_discarded_total (Network.PacketsOutboundDiscarded)
 # TYPE windows_net_packets_outbound_discarded_total counter
 # HELP windows_net_packets_outbound_errors_total (Network.PacketsOutboundErrors)


### PR DESCRIPTION
From https://prometheus.io/docs/practices/naming/:
To avoid confusion combining different metrics, always use bytes, even
where bits appear more common.

Fixes #800