### PR TITLE
Service Api collection close servicehandler to avoid memory leak

### DIFF
--- a/collector/service.go
+++ b/collector/service.go
@@ -246,18 +246,17 @@ func (c *serviceCollector) collectAPI(ch chan<- prometheus.Metric) error {
 		if err != nil {
 			continue
 		}
+		defer serviceHandle.Close()
 
 		// Get Service Configuration
 		serviceConfig, err := serviceHandle.Config()
 		if err != nil {
-			_ = serviceHandle.Close()
 			continue
 		}
 
 		// Get Service Current Status
 		serviceStatus, err := serviceHandle.Query()
 		if err != nil {
-			_ = serviceHandle.Close()
 			continue
 		}
 


### PR DESCRIPTION
- Correct closing of service handler that was causing a memory increase over time since there were handlers kept on the heap.

@breed808, this is a fix for the feature we added on this PR https://github.com/prometheus-community/windows_exporter/pull/812.