### PR TITLE
use IsWindowsService to detect if running as service

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main
@@ -324,13 +325,13 @@ func main() {
 
 	initWbem()
 
-	isInteractive, err := svc.IsAnInteractiveSession()
+	isService, err := svc.IsWindowsService()
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	stopCh := make(chan bool)
-	if !isInteractive {
+	if isService {
 		go func() {
 			err = svc.Run(serviceName, &windowsExporterService{stopCh: stopCh})
 			if err != nil {


### PR DESCRIPTION
Fixes:  #856

When working on https://github.com/prometheus-community/windows_exporter/pull/581#issuecomment-962050709 I got the error `time="2021-11-05T00:18:54Z" level=error msg="Failed to start service: The service process could not connect to the service controller." source="exporter.go:337"`

It was not running as a service so it should not fall into this code path.  I found https://pkg.go.dev/golang.org/x/sys/windows/svc#IsAnInteractiveSession was depreciated so made the switch.