### PR TITLE
some metric name typed error

### DIFF
--- a/docs/collector.net.md
+++ b/docs/collector.net.md
@@ -30,11 +30,11 @@ Name | Description | Type | Labels
 `windows_net_packets_outbound_errors_total` | Total packets that could not be transmitted due to errors | counter | `nic`
 `windows_net_packets_received_discarded_total` | Total inbound packets that were chosen to be discarded even though no errors had been detected to prevent delivery | counter | `nic`
 `windows_net_packets_received_errors_total` | Total packets that could not be received due to errors  | counter | `nic`
-`windows_net_packets_received_total_total` | Total packets received by interface | counter | `nic`
+`windows_net_packets_received_total` | Total packets received by interface | counter | `nic`
 `windows_net_packets_received_unknown_total` | Total packets received by interface that were discarded because of an unknown or unsupported protocol | counter | `nic`
 `windows_net_packets_total` | Total packets received and transmitted by interface | counter | `nic`
 `windows_net_packets_sent_total` | Total packets transmitted by interface | counter | `nic`
-`windows_net_current_bandwidth_bytes` | Estimate of the interface's current bandwidth in bytes per second | gauge | `nic`
+`windows_net_current_bandwidth` | Estimate of the interface's current bandwidth in bytes per second | gauge | `nic`
 
 ### Example metric
 Query the rate of transmitted network traffic
@@ -45,14 +45,14 @@ rate(windows_net_bytes_sent_total{instance="localhost"}[2m])
 ## Useful queries
 Get total utilisation of network interface as a percentage
 ```
-rate(windows_net_bytes_total{instance="localhost", nic="Microsoft_Hyper_V_Network_Adapter__1"}[2m]) / windows_net_current_bandwidth_bytes{instance="localhost", nic="Microsoft_Hyper_V_Network_Adapter__1"} * 100
+rate(windows_net_bytes_total{instance="localhost", nic="Microsoft_Hyper_V_Network_Adapter__1"}[2m]) / windows_net_current_bandwidth{instance="localhost", nic="Microsoft_Hyper_V_Network_Adapter__1"} * 100
 ```
 
 ## Alerting examples
 **prometheus.rules**
 ```yaml
 - alert: NetInterfaceUsage
-  expr: rate(windows_net_bytes_total[2m]) / windows_net_current_bandwidth_bytes * 100 > 95
+  expr: rate(windows_net_bytes_total[2m]) / windows_net_current_bandwidth * 100 > 95
   for: 10m
   labels:
     severity: high


### PR DESCRIPTION
`windows_net_current_bandwidth_bytes `not exists, but `windows_net_current_bandwidth` .
`windows_net_packets_received_total_total`  not exists, but `windows_net_packets_received_total`.