### PR TITLE
Add Dependabot dependency tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Bot will submit PRs when new dependency versions are detected,
preventing dependencies from becoming out-of-date.