### PR TITLE
Fix default path for textfile collector

### DIFF
--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -338,5 +338,5 @@ func checkBOM(encoding utfbom.Encoding) error {
 
 func getDefaultPath() string {
 	execPath, _ := os.Executable()
-	return filepath.Join(execPath, "textfile_inputs")
+	return filepath.Join(filepath.Dir(execPath), "textfile_inputs")
 }


### PR DESCRIPTION
This PR fixes the default path for textfile collector. The previous implementation returned the full exe path, producing lots of error message:

> "Error reading textfile collector directory "C:
Program Files\\windows_exporter\\windows_exporter.exe
textfile_inputs": open C:\Program Files\windows_exporter\windows_exporter.exe\textfile_inputs: The system cannot find the path specified." 