### PR TITLE
Move textfile mtime metric from loop

### DIFF
--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -313,9 +313,10 @@ fileLoop:
 	} else {
 		for _, mf := range metricFamilies {
 			convertMetricFamily(mf, ch)
-			c.exportMTimes(mtimes, ch)
 		}
 	}
+
+	c.exportMTimes(mtimes, ch)
 
 	// Export if there were errors.
 	ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
Loop was erroneously creating duplicate `windows_textfile_mtime_seconds`
metrics, causing the exporter to return a HTTP 500 error and no metrics
from any collector.

Resolves #899