### PR TITLE
Fix counter metrics should have "_total" suffix issue

### DIFF
--- a/collector/tcp.go
+++ b/collector/tcp.go
@@ -31,13 +31,13 @@ func NewTCPCollector() (Collector, error) {
 
 	return &TCPCollector{
 		ConnectionFailures: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "connection_failures"),
+			prometheus.BuildFQName(Namespace, subsystem, "connection_failures_total"),
 			"(TCP.ConnectionFailures)",
 			[]string{"af"},
 			nil,
 		),
 		ConnectionsActive: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "connections_active"),
+			prometheus.BuildFQName(Namespace, subsystem, "connections_active_total"),
 			"(TCP.ConnectionsActive)",
 			[]string{"af"},
 			nil,
@@ -49,13 +49,13 @@ func NewTCPCollector() (Collector, error) {
 			nil,
 		),
 		ConnectionsPassive: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "connections_passive"),
+			prometheus.BuildFQName(Namespace, subsystem, "connections_passive_total"),
 			"(TCP.ConnectionsPassive)",
 			[]string{"af"},
 			nil,
 		),
 		ConnectionsReset: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "connections_reset"),
+			prometheus.BuildFQName(Namespace, subsystem, "connections_reset_total"),
 			"(TCP.ConnectionsReset)",
 			[]string{"af"},
 			nil,

--- a/docs/collector.tcp.md
+++ b/docs/collector.tcp.md
@@ -17,11 +17,11 @@ None
 
 Name | Description | Type | Labels
 -----|-------------|------|-------
-`windows_tcp_connection_failures` | Number of times TCP connections have made a direct transition to the CLOSED state from the SYN-SENT state or the SYN-RCVD state, plus the number of times TCP connections have made a direct transition from the SYN-RCVD state to the LISTEN state | counter | af
-`windows_tcp_connections_active` |  Number of times TCP connections have made a direct transition from the CLOSED state to the SYN-SENT state.| counter | af
+`windows_tcp_connection_failures_total` | Number of times TCP connections have made a direct transition to the CLOSED state from the SYN-SENT state or the SYN-RCVD state, plus the number of times TCP connections have made a direct transition from the SYN-RCVD state to the LISTEN state | counter | af
+`windows_tcp_connections_active_total` |  Number of times TCP connections have made a direct transition from the CLOSED state to the SYN-SENT state.| counter | af
 `windows_tcp_connections_established` | Number of TCP connections for which the current state is either ESTABLISHED or CLOSE-WAIT. | gauge | af
-`windows_tcp_connections_passive` | Number of times TCP connections have made a direct transition from the LISTEN state to the SYN-RCVD state. | counter | af
-`windows_tcp_connections_reset` | Number of times TCP connections have made a direct transition from the LISTEN state to the SYN-RCVD state. | counter | af
+`windows_tcp_connections_passive_total` | Number of times TCP connections have made a direct transition from the LISTEN state to the SYN-RCVD state. | counter | af
+`windows_tcp_connections_reset_total` | Number of times TCP connections have made a direct transition from the LISTEN state to the SYN-RCVD state. | counter | af
 `windows_tcp_segments_total` | Total segments sent or received using the TCP protocol | counter | af
 `windows_tcp_segments_received_total` | Total segments received, including those received in error. This count includes segments received on currently established connections | counter | af
 `windows_tcp_segments_retransmitted_total` | Total segments retransmitted. That is, segments transmitted that contain one or more previously transmitted bytes | counter | af


### PR DESCRIPTION
Hi @breed808 @carlpett,

This fix all `counter metrics should have "_total" suffix` issues reported by promtool. See #659.

NOTE: This must be noted as breaking changes in the CHANGELOG for the next version.