### PR TITLE
README.md: Replace the AppVeyor badge with the GH Actions one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # windows_exporter
 
-[![Build status](https://ci.appveyor.com/api/projects/status/xoym3fftr7giasiw/branch/master?svg=true)](https://ci.appveyor.com/project/prometheus-community/windows-exporter)
+![Build Status](https://github.com/prometheus-community/windows_exporter/workflows/windows_exporter%20CI/CD/badge.svg)
 
 A Prometheus exporter for Windows machines.
 


### PR DESCRIPTION
Hi @carlpett @breed808,

This replace the old AppVeyor badge by the new one for GH Actions.