### PR TITLE
Port should default to 9182 if not defined

### DIFF
--- a/installer/windows_exporter.wxs
+++ b/installer/windows_exporter.wxs
@@ -25,7 +25,7 @@
     <Property Id="LISTEN_ADDR" Secure="yes" />
     <Property Id="LISTEN_PORT" Secure="yes" />
     <SetProperty Id="ListenFlagBoth" After="InstallFiles" Sequence="execute" Value="--telemetry.addr [LISTEN_ADDR]:[LISTEN_PORT]">LISTEN_ADDR AND LISTEN_PORT</SetProperty>
-    <SetProperty Id="ListenFlagAddr" After="InstallFiles" Sequence="execute" Value="--telemetry.addr [LISTEN_ADDR]:">LISTEN_ADDR AND (NOT LISTEN_PORT)</SetProperty>
+    <SetProperty Id="ListenFlagAddr" After="InstallFiles" Sequence="execute" Value="--telemetry.addr [LISTEN_ADDR]:9182">LISTEN_ADDR AND (NOT LISTEN_PORT)</SetProperty>
     <SetProperty Id="ListenFlagPort" After="InstallFiles" Sequence="execute" Value="--telemetry.addr 0.0.0.0:[LISTEN_PORT]">LISTEN_PORT AND (NOT LISTEN_ADDR)</SetProperty>
 
     <Property Id="METRICS_PATH" Secure="yes"/>


### PR DESCRIPTION
Resolves #911 which was introduced by 45e9357a.

This is due to the exporter only using the default port if no LISTEN_ADDR
**and** no LISTEN_PORT is defined.