### PR TITLE
Don't upgrade dependencies when installing tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Install e2e deps
         run: |
-          go get -u github.com/prometheus/promu@v0.11.1
-          go get -u github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.2.0
+          go get github.com/prometheus/promu@v0.11.1
+          go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.2.0
           # GOPATH\bin dir must be appended to PATH else the `promu` command won't be found
           echo "$(go env GOPATH)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
@@ -90,8 +90,8 @@ jobs:
 
       - name: Install Build deps
         run: |
-          go get -u github.com/prometheus/promu@v0.11.1
-          go get -u github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.2.0
+          go get github.com/prometheus/promu@v0.11.1
+          go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.2.0
           # GOPATH\bin dir must be added to PATH else the `promu` and `goversioninfo` commands won't be found
           echo "$(go env GOPATH)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 


### PR DESCRIPTION
Dependency upgrade has resulted in [github.com/prometheus/client_golang](https://github.com/prometheus/client_golang) being upgraded from v1.11.0 to v1.12.0 prior to end-to-end test.
This new release introduces new `go_*` metrics, causing the test to fail on the unexpected output.

This fixes CI failures with recent PRs (#885 and #921).
I'll add the expected output in another PR once Dependabot picks up the new `client_golang` release.