### PR TITLE
feat: add storage metrics for container collector

### DIFF
--- a/collector/container.go
+++ b/collector/container.go
@@ -37,6 +37,12 @@ type ContainerMetricsCollector struct {
 	PacketsSent            *prometheus.Desc
 	DroppedPacketsIncoming *prometheus.Desc
 	DroppedPacketsOutgoing *prometheus.Desc
+
+	// Storage
+	ReadCountNormalized  *prometheus.Desc
+	ReadSizeBytes        *prometheus.Desc
+	WriteCountNormalized *prometheus.Desc
+	WriteSizeBytes       *prometheus.Desc
 }
 
 // NewContainerMetricsCollector constructs a new ContainerMetricsCollector
@@ -125,6 +131,30 @@ func NewContainerMetricsCollector() (Collector, error) {
 			prometheus.BuildFQName(Namespace, subsystem, "network_transmit_packets_dropped_total"),
 			"Dropped Outgoing Packets on Interface",
 			[]string{"container_id", "interface"},
+			nil,
+		),
+		ReadCountNormalized: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "storage_read_count_normalized"),
+			"Read Count Normalized",
+			[]string{"container_id"},
+			nil,
+		),
+		ReadSizeBytes: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "storage_read_size_bytes"),
+			"Read Size Bytes",
+			[]string{"container_id"},
+			nil,
+		),
+		WriteCountNormalized: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "storage_write_count_normalized"),
+			"Write Count Normalized",
+			[]string{"container_id"},
+			nil,
+		),
+		WriteSizeBytes: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "storage_write_size_bytes"),
+			"Write Size Bytes",
+			[]string{"container_id"},
 			nil,
 		),
 	}, nil
@@ -274,6 +304,31 @@ func (c *ContainerMetricsCollector) collect(ch chan<- prometheus.Metric) (*prome
 			)
 			break
 		}
+
+		ch <- prometheus.MustNewConstMetric(
+			c.ReadCountNormalized,
+			prometheus.CounterValue,
+			float64(cstats.Storage.ReadCountNormalized),
+			containerIdWithPrefix,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.ReadSizeBytes,
+			prometheus.CounterValue,
+			float64(cstats.Storage.ReadCountNormalized),
+			containerIdWithPrefix,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.WriteCountNormalized,
+			prometheus.CounterValue,
+			float64(cstats.Storage.WriteCountNormalized),
+			containerIdWithPrefix,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.WriteSizeBytes,
+			prometheus.CounterValue,
+			float64(cstats.Storage.WriteSizeBytes),
+			containerIdWithPrefix,
+		)
 	}
 
 	return nil, nil

--- a/docs/collector.container.md
+++ b/docs/collector.container.md
@@ -30,6 +30,10 @@ Name | Description | Type | Labels
 `windows_container_network_transmit_bytes_total` | Bytes Sent on Interface | counter | `container_id`, `interface`
 `windows_container_network_transmit_packets_total` | Packets Sent on Interface | counter | `container_id`, `interface`
 `windows_container_network_transmit_packets_dropped_total` | Dropped Outgoing Packets on Interface | counter | `container_id`, `interface`
+**`windows_container_storage_read_count_normalized`** | Read Count Normalized | counter | `container_id`
+`windows_container_storage_read_size_bytes` | Read Size Bytes | counter | `container_id`
+`windows_container_storage_write_count_normalized` | Write Count Normalized | counter | `container_id`
+`windows_container_storage_write_size_bytes` | Write Size Bytes | counter | `container_id`
 
 ### Example metric
 _windows_container_network_receive_bytes_total{container_id="docker://1bd30e8b8ac28cbd76a9b697b4d7bb9d760267b0733d1bc55c60024e98d1e43e",interface="822179E7-002C-4280-ABBA-28BCFE401826"} 9.3305343e+07_


### PR DESCRIPTION
Add storage metrics for windows container from container's storagestats of hcshim.
Example metrics:
```
# HELP windows_container_storage_read_count_normalized Read Count Normalized
# TYPE windows_container_storage_read_count_normalized counter
windows_container_storage_read_count_normalized{container_id="docker://2b5068cb7949ed654dc578479c876b619fbe4310d298afd4c2b2019e112a84f1"} 676
windows_container_storage_read_count_normalized{container_id="docker://73bb83c4396862e9a2e01cf745333bd34d1c304bb0908b913ef643cac7063be3"} 955
windows_container_storage_read_count_normalized{container_id="docker://780647ddf58765695fc54e5ab5b8fa2adcf021eb21cdc81a65af9fee8508cfa5"} 4246
windows_container_storage_read_count_normalized{container_id="docker://7e1a0e3eb68e3b0bb829ef1cbdfd323d02a2dd58c359fbe50cf48801feac39f7"} 3864
windows_container_storage_read_count_normalized{container_id="docker://c987a6b59dd0755a20809057f0197cbf2afc8c39cee89c7ad14753b98ea40071"} 991
windows_container_storage_read_count_normalized{container_id="docker://db86fa8b8808de961a724699df886e46fbd7e70c045ac179bf83bc3dbd9a20bc"} 4488
# HELP windows_container_storage_read_size_bytes Read Size Bytes
# TYPE windows_container_storage_read_size_bytes counter
windows_container_storage_read_size_bytes{container_id="docker://2b5068cb7949ed654dc578479c876b619fbe4310d298afd4c2b2019e112a84f1"} 676
windows_container_storage_read_size_bytes{container_id="docker://73bb83c4396862e9a2e01cf745333bd34d1c304bb0908b913ef643cac7063be3"} 955
windows_container_storage_read_size_bytes{container_id="docker://780647ddf58765695fc54e5ab5b8fa2adcf021eb21cdc81a65af9fee8508cfa5"} 4246
windows_container_storage_read_size_bytes{container_id="docker://7e1a0e3eb68e3b0bb829ef1cbdfd323d02a2dd58c359fbe50cf48801feac39f7"} 3864
windows_container_storage_read_size_bytes{container_id="docker://c987a6b59dd0755a20809057f0197cbf2afc8c39cee89c7ad14753b98ea40071"} 991
windows_container_storage_read_size_bytes{container_id="docker://db86fa8b8808de961a724699df886e46fbd7e70c045ac179bf83bc3dbd9a20bc"} 4488
# HELP windows_container_storage_write_count_normalized Write Count Normalized
# TYPE windows_container_storage_write_count_normalized counter
windows_container_storage_write_count_normalized{container_id="docker://2b5068cb7949ed654dc578479c876b619fbe4310d298afd4c2b2019e112a84f1"} 484
windows_container_storage_write_count_normalized{container_id="docker://73bb83c4396862e9a2e01cf745333bd34d1c304bb0908b913ef643cac7063be3"} 490
windows_container_storage_write_count_normalized{container_id="docker://780647ddf58765695fc54e5ab5b8fa2adcf021eb21cdc81a65af9fee8508cfa5"} 1873
windows_container_storage_write_count_normalized{container_id="docker://7e1a0e3eb68e3b0bb829ef1cbdfd323d02a2dd58c359fbe50cf48801feac39f7"} 17739
windows_container_storage_write_count_normalized{container_id="docker://c987a6b59dd0755a20809057f0197cbf2afc8c39cee89c7ad14753b98ea40071"} 462
windows_container_storage_write_count_normalized{container_id="docker://db86fa8b8808de961a724699df886e46fbd7e70c045ac179bf83bc3dbd9a20bc"} 1846
# HELP windows_container_storage_write_size_bytes Write Size Bytes
# TYPE windows_container_storage_write_size_bytes counter
windows_container_storage_write_size_bytes{container_id="docker://2b5068cb7949ed654dc578479c876b619fbe4310d298afd4c2b2019e112a84f1"} 3.551232e+06
windows_container_storage_write_size_bytes{container_id="docker://73bb83c4396862e9a2e01cf745333bd34d1c304bb0908b913ef643cac7063be3"} 3.588096e+06
windows_container_storage_write_size_bytes{container_id="docker://780647ddf58765695fc54e5ab5b8fa2adcf021eb21cdc81a65af9fee8508cfa5"} 1.370112e+07
windows_container_storage_write_size_bytes{container_id="docker://7e1a0e3eb68e3b0bb829ef1cbdfd323d02a2dd58c359fbe50cf48801feac39f7"} 1.08847616e+08
windows_container_storage_write_size_bytes{container_id="docker://c987a6b59dd0755a20809057f0197cbf2afc8c39cee89c7ad14753b98ea40071"} 3.371008e+06
windows_container_storage_write_size_bytes{container_id="docker://db86fa8b8808de961a724699df886e46fbd7e70c045ac179bf83bc3dbd9a20bc"} 1.3541376e+07
```