### PR TITLE
feat: add storage metrics for container collector

### DIFF
--- a/collector/container.go
+++ b/collector/container.go
@@ -37,6 +37,12 @@ type ContainerMetricsCollector struct {
 	PacketsSent            *prometheus.Desc
 	DroppedPacketsIncoming *prometheus.Desc
 	DroppedPacketsOutgoing *prometheus.Desc
+
+	// Storage
+	ReadCountNormalized  *prometheus.Desc
+	ReadSizeBytes        *prometheus.Desc
+	WriteCountNormalized *prometheus.Desc
+	WriteSizeBytes       *prometheus.Desc
 }
 
 // NewContainerMetricsCollector constructs a new ContainerMetricsCollector
@@ -125,6 +131,30 @@ func NewContainerMetricsCollector() (Collector, error) {
 			prometheus.BuildFQName(Namespace, subsystem, "network_transmit_packets_dropped_total"),
 			"Dropped Outgoing Packets on Interface",
 			[]string{"container_id", "interface"},
+			nil,
+		),
+		ReadCountNormalized: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "storage_read_count_normalized_total"),
+			"Read Count Normalized",
+			[]string{"container_id"},
+			nil,
+		),
+		ReadSizeBytes: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "storage_read_size_bytes_total"),
+			"Read Size Bytes",
+			[]string{"container_id"},
+			nil,
+		),
+		WriteCountNormalized: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "storage_write_count_normalized_total"),
+			"Write Count Normalized",
+			[]string{"container_id"},
+			nil,
+		),
+		WriteSizeBytes: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "storage_write_size_bytes_total"),
+			"Write Size Bytes",
+			[]string{"container_id"},
 			nil,
 		),
 	}, nil
@@ -274,6 +304,31 @@ func (c *ContainerMetricsCollector) collect(ch chan<- prometheus.Metric) (*prome
 			)
 			break
 		}
+
+		ch <- prometheus.MustNewConstMetric(
+			c.ReadCountNormalized,
+			prometheus.CounterValue,
+			float64(cstats.Storage.ReadCountNormalized),
+			containerIdWithPrefix,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.ReadSizeBytes,
+			prometheus.CounterValue,
+			float64(cstats.Storage.ReadSizeBytes),
+			containerIdWithPrefix,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.WriteCountNormalized,
+			prometheus.CounterValue,
+			float64(cstats.Storage.WriteCountNormalized),
+			containerIdWithPrefix,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.WriteSizeBytes,
+			prometheus.CounterValue,
+			float64(cstats.Storage.WriteSizeBytes),
+			containerIdWithPrefix,
+		)
 	}
 
 	return nil, nil

--- a/docs/collector.container.md
+++ b/docs/collector.container.md
@@ -30,6 +30,10 @@ Name | Description | Type | Labels
 `windows_container_network_transmit_bytes_total` | Bytes Sent on Interface | counter | `container_id`, `interface`
 `windows_container_network_transmit_packets_total` | Packets Sent on Interface | counter | `container_id`, `interface`
 `windows_container_network_transmit_packets_dropped_total` | Dropped Outgoing Packets on Interface | counter | `container_id`, `interface`
+`windows_container_storage_read_count_normalized_total"` | Read Count Normalized | counter | `container_id`
+`windows_container_storage_read_size_bytes_total"` | Read Size Bytes | counter | `container_id`
+`windows_container_storage_write_count_normalized_total"` | Write Count Normalized | counter | `container_id`
+`windows_container_storage_write_size_bytes_total"` | Write Size Bytes | counter | `container_id`
 
 ### Example metric
 _windows_container_network_receive_bytes_total{container_id="docker://1bd30e8b8ac28cbd76a9b697b4d7bb9d760267b0733d1bc55c60024e98d1e43e",interface="822179E7-002C-4280-ABBA-28BCFE401826"} 9.3305343e+07_

--- a/docs/collector.container.md
+++ b/docs/collector.container.md
@@ -41,7 +41,11 @@ _windows_container_network_receive_bytes_total{container_id="docker://1bd30e8b8a
 This metric means that total _9.3305343e+07_ bytes received on interface _822179E7-002C-4280-ABBA-28BCFE401826_ for container _docker://1bd30e8b8ac28cbd76a9b697b4d7bb9d760267b0733d1bc55c60024e98d1e43e_
 
 ## Useful queries
-_This collector does not yet have any useful queries added, we would appreciate your help adding them!_
-
+Attach labels namespace/pod/container fow windows container metrics.
+```
+# kube_pod_container_info(a metric of kube-state-metrics) has labels namespace/pod/container/container_id for a container, while windows container metrics only have container_id.
+# Attaching labels namespace/pod/container for windows container metrics, is useful to query for windows pods.
+windows_container_network_receive_bytes_total * on(container_id) group_left(namespace, pod, container) kube_pod_container_info{container_id!=""}
+```
 ## Alerting examples
 _This collector does not yet have alerting examples, we would appreciate your help adding them!_


### PR DESCRIPTION
Add storage metrics for windows container from container's storagestats of hcsshim.
reference: [windows container's Statistics struct](<https://github.com/microsoft/hcsshim/blob/master/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/schema1/schema1.go#L188>)

Example metrics:
```
# TYPE windows_container_storage_read_count_normalized_total counter
windows_container_storage_read_count_normalized_total{container_id="docker://0a1d78f90178bbfd80aa49572a60868c2421899121c60394938ca2e830860a7c"} 5088
windows_container_storage_read_count_normalized_total{container_id="docker://1a4e8d1fdbe62dfa8638cf90704f72d9a199e3afccfc1b36d364a96fb72577ad"} 1213
windows_container_storage_read_count_normalized_total{container_id="docker://38c1eb0b679a9dcfe2ab259617b653740241caaf8b6018770b2977dcb8762ec3"} 897
windows_container_storage_read_count_normalized_total{container_id="docker://be0a3b99bbd220a0fe30db27cbb11899485815d776d687e3e68afcb38890c6ee"} 942
windows_container_storage_read_count_normalized_total{container_id="docker://cd83f591f99d6530424632ea4a5cbbaf44f1e51eb8d4683d020480ab21be451a"} 5038
windows_container_storage_read_count_normalized_total{container_id="docker://eccf6290641c9e2bbe9d71ad8d1210498584f70a520ebe78f6812708bf406018"} 1109
# HELP windows_container_storage_read_size_bytes_total Read Size Bytes
# TYPE windows_container_storage_read_size_bytes_total counter
windows_container_storage_read_size_bytes_total{container_id="docker://0a1d78f90178bbfd80aa49572a60868c2421899121c60394938ca2e830860a7c"} 3.8066176e+07
windows_container_storage_read_size_bytes_total{container_id="docker://1a4e8d1fdbe62dfa8638cf90704f72d9a199e3afccfc1b36d364a96fb72577ad"} 9.13408e+06
windows_container_storage_read_size_bytes_total{container_id="docker://38c1eb0b679a9dcfe2ab259617b653740241caaf8b6018770b2977dcb8762ec3"} 6.810112e+06
windows_container_storage_read_size_bytes_total{container_id="docker://be0a3b99bbd220a0fe30db27cbb11899485815d776d687e3e68afcb38890c6ee"} 7.121408e+06
windows_container_storage_read_size_bytes_total{container_id="docker://cd83f591f99d6530424632ea4a5cbbaf44f1e51eb8d4683d020480ab21be451a"} 3.7699584e+07
windows_container_storage_read_size_bytes_total{container_id="docker://eccf6290641c9e2bbe9d71ad8d1210498584f70a520ebe78f6812708bf406018"} 8.397312e+06
# HELP windows_container_storage_write_count_normalized_total Write Count Normalized
# TYPE windows_container_storage_write_count_normalized_total counter
windows_container_storage_write_count_normalized_total{container_id="docker://0a1d78f90178bbfd80aa49572a60868c2421899121c60394938ca2e830860a7c"} 37673
windows_container_storage_write_count_normalized_total{container_id="docker://1a4e8d1fdbe62dfa8638cf90704f72d9a199e3afccfc1b36d364a96fb72577ad"} 841
windows_container_storage_write_count_normalized_total{container_id="docker://38c1eb0b679a9dcfe2ab259617b653740241caaf8b6018770b2977dcb8762ec3"} 837
windows_container_storage_write_count_normalized_total{container_id="docker://be0a3b99bbd220a0fe30db27cbb11899485815d776d687e3e68afcb38890c6ee"} 863
windows_container_storage_write_count_normalized_total{container_id="docker://cd83f591f99d6530424632ea4a5cbbaf44f1e51eb8d4683d020480ab21be451a"} 37617
windows_container_storage_write_count_normalized_total{container_id="docker://eccf6290641c9e2bbe9d71ad8d1210498584f70a520ebe78f6812708bf406018"} 881
# HELP windows_container_storage_write_size_bytes_total Write Size Bytes
# TYPE windows_container_storage_write_size_bytes_total counter
windows_container_storage_write_size_bytes_total{container_id="docker://0a1d78f90178bbfd80aa49572a60868c2421899121c60394938ca2e830860a7c"} 2.26397696e+08
windows_container_storage_write_size_bytes_total{container_id="docker://1a4e8d1fdbe62dfa8638cf90704f72d9a199e3afccfc1b36d364a96fb72577ad"} 6.148096e+06
windows_container_storage_write_size_bytes_total{container_id="docker://38c1eb0b679a9dcfe2ab259617b653740241caaf8b6018770b2977dcb8762ec3"} 6.090752e+06
windows_container_storage_write_size_bytes_total{container_id="docker://be0a3b99bbd220a0fe30db27cbb11899485815d776d687e3e68afcb38890c6ee"} 6.352896e+06
windows_container_storage_write_size_bytes_total{container_id="docker://cd83f591f99d6530424632ea4a5cbbaf44f1e51eb8d4683d020480ab21be451a"} 2.26188288e+08
windows_container_storage_write_size_bytes_total{container_id="docker://eccf6290641c9e2bbe9d71ad8d1210498584f70a520ebe78f6812708bf406018"} 6.377472e+0
```