### PR TITLE
Fix formatting for kubernetes documentation

### DIFF
--- a/kubernetes/kubernetes.md
+++ b/kubernetes/kubernetes.md
@@ -23,6 +23,7 @@ If you don't have a version of `make` on your Windows machine, You can use WSL t
 On Windows:
 ```
 Item -ItemType SymbolicLink -Path "c:\docker" -Target "C:\Program Files\Docker\Docker\resources\bin\docker.exe"
+```
 
 In WSL:
 ```


### PR DESCRIPTION
The docs don't render properly in Markdown due to missing closing code block.