### PR TITLE
Use `powershell` image for firewall init container

### DIFF
--- a/kubernetes/kubernetes.md
+++ b/kubernetes/kubernetes.md
@@ -57,7 +57,7 @@ spec:
     spec:
       initContainers:
         - name: configure-firewall
-          image: mcr.microsoft.com/windows/nanoserver:1809
+          image: mcr.microsoft.com/windows/powershell:lts-nanoserver-1809
           command: ["powershell"]
           args: ["New-NetFirewallRule", "-DisplayName", "'windows-exporter'", "-Direction", "inbound", "-Profile", "Any", "-Action", "Allow", "-LocalPort", "9182", "-Protocol", "TCP"]
 ```


### PR DESCRIPTION
Previous `nanoserver` image did not have Powershell installed, causing
the init container to fail.

Resolves #961.