### PR TITLE
Resolve recent CI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,8 @@ jobs:
       - name: Install Build deps
         run: |
           dotnet tool install --global GitVersion.Tool --version 5.*
-          go get "github.com/prometheus/promu@$($Env:PROMU_VER)"
-          go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.2.0
+          go install "github.com/prometheus/promu@$($Env:PROMU_VER)"
+          go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
           # GOPATH\bin dir must be added to PATH else the `promu` and `goversioninfo` commands won't be found
           echo "$(go env GOPATH)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,9 @@ jobs:
           go-version: '^1.17.5'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.43
+          version: v1.45.2
           args: "--timeout=5m"
 
       # golangci-lint action doesn't always provide helpful output, so re-run without the action for


### PR DESCRIPTION
CI builds for #968 and #969 have been failing due to issues with the golangci-lint action and the `goversioninfo` tool installation.

This PR updates both the action and tool, and changes tool installation from `go get` to `go install`.