### PR TITLE
fix PercentTimeinGC metric

### DIFF
--- a/collector/netframework_clrmemory.go
+++ b/collector/netframework_clrmemory.go
@@ -143,7 +143,11 @@ type Win32_PerfRawData_NETFramework_NETCLRMemory struct {
 	NumberofSinkBlocksinuse            uint64
 	NumberTotalcommittedBytes          uint64
 	NumberTotalreservedBytes           uint64
+	// PercentTimeinGC has countertype=PERF_RAW_FRACTION.
+	// Formula: (100 * CounterValue) / BaseValue
+	// By docs https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/scripting-articles/ms974615(v=msdn.10)#perf_raw_fraction
 	PercentTimeinGC                    uint32
+	// BaseValue is just a "magic" number used to make the calculation come out right.
 	PercentTimeinGC_base               uint32
 	ProcessID                          uint64
 	PromotedFinalizationMemoryfromGen0 uint64

--- a/collector/netframework_clrmemory.go
+++ b/collector/netframework_clrmemory.go
@@ -124,29 +124,29 @@ func (c *NETFramework_NETCLRMemoryCollector) Collect(ctx *ScrapeContext, ch chan
 type Win32_PerfRawData_NETFramework_NETCLRMemory struct {
 	Name string
 
-	AllocatedBytesPersec               uint64
-	FinalizationSurvivors              uint64
-	Frequency_PerfTime                 uint64
-	Gen0heapsize                       uint64
-	Gen0PromotedBytesPerSec            uint64
-	Gen1heapsize                       uint64
-	Gen1PromotedBytesPerSec            uint64
-	Gen2heapsize                       uint64
-	LargeObjectHeapsize                uint64
-	NumberBytesinallHeaps              uint64
-	NumberGCHandles                    uint64
-	NumberGen0Collections              uint64
-	NumberGen1Collections              uint64
-	NumberGen2Collections              uint64
-	NumberInducedGC                    uint64
-	NumberofPinnedObjects              uint64
-	NumberofSinkBlocksinuse            uint64
-	NumberTotalcommittedBytes          uint64
-	NumberTotalreservedBytes           uint64
+	AllocatedBytesPersec      uint64
+	FinalizationSurvivors     uint64
+	Frequency_PerfTime        uint64
+	Gen0heapsize              uint64
+	Gen0PromotedBytesPerSec   uint64
+	Gen1heapsize              uint64
+	Gen1PromotedBytesPerSec   uint64
+	Gen2heapsize              uint64
+	LargeObjectHeapsize       uint64
+	NumberBytesinallHeaps     uint64
+	NumberGCHandles           uint64
+	NumberGen0Collections     uint64
+	NumberGen1Collections     uint64
+	NumberGen2Collections     uint64
+	NumberInducedGC           uint64
+	NumberofPinnedObjects     uint64
+	NumberofSinkBlocksinuse   uint64
+	NumberTotalcommittedBytes uint64
+	NumberTotalreservedBytes  uint64
 	// PercentTimeinGC has countertype=PERF_RAW_FRACTION.
 	// Formula: (100 * CounterValue) / BaseValue
 	// By docs https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/scripting-articles/ms974615(v=msdn.10)#perf_raw_fraction
-	PercentTimeinGC                    uint32
+	PercentTimeinGC uint32
 	// BaseValue is just a "magic" number used to make the calculation come out right.
 	PercentTimeinGC_base               uint32
 	ProcessID                          uint64

--- a/collector/netframework_clrmemory.go
+++ b/collector/netframework_clrmemory.go
@@ -144,6 +144,7 @@ type Win32_PerfRawData_NETFramework_NETCLRMemory struct {
 	NumberTotalcommittedBytes          uint64
 	NumberTotalreservedBytes           uint64
 	PercentTimeinGC                    uint32
+	PercentTimeinGC_base               uint32
 	ProcessID                          uint64
 	PromotedFinalizationMemoryfromGen0 uint64
 	PromotedMemoryfromGen0             uint64
@@ -294,7 +295,7 @@ func (c *NETFramework_NETCLRMemoryCollector) collect(ch chan<- prometheus.Metric
 		ch <- prometheus.MustNewConstMetric(
 			c.TimeinGC,
 			prometheus.GaugeValue,
-			float64(process.PercentTimeinGC)/float64(process.Frequency_PerfTime),
+			float64(100*process.PercentTimeinGC)/float64(process.PercentTimeinGC_base),
 			process.Name,
 		)
 	}


### PR DESCRIPTION
Fix bug for counting value PercentTimeinGC

From program `WEBMTest.exe` in class `Win32_PerfRawData_NETFramework_NETCLRMemory` I was found counter type
```
[DisplayName("% Time in GC"): ToInstance, countertype(537003008): ToInstance, 
perfindex(2606): ToInstance, helpindex(2607): ToInstance, defaultscale(0): ToInstance, 
perfdetail(100): ToInstance] uint32 PercentTimeinGC
```
The mapping for countertype(537003008) is *PERF_RAW_FRACTION*.

For Cooking Type MSDN has formula (100 * CounterValue) / BaseValue
[Article](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/scripting-articles/ms974615(v=msdn.10)?redirectedfrom=MSDN#perf_raw_fraction
)