### PR TITLE
fix: remove UpdateDomain (mscluster-resourcegroup) 

### DIFF
--- a/collector/mscluster_resourcegroup.go
+++ b/collector/mscluster_resourcegroup.go
@@ -26,7 +26,6 @@ type MSCluster_ResourceGroupCollector struct {
 	Priority            *prometheus.Desc
 	ResiliencyPeriod    *prometheus.Desc
 	State               *prometheus.Desc
-	UpdateDomain        *prometheus.Desc
 }
 
 func newMSCluster_ResourceGroupCollector() (Collector, error) {
@@ -132,7 +131,6 @@ type MSCluster_ResourceGroup struct {
 	Priority            uint
 	ResiliencyPeriod    uint
 	State               uint
-	UpdateDomain        uint
 }
 
 // Collect sends the metric values for each metric
@@ -234,13 +232,6 @@ func (c *MSCluster_ResourceGroupCollector) Collect(ctx *ScrapeContext, ch chan<-
 			c.State,
 			prometheus.GaugeValue,
 			float64(v.State),
-			v.Name,
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.UpdateDomain,
-			prometheus.GaugeValue,
-			float64(v.UpdateDomain),
 			v.Name,
 		)
 


### PR DESCRIPTION
UpdateDomain metric not exists as we can see in  https://docs.microsoft.com/en-us/previous-versions/windows/desktop/cluswmi/mscluster-resourcegroup, just removing from mscluster_resourcegroup.go
When execute windows_exporter.exe with this metric we get this error:

panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x60 pc=0xaad61d]

goroutine 66 [running]:
github.com/prometheus/client_golang/prometheus.NewConstMetric(0xc00009de30?, 0x2?, 0x3ff0000000000000?, {0xc000387730?, 0x1?, 0x1?})
        C:/Users/ricar/go/pkg/mod/github.com/prometheus/client_golang@v1.12.2/prometheus/value.go:88 +0x1d
github.com/prometheus/client_golang/prometheus.MustNewConstMetric(...)
        C:/Users/ricar/go/pkg/mod/github.com/prometheus/client_golang@v1.12.2/prometheus/value.go:105
github.com/prometheus-community/windows_exporter/collector.(*MSCluster_ResourceGroupCollector).Collect(0xc000552000, 0x0?, 0x0?)
        E:/Downloads/Prometheus/windows_exporter/windows_exporter/collector/mscluster_resourcegroup.go:240 +0xdfb
main.execute({0xc00006e0c6, 0x17}, {0xef6420, 0xc000552000}, 0x0?, 0x0?)
        E:/Downloads/Prometheus/windows_exporter/windows_exporter/exporter.go:199 +0x84
main.windowsCollector.Collect.func2({0xc00006e0c6, 0x17}, {0xef6420?, 0xc000552000?})
        E:/Downloads/Prometheus/windows_exporter/windows_exporter/exporter.go:140 +0x9b
created by main.windowsCollector.Collect
        E:/Downloads/Prometheus/windows_exporter/windows_exporter/exporter.go:138 +0x5c5

Signed-off-by: Alex Wiedermann <alexwdrnn@gmail.com>