### PR TITLE
Add content write permissions to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
       - edited
 
 permissions:
-  contents: read
+  contents: write
   packages: write
   
 env:


### PR DESCRIPTION
Write permissions are required to upload release artifacts.