### PR TITLE
Add Hyper-V Hypervisor Logical Processor metrics

### DIFF
--- a/collector/hyperv.go
+++ b/collector/hyperv.go
@@ -54,9 +54,9 @@ type HyperVCollector struct {
 	VirtualProcessors *prometheus.Desc
 
 	// Win32_PerfRawData_HvStats_HyperVHypervisorLogicalProcessor
-	HostLPGuestRunTime      *prometheus.Desc
-	HostLPHypervisorRunTime *prometheus.Desc
-	HostLPTotalRunTime      *prometheus.Desc
+	HostLPGuestRunTimePercent      *prometheus.Desc
+	HostLPHypervisorRunTimePercent *prometheus.Desc
+	HostLPTotalRunTimePercent      *prometheus.Desc
 
 	// Win32_PerfRawData_HvStats_HyperVHypervisorRootVirtualProcessor
 	HostGuestRunTime      *prometheus.Desc
@@ -314,20 +314,20 @@ func NewHyperVCollector() (Collector, error) {
 
 		//
 
-		HostLPGuestRunTime: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, buildSubsystemName("host_lp"), "guest_run_time"),
+		HostLPGuestRunTimePercent: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, buildSubsystemName("host_lp"), "guest_run_time_percent"),
 			"The percentage of time spent by the processor in guest code",
 			[]string{"core"},
 			nil,
 		),
-		HostLPHypervisorRunTime: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, buildSubsystemName("host_lp"), "hypervisor_run_time"),
+		HostLPHypervisorRunTimePercent: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, buildSubsystemName("host_lp"), "hypervisor_run_time_percent"),
 			"The percentage of time spent by the processor in hypervisor code",
 			[]string{"core"},
 			nil,
 		),
-		HostLPTotalRunTime: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, buildSubsystemName("host_lp"), "total_run_time"),
+		HostLPTotalRunTimePercent: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, buildSubsystemName("host_lp"), "total_run_time_percent"),
 			"The percentage of time spent by the processor in guest and hypervisor code",
 			[]string{"core"},
 			nil,
@@ -1058,21 +1058,21 @@ func (c *HyperVCollector) collectHostLPUsage(ch chan<- prometheus.Metric) (*prom
 		coreId := parts[2]
 
 		ch <- prometheus.MustNewConstMetric(
-			c.HostLPGuestRunTime,
+			c.HostLPGuestRunTimePercent,
 			prometheus.GaugeValue,
 			float64(obj.PercentGuestRunTime),
 			coreId,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
-			c.HostLPHypervisorRunTime,
+			c.HostLPHypervisorRunTimePercent,
 			prometheus.GaugeValue,
 			float64(obj.PercentHypervisorRunTime),
 			coreId,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
-			c.HostLPTotalRunTime,
+			c.HostLPTotalRunTimePercent,
 			prometheus.GaugeValue,
 			float64(obj.PercentTotalRunTime),
 			coreId,

--- a/docs/collector.hyperv.md
+++ b/docs/collector.hyperv.md
@@ -5,7 +5,7 @@ The hyperv collector exposes metrics about the Hyper-V hypervisor
 |||
 -|-
 Metric name prefix  | `hyperv`
-Classes             | `Win32_PerfRawData_VmmsVirtualMachineStats_HyperVVirtualMachineHealthSummary`<br/>`Win32_PerfRawData_VidPerfProvider_HyperVVMVidPartition`<br/>`Win32_PerfRawData_HvStats_HyperVHypervisorRootPartition`<br/>`Win32_PerfRawData_HvStats_HyperVHypervisor`<br/>`Win32_PerfRawData_HvStats_HyperVHypervisorRootVirtualProcessor`<br/>`Win32_PerfRawData_HvStats_HyperVHypervisorVirtualProcessor`<br/>`Win32_PerfRawData_NvspSwitchStats_HyperVVirtualSwitch`<br/>`Win32_PerfRawData_EthernetPerfProvider_HyperVLegacyNetworkAdapter`<br/>`Win32_PerfRawData_Counters_HyperVVirtualStorageDevice`<br/>`Win32_PerfRawData_NvspNicStats_HyperVVirtualNetworkAdapter`
+Classes             | `Win32_PerfRawData_VmmsVirtualMachineStats_HyperVVirtualMachineHealthSummary`<br/>`Win32_PerfRawData_VidPerfProvider_HyperVVMVidPartition`<br/>`Win32_PerfRawData_HvStats_HyperVHypervisorRootPartition`<br/>`Win32_PerfRawData_HvStats_HyperVHypervisor`<br/>`Win32_PerfRawData_HvStats_HyperVHypervisorLogicalProcessor`<br/>`Win32_PerfRawData_HvStats_HyperVHypervisorRootVirtualProcessor`<br/>`Win32_PerfRawData_HvStats_HyperVHypervisorVirtualProcessor`<br/>`Win32_PerfRawData_NvspSwitchStats_HyperVVirtualSwitch`<br/>`Win32_PerfRawData_EthernetPerfProvider_HyperVLegacyNetworkAdapter`<br/>`Win32_PerfRawData_Counters_HyperVVirtualStorageDevice`<br/>`Win32_PerfRawData_NvspNicStats_HyperVVirtualNetworkAdapter`
 Enabled by default? | No
 
 ## Flags
@@ -44,6 +44,9 @@ Name | Description | Type | Labels
 `windows_hyperv_root_partition_virtual_tlb_pages` | _Not yet documented_ | counter | None
 `windows_hyperv_hypervisor_virtual_processors` | _Not yet documented_ | counter | None
 `windows_hyperv_hypervisor_logical_processors` | _Not yet documented_ | counter | None
+`windows_hyperv_host_lp_guest_run_time` | _Not yet documented_ | counter | `core`
+`windows_hyperv_host_lp_hypervisor_run_time` | _Not yet documented_ | counter | `core`
+`windows_hyperv_host_lp_total_run_time` | _Not yet documented_ | counter | `core`
 `windows_hyperv_host_cpu_guest_run_time` | _Not yet documented_ | counter | `core`
 `windows_hyperv_host_cpu_hypervisor_run_time` | _Not yet documented_ | counter | `core`
 `windows_hyperv_host_cpu_remote_run_time` | _Not yet documented_ | counter | `core`

--- a/docs/collector.hyperv.md
+++ b/docs/collector.hyperv.md
@@ -44,9 +44,9 @@ Name | Description | Type | Labels
 `windows_hyperv_root_partition_virtual_tlb_pages` | _Not yet documented_ | counter | None
 `windows_hyperv_hypervisor_virtual_processors` | _Not yet documented_ | counter | None
 `windows_hyperv_hypervisor_logical_processors` | _Not yet documented_ | counter | None
-`windows_hyperv_host_lp_guest_run_time` | _Not yet documented_ | counter | `core`
-`windows_hyperv_host_lp_hypervisor_run_time` | _Not yet documented_ | counter | `core`
-`windows_hyperv_host_lp_total_run_time` | _Not yet documented_ | counter | `core`
+`windows_hyperv_host_lp_guest_run_time_percent` | _Not yet documented_ | counter | `core`
+`windows_hyperv_host_lp_hypervisor_run_time_percent` | _Not yet documented_ | counter | `core`
+`windows_hyperv_host_lp_total_run_time_percent` | _Not yet documented_ | counter | `core`
 `windows_hyperv_host_cpu_guest_run_time` | _Not yet documented_ | counter | `core`
 `windows_hyperv_host_cpu_hypervisor_run_time` | _Not yet documented_ | counter | `core`
 `windows_hyperv_host_cpu_remote_run_time` | _Not yet documented_ | counter | `core`
@@ -123,7 +123,7 @@ Percent of physical CPU resources by the hosts themselves (on all monitored host
 ```
 Percent of physical CPU resources by the hypervisor (on all monitored hosts)
 ```
-(sum by (instance)(rate(windows_hyperv_host_lp_total_run_time{}[1m]))) / sum by (instance)(windows_hyperv_hypervisor_logical_processors{}) / 100000
+(sum by (instance)(rate(windows_hyperv_host_lp_total_run_time_percent{}[1m]))) / sum by (instance)(windows_hyperv_hypervisor_logical_processors{}) / 100000
 ```
 
 ## Alerting examples

--- a/docs/collector.hyperv.md
+++ b/docs/collector.hyperv.md
@@ -121,6 +121,10 @@ Percent of physical CPU resources by the hosts themselves (on all monitored host
 ```
 (sum by (instance)(rate(windows_hyperv_host_cpu_total_run_time{}[1m]))) / sum by (instance)(windows_cs_logical_processors{}) / 100000
 ```
+Percent of physical CPU resources by the hypervisor (on all monitored hosts)
+```
+(sum by (instance)(rate(windows_hyperv_host_lp_total_run_time{}[1m]))) / sum by (instance)(windows_hyperv_hypervisor_logical_processors{}) / 100000
+```
 
 ## Alerting examples
 _This collector does not yet have alerting examples, we would appreciate your help adding them!_


### PR DESCRIPTION
Add Win32_PerfRawData_HvStats_HyperVHypervisorLogicalProcessor WMI class to monitor Hyper-V Hypervisor Logical Processor. The class shows metrics for actual CPU utilization on hypervisor hosts.

This addresses https://github.com/prometheus-community/windows_exporter/issues/444

Example output:
```
# HELP windows_hyperv_host_lp_guest_run_time The percentage of time spent by the processor in guest code
# TYPE windows_hyperv_host_lp_guest_run_time gauge
windows_hyperv_host_lp_guest_run_time{core="0"} 4.288535665036e+12
windows_hyperv_host_lp_guest_run_time{core="1"} 3.8546816773e+11
# HELP windows_hyperv_host_lp_hypervisor_run_time The percentage of time spent by the processor in hypervisor code
# TYPE windows_hyperv_host_lp_hypervisor_run_time gauge
windows_hyperv_host_lp_hypervisor_run_time{core="0"} 9.95114252719e+11
windows_hyperv_host_lp_hypervisor_run_time{core="1"} 2.50063864275e+11
# HELP windows_hyperv_host_lp_total_run_time The percentage of time spent by the processor in guest and hypervisor code
# TYPE windows_hyperv_host_lp_total_run_time gauge
windows_hyperv_host_lp_total_run_time{core="0"} 5.283649917755e+12
windows_hyperv_host_lp_total_run_time{core="1"} 6.35532032005e+11
```