### PR TITLE
Fix Error "Service Access is denied" in service collector useApi

### DIFF
--- a/collector/service.go
+++ b/collector/service.go
@@ -6,6 +6,7 @@ package collector
 import (
 	"fmt"
 	"strings"
+	"syscall"
 
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
@@ -234,30 +235,43 @@ func (c *serviceCollector) collectAPI(ch chan<- prometheus.Metric) error {
 	}
 	defer svcmgrConnection.Disconnect() //nolint:errcheck
 
-	// List All Services from the Services Manager
+	// List All Services from the Services Manager.
 	serviceList, err := svcmgrConnection.ListServices()
 	if err != nil {
 		return err
 	}
 
-	// Iterate through the Services List
+	// Iterate through the Services List.
 	for _, service := range serviceList {
-		// Retrieve handle for each service
-		serviceHandle, err := svcmgrConnection.OpenService(service)
+		// Get UTF16 service name.
+		serviceName, err := syscall.UTF16PtrFromString(service)
 		if err != nil {
-			continue
-		}
-		defer serviceHandle.Close()
-
-		// Get Service Configuration
-		serviceConfig, err := serviceHandle.Config()
-		if err != nil {
+			log.Warnf("Service %s get name error:  %#v", service, err)
 			continue
 		}
 
-		// Get Service Current Status
-		serviceStatus, err := serviceHandle.Query()
+		// Open connection for service handler.
+		serviceHandle, err := windows.OpenService(svcmgrConnection.Handle, serviceName, windows.GENERIC_READ)
 		if err != nil {
+			log.Warnf("Open service %s error:  %#v", service, err)
+			continue
+		}
+
+		// Create handle for each service.
+		serviceManager := &mgr.Service{Name: service, Handle: serviceHandle}
+		defer serviceManager.Close()
+
+		// Get Service Configuration.
+		serviceConfig, err := serviceManager.Config()
+		if err != nil {
+			log.Warnf("Get ervice %s config error:  %#v", service, err)
+			continue
+		}
+
+		// Get Service Current Status.
+		serviceStatus, err := serviceManager.Query()
+		if err != nil {
+			log.Warnf("Get service %s status error:  %#v", service, err)
 			continue
 		}
 


### PR DESCRIPTION
Fix error preventing to collect certain restricted services when using the service collector in api mode "useApi".
Since the handler used sets by default SC_MANAGER_ALL_ACCESS when creating a service handler, in certain windows distributions and for certain services, it is not possible to open a connection to those services that are restricted.
Opening the service with GENERIC_READ fixes the issue.