### PR TITLE
fix Windows Service timeout during high CPU (eg. post Windows Update)

### DIFF
--- a/collector/service.go
+++ b/collector/service.go
@@ -6,6 +6,7 @@ package collector
 import (
 	"fmt"
 	"strings"
+	"syscall"
 
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
@@ -234,30 +235,43 @@ func (c *serviceCollector) collectAPI(ch chan<- prometheus.Metric) error {
 	}
 	defer svcmgrConnection.Disconnect() //nolint:errcheck
 
-	// List All Services from the Services Manager
+	// List All Services from the Services Manager.
 	serviceList, err := svcmgrConnection.ListServices()
 	if err != nil {
 		return err
 	}
 
-	// Iterate through the Services List
+	// Iterate through the Services List.
 	for _, service := range serviceList {
-		// Retrieve handle for each service
-		serviceHandle, err := svcmgrConnection.OpenService(service)
+		// Get UTF16 service name.
+		serviceName, err := syscall.UTF16PtrFromString(service)
 		if err != nil {
-			continue
-		}
-		defer serviceHandle.Close()
-
-		// Get Service Configuration
-		serviceConfig, err := serviceHandle.Config()
-		if err != nil {
+			log.Warnf("Service %s get name error:  %#v", service, err)
 			continue
 		}
 
-		// Get Service Current Status
-		serviceStatus, err := serviceHandle.Query()
+		// Open connection for service handler.
+		serviceHandle, err := windows.OpenService(svcmgrConnection.Handle, serviceName, windows.GENERIC_READ)
 		if err != nil {
+			log.Warnf("Open service %s error:  %#v", service, err)
+			continue
+		}
+
+		// Create handle for each service.
+		serviceManager := &mgr.Service{Name: service, Handle: serviceHandle}
+		defer serviceManager.Close()
+
+		// Get Service Configuration.
+		serviceConfig, err := serviceManager.Config()
+		if err != nil {
+			log.Warnf("Get ervice %s config error:  %#v", service, err)
+			continue
+		}
+
+		// Get Service Current Status.
+		serviceStatus, err := serviceManager.Query()
+		if err != nil {
+			log.Warnf("Get service %s status error:  %#v", service, err)
 			continue
 		}
 

--- a/exporter.go
+++ b/exporter.go
@@ -291,14 +291,14 @@ func main() {
 			"Seconds to subtract from the timeout allowed by the client. Tune to allow for overhead or high loads.",
 		).Default("0.5").Float64()
 	)
-
+	log.AddFlags(kingpin.CommandLine)
 	kingpin.Version(version.Print("windows_exporter"))
 	kingpin.HelpFlag.Short('h')
 
 	// Load values from configuration file(s). Executable flags must first be parsed, in order
 	// to load the specified file(s).
 	kingpin.Parse()
-
+	log.Debug("Logging has Started")
 	if *configFile != "" {
 		resolver, err := config.NewResolver(*configFile)
 		if err != nil {

--- a/initiate/initiate.go
+++ b/initiate/initiate.go
@@ -1,0 +1,69 @@
+package initiate
+
+import (
+	"fmt"
+
+	"github.com/prometheus-community/windows_exporter/log"
+	"github.com/prometheus/common/version"
+	"golang.org/x/sys/windows/svc"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+const (
+	serviceName = "windows_exporter"
+)
+
+type windowsExporterService struct {
+	stopCh chan<- bool
+}
+
+func (s *windowsExporterService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
+	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+	changes <- svc.Status{State: svc.StartPending}
+	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+loop:
+	for {
+		select {
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Interrogate:
+				changes <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				log.Debug("Service Stop Received")
+				s.stopCh <- true
+				break loop
+			default:
+				log.Error(fmt.Sprintf("unexpected control request #%d", c))
+			}
+		}
+	}
+	changes <- svc.Status{State: svc.StopPending}
+	return
+}
+
+var StopCh chan bool
+
+func init() {
+	log.AddFlags(kingpin.CommandLine)
+	kingpin.Version(version.Print("windows_exporter"))
+	kingpin.HelpFlag.Short('h')
+	// Load values from configuration file(s). Executable flags must first be parsed, in order
+	// to load the specified file(s).
+	kingpin.Parse()
+	log.Debug("Logging has Started")
+	log.Debug("Checking if We are a service")
+	isService, err := svc.IsWindowsService()
+	if err != nil {
+		log.Fatal(err)
+	}
+	StopCh := make(chan bool)
+	log.Debug("Attempting to start exporter service")
+	if isService {
+		go func() {
+			err = svc.Run(serviceName, &windowsExporterService{stopCh: StopCh})
+			if err != nil {
+				log.Errorf("Failed to start service: %v", err)
+			}
+		}()
+	}
+}

--- a/initiate/initiate.go
+++ b/initiate/initiate.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 
 	"github.com/prometheus-community/windows_exporter/log"
-	"github.com/prometheus/common/version"
 	"golang.org/x/sys/windows/svc"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 const (
@@ -44,13 +42,6 @@ loop:
 var StopCh chan bool
 
 func init() {
-	log.AddFlags(kingpin.CommandLine)
-	kingpin.Version(version.Print("windows_exporter"))
-	kingpin.HelpFlag.Short('h')
-	// Load values from configuration file(s). Executable flags must first be parsed, in order
-	// to load the specified file(s).
-	kingpin.Parse()
-	log.Debug("Logging has Started")
 	log.Debug("Checking if We are a service")
 	isService, err := svc.IsWindowsService()
 	if err != nil {


### PR DESCRIPTION
This PR attempts to resolve a long standing [issue](https://github.com/prometheus-community/windows_exporter/issues/551) with the windows service timing out when CPU is constrained on the host machine.

The underlying cause of this is due to how late the service initialization happens in the code due to it existing in main() which is the last part of code to be run during startup as per:

![image](https://user-images.githubusercontent.com/54275278/186161561-a4520665-04c8-49ed-905e-510d194767ab.png)

What we attempt to do here is call the windows service as early as possible by placing it in a separate package's init() at the top of the main packages import list causing it to occur as early in the process as possible

Originally I had also moved the initiation of logging into this same package however i ran into issues with double logging in event viewer so ill revisit this at a later date. 

The benefit of having the logging called as early as possible is that you can properly debug issues such as this as until logging is initiated as part of main() in the main package none of the log commands can actually execute