### PR TITLE
fix Windows Service timeout during high CPU (eg. post Windows Update)

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -52,7 +52,6 @@ type prometheusVersion struct {
 const (
 	defaultCollectors            = "cpu,cs,logical_disk,net,os,service,system,textfile"
 	defaultCollectorsPlaceholder = "[defaults]"
-	serviceName                  = "windows_exporter"
 )
 
 var (

--- a/exporter.go
+++ b/exporter.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	//We keep this at the top to ensure it happens first
+	//Its important that we do these first so that we can register with the windows service control ASAP to avoid timeouts
 	"github.com/prometheus-community/windows_exporter/initiate"
 	"github.com/prometheus-community/windows_exporter/log"
 

--- a/exporter.go
+++ b/exporter.go
@@ -4,6 +4,10 @@
 package main
 
 import (
+	//We keep this at the top to ensure it happens first
+	"github.com/prometheus-community/windows_exporter/initiate"
+	"github.com/prometheus-community/windows_exporter/log"
+
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,12 +20,10 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/sys/windows/svc"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/collector"
 	"github.com/prometheus-community/windows_exporter/config"
-	"github.com/prometheus-community/windows_exporter/log"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -289,7 +291,6 @@ func main() {
 			"Seconds to subtract from the timeout allowed by the client. Tune to allow for overhead or high loads.",
 		).Default("0.5").Float64()
 	)
-
 	log.AddFlags(kingpin.CommandLine)
 	kingpin.Version(version.Print("windows_exporter"))
 	kingpin.HelpFlag.Short('h')
@@ -297,7 +298,7 @@ func main() {
 	// Load values from configuration file(s). Executable flags must first be parsed, in order
 	// to load the specified file(s).
 	kingpin.Parse()
-
+	log.Debug("Logging has Started")
 	if *configFile != "" {
 		resolver, err := config.NewResolver(*configFile)
 		if err != nil {
@@ -326,21 +327,6 @@ func main() {
 	}
 
 	initWbem()
-
-	isService, err := svc.IsWindowsService()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	stopCh := make(chan bool)
-	if isService {
-		go func() {
-			err = svc.Run(serviceName, &windowsExporterService{stopCh: stopCh})
-			if err != nil {
-				log.Errorf("Failed to start service: %v", err)
-			}
-		}()
-	}
 
 	collectors, err := loadCollectors(*enabledCollectors)
 	if err != nil {
@@ -421,7 +407,7 @@ func main() {
 	}()
 
 	for {
-		if <-stopCh {
+		if <-initiate.StopCh {
 			log.Info("Shutting down windows_exporter")
 			break
 		}
@@ -461,33 +447,6 @@ func withConcurrencyLimit(n int, next http.HandlerFunc) http.HandlerFunc {
 		}
 		next(w, r)
 	}
-}
-
-type windowsExporterService struct {
-	stopCh chan<- bool
-}
-
-func (s *windowsExporterService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
-	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
-	changes <- svc.Status{State: svc.StartPending}
-	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
-loop:
-	for {
-		select {
-		case c := <-r:
-			switch c.Cmd {
-			case svc.Interrogate:
-				changes <- c.CurrentStatus
-			case svc.Stop, svc.Shutdown:
-				s.stopCh <- true
-				break loop
-			default:
-				log.Error(fmt.Sprintf("unexpected control request #%d", c))
-			}
-		}
-	}
-	changes <- svc.Status{State: svc.StopPending}
-	return
 }
 
 type metricsHandler struct {

--- a/initiate/initiate.go
+++ b/initiate/initiate.go
@@ -1,3 +1,4 @@
+//This package allows us to initiate Time Sensitive components (Like registering the windows service) as early as possible in the startup process
 package initiate
 
 import (

--- a/initiate/initiate.go
+++ b/initiate/initiate.go
@@ -1,0 +1,60 @@
+package initiate
+
+import (
+	"fmt"
+
+	"github.com/prometheus-community/windows_exporter/log"
+	"golang.org/x/sys/windows/svc"
+)
+
+const (
+	serviceName = "windows_exporter"
+)
+
+type windowsExporterService struct {
+	stopCh chan<- bool
+}
+
+func (s *windowsExporterService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
+	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+	changes <- svc.Status{State: svc.StartPending}
+	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+loop:
+	for {
+		select {
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Interrogate:
+				changes <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				log.Debug("Service Stop Received")
+				s.stopCh <- true
+				break loop
+			default:
+				log.Error(fmt.Sprintf("unexpected control request #%d", c))
+			}
+		}
+	}
+	changes <- svc.Status{State: svc.StopPending}
+	return
+}
+
+var StopCh chan bool
+
+func init() {
+	log.Debug("Checking if We are a service")
+	isService, err := svc.IsWindowsService()
+	if err != nil {
+		log.Fatal(err)
+	}
+	StopCh := make(chan bool)
+	log.Debug("Attempting to start exporter service")
+	if isService {
+		go func() {
+			err = svc.Run(serviceName, &windowsExporterService{stopCh: StopCh})
+			if err != nil {
+				log.Errorf("Failed to start service: %v", err)
+			}
+		}()
+	}
+}

--- a/initiate/initiate.go
+++ b/initiate/initiate.go
@@ -39,7 +39,7 @@ loop:
 	return
 }
 
-var StopCh chan bool
+var StopCh = make(chan bool)
 
 func init() {
 	log.Debug("Checking if We are a service")
@@ -47,7 +47,6 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	StopCh := make(chan bool)
 	log.Debug("Attempting to start exporter service")
 	if isService {
 		go func() {


### PR DESCRIPTION
This PR attempts to resolve a long standing [issue](https://github.com/prometheus-community/windows_exporter/issues/551) with the windows service timing out when CPU is constrained on the host machine.
The underlying cause of this is due to how late the service initialization happens in the code due to it existing in main() which is the last part of code to be run during startup as per:

![image](https://user-images.githubusercontent.com/54275278/186177540-67374a9e-cbf4-48ce-9036-e6bd47d53821.png)
 
What we attempt to do here is call the windows service as early as possible by placing it in a separate package's init() at the top of the main packages import list causing it to occur as early in the process as possible
Originally I had also moved the initiation of logging into this same package however i ran into issues with double logging in event viewer so ill revisit this at a later date.
The benefit of having the logging called as early as possible is that you can properly debug issues such as this as until logging is initiated as part of main() in the main package none of the log commands can actually execute