### PR TITLE
Add ARM64 builds to releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
           (Get-Content -Path VERSION) -replace '\+', '_' | Set-Content -Path VERSION
           make build-all
           # GH requires all files to have different names, so add version/arch to differentiate
-          foreach($Arch in "amd64","386") {
+          foreach($Arch in "amd64", "arm64","386") {
             Move-Item output\$Arch\windows_exporter.exe output\windows_exporter-$Version-$Arch.exe
           }
 
@@ -166,7 +166,7 @@ jobs:
           $TagName = $env:GITHUB_REF -replace 'refs/tags/', ''
           # The MSI version is not semver compliant, so just take the numerical parts
           $MSIVersion = $TagName -replace '^v?([0-9\.]+).*$','$1'
-          foreach($Arch in "amd64","386") {
+          foreach($Arch in "amd64", "arm64","386") {
             Write-Verbose "Building windows_exporter $MSIVersion msi for $Arch"
             .\installer\build.ps1 -PathToExecutable .\output\windows_exporter-$BuildVersion-$Arch.exe -Version $MSIVersion -Arch "$Arch"
             Move-Item installer\Output\windows_exporter-$MSIVersion-$Arch.msi output\

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ crossbuild:
 	# The prometheus/golang-builder image for promu crossbuild doesn't exist
 	# on Windows, so for now, we'll just build twice
 	GOARCH=amd64 promu build --prefix=output/amd64
+	GOARCH=arm64 promu build --prefix=output/arm64
 	GOARCH=386   promu build --prefix=output/386
 
 build-image: crossbuild


### PR DESCRIPTION
Support for these builds will be "best effort" as the project maintainers have no access to ARM64 Windows installations at this time.

Resolves #957 