### PR TITLE
Added WebService uptime metric in iis collector

### DIFF
--- a/collector/iis.go
+++ b/collector/iis.go
@@ -69,6 +69,7 @@ type IISCollector struct {
 	CurrentConnections                  *prometheus.Desc
 	CurrentISAPIExtensionRequests       *prometheus.Desc
 	CurrentNonAnonymousUsers            *prometheus.Desc
+	ServiceUptime                       *prometheus.Desc
 	TotalBytesReceived                  *prometheus.Desc
 	TotalBytesSent                      *prometheus.Desc
 	TotalAnonymousUsers                 *prometheus.Desc
@@ -239,6 +240,12 @@ func NewIISCollector() (Collector, error) {
 		CurrentNonAnonymousUsers: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "current_non_anonymous_users"),
 			"Number of users who currently have a non-anonymous connection using the Web service (WebService.CurrentNonAnonymousUsers)",
+			[]string{"site"},
+			nil,
+		),
+		ServiceUptime: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "service_uptime"),
+			"Number of seconds the WebService is up (WebService.ServiceUptime)",
 			[]string{"site"},
 			nil,
 		),
@@ -845,6 +852,7 @@ type perflibWebService struct {
 	CurrentConnections            float64 `perflib:"Current Connections"`
 	CurrentISAPIExtensionRequests float64 `perflib:"Current ISAPI Extension Requests"`
 	CurrentNonAnonymousUsers      float64 `perflib:"Current NonAnonymous Users"`
+	ServiceUptime                 float64 `perflib:"Service Uptime"`
 
 	TotalBytesReceived                  float64 `perflib:"Total Bytes Received"`
 	TotalBytesSent                      float64 `perflib:"Total Bytes Sent"`
@@ -923,6 +931,12 @@ func (c *IISCollector) collectWebService(ctx *ScrapeContext, ch chan<- prometheu
 			c.CurrentNonAnonymousUsers,
 			prometheus.GaugeValue,
 			app.CurrentNonAnonymousUsers,
+			app.Name,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.ServiceUptime,
+			prometheus.GaugeValue,
+			app.ServiceUptime,
 			app.Name,
 		)
 		ch <- prometheus.MustNewConstMetric(

--- a/docs/collector.iis.md
+++ b/docs/collector.iis.md
@@ -36,7 +36,7 @@ Name | Description | Type | Labels
 `windows_iis_current_connections` |  The number of active connections to the web service | counter | `site`
 `windows_iis_current_isapi_extension_requests` | The number of [ISAPI extension](https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525172(v=vs.90)) requests that are being processed simultaneously by the web service | counter | `site`
 `windows_iis_current_non_anonymous_users` | The number of users who currently have a nonanonymous request pending with the web service | counter | `site`
-`windows_iis_service_uptime` | The uptime for the web service or a Web site (seconds) | counter | `site`
+`windows_iis_service_uptime` | The uptime for the web service or a Web site (seconds) | gauge | `site`
 `windows_iis_received_bytes_total` | The total bytes of data that have been received by the web service since the service started | counter | `site`
 `windows_iis_sent_bytes_total` | The number of data bytes that have been sent by the web service since the service started | counter | `site`
 `windows_iis_anonymous_users_total` | The number of users who have established an anonymous request since the web service started | counter | `site`


### PR DESCRIPTION
Added the WebService uptime metric in the iis collector. This metric is
a counter and counts up the seconds when the service is up. If the
service is stopped, the uptime is 0. Fixes #1058.