### PR TITLE
Cleaning up listen addresses flags before parsing config file

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -303,6 +303,12 @@ func main() {
 		if err != nil {
 			log.Fatalf("%v\n", err)
 		}
+
+		// NOTE: This is temporary fix for issue #1092, calling kingpin.Parse
+		// twice makes slices flags duplicate its value, this clean up
+		// the first parse before the second call.
+		*webConfig.WebListenAddresses = (*webConfig.WebListenAddresses)[1:]
+
 		// Parse flags once more to include those discovered in configuration file(s).
 		kingpin.Parse()
 	}


### PR DESCRIPTION
Parsing the flags twice duplicates the value for slice flags, it seems other binaries (alertmanager, exporters) are using both flags and treat it differently, besides this dirty fix solving this issue in particular, a bigger refactoring is required.

The following scenarios were tested:

1) Setting the bind flag directly: `--config.file=config.yml --web.listen-address=":9099"` bind on `:9099`

2) No bind flag and config set + passed via flag:
```
config.yml:
web:
  listen-address: :9183

--config.file=config.yml
```
bind on :9183

3) No bind flags and config flag = `--config.file=config.yml` - bind on default :9182
