### PR TITLE
Remove init functions from collectors

### DIFF
--- a/collector/ad.go
+++ b/collector/ad.go
@@ -76,8 +76,8 @@ type ADCollector struct {
 	TombstonedObjectsVisitedTotal                       *prometheus.Desc
 }
 
-// NewADCollector ...
-func NewADCollector() (Collector, error) {
+// newADCollector ...
+func newADCollector() (Collector, error) {
 	const subsystem = "ad"
 	return &ADCollector{
 		AddressBookOperationsTotal: prometheus.NewDesc(

--- a/collector/ad.go
+++ b/collector/ad.go
@@ -11,10 +11,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("ad", NewADCollector)
-}
-
 // A ADCollector is a Prometheus collector for WMI Win32_PerfRawData_DirectoryServices_DirectoryServices metrics
 type ADCollector struct {
 	AddressBookOperationsTotal                          *prometheus.Desc

--- a/collector/ad_test.go
+++ b/collector/ad_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkADCollector(b *testing.B) {
-	benchmarkCollector(b, "ad", NewADCollector)
+	benchmarkCollector(b, "ad", newADCollector)
 }

--- a/collector/adcs.go
+++ b/collector/adcs.go
@@ -10,10 +10,6 @@ import (
 	"strings"
 )
 
-func init() {
-	registerCollector("adcs", adcsCollectorMethod, "Certification Authority")
-}
-
 type adcsCollector struct {
 	RequestsPerSecond                            *prometheus.Desc
 	RequestProcessingTime                        *prometheus.Desc

--- a/collector/adfs.go
+++ b/collector/adfs.go
@@ -8,10 +8,6 @@ import (
 	"math"
 )
 
-func init() {
-	registerCollector("adfs", newADFSCollector, "AD FS")
-}
-
 type adfsCollector struct {
 	adLoginConnectionFailures                          *prometheus.Desc
 	certificateAuthentications                         *prometheus.Desc

--- a/collector/cache.go
+++ b/collector/cache.go
@@ -8,10 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	registerCollector("cache", newCacheCollector, "Cache")
-}
-
 // A CacheCollector is a Prometheus collector for Perflib Cache metrics
 type CacheCollector struct {
 	AsyncCopyReadsTotal         *prometheus.Desc

--- a/collector/container.go
+++ b/collector/container.go
@@ -9,10 +9,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	registerCollector("container", NewContainerMetricsCollector)
-}
-
 // A ContainerMetricsCollector is a Prometheus collector for containers metrics
 type ContainerMetricsCollector struct {
 	// Presence

--- a/collector/container.go
+++ b/collector/container.go
@@ -41,8 +41,8 @@ type ContainerMetricsCollector struct {
 	WriteSizeBytes       *prometheus.Desc
 }
 
-// NewContainerMetricsCollector constructs a new ContainerMetricsCollector
-func NewContainerMetricsCollector() (Collector, error) {
+// newContainerMetricsCollector constructs a new ContainerMetricsCollector
+func newContainerMetricsCollector() (Collector, error) {
 	const subsystem = "container"
 	return &ContainerMetricsCollector{
 		ContainerAvailable: prometheus.NewDesc(

--- a/collector/container_test.go
+++ b/collector/container_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkContainerCollector(b *testing.B) {
-	benchmarkCollector(b, "container", NewContainerMetricsCollector)
+	benchmarkCollector(b, "container", newContainerMetricsCollector)
 }

--- a/collector/cpu.go
+++ b/collector/cpu.go
@@ -9,17 +9,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	var deps string
-	// See below for 6.05 magic value
-	if getWindowsVersion() > 6.05 {
-		deps = "Processor Information"
-	} else {
-		deps = "Processor"
-	}
-	registerCollector("cpu", newCPUCollector, deps)
-}
-
 type cpuCollectorBasic struct {
 	CStateSecondsTotal *prometheus.Desc
 	TimeTotal          *prometheus.Desc

--- a/collector/cpu_info.go
+++ b/collector/cpu_info.go
@@ -13,10 +13,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("cpu_info", newCpuInfoCollector)
-}
-
 // If you are adding additional labels to the metric, make sure that they get added in here as well. See below for explanation.
 const (
 	win32ProcessorQuery = "SELECT Architecture, DeviceId, Description, Family, L2CacheSize, L3CacheSize, Name FROM Win32_Processor"

--- a/collector/cs.go
+++ b/collector/cs.go
@@ -17,8 +17,8 @@ type CSCollector struct {
 	Hostname            *prometheus.Desc
 }
 
-// NewCSCollector ...
-func NewCSCollector() (Collector, error) {
+// newCSCollector ...
+func newCSCollector() (Collector, error) {
 	const subsystem = "cs"
 
 	return &CSCollector{

--- a/collector/cs.go
+++ b/collector/cs.go
@@ -10,10 +10,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	registerCollector("cs", NewCSCollector)
-}
-
 // A CSCollector is a Prometheus collector for WMI metrics
 type CSCollector struct {
 	PhysicalMemoryBytes *prometheus.Desc

--- a/collector/cs_test.go
+++ b/collector/cs_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkCsCollector(b *testing.B) {
-	benchmarkCollector(b, "cs", NewCSCollector)
+	benchmarkCollector(b, "cs", newCSCollector)
 }

--- a/collector/dfsr.go
+++ b/collector/dfsr.go
@@ -82,8 +82,8 @@ func dfsrGetPerfObjectName(collector string) string {
 	return (prefix + suffix)
 }
 
-// NewDFSRCollector is registered
-func NewDFSRCollector() (Collector, error) {
+// newDFSRCollector is registered
+func newDFSRCollector() (Collector, error) {
 	log.Info("dfsr collector is in an experimental state! Metrics for this collector have not been tested.")
 	const subsystem = "dfsr"
 

--- a/collector/dfsr.go
+++ b/collector/dfsr.go
@@ -11,16 +11,6 @@ import (
 
 var dfsrEnabledCollectors = kingpin.Flag("collectors.dfsr.sources-enabled", "Comma-seperated list of DFSR Perflib sources to use.").Default("connection,folder,volume").String()
 
-func init() {
-	// Perflib sources are dynamic, depending on the enabled child collectors
-	var perflibDependencies []string
-	for _, source := range expandEnabledChildCollectors(*dfsrEnabledCollectors) {
-		perflibDependencies = append(perflibDependencies, dfsrGetPerfObjectName(source))
-	}
-
-	registerCollector("dfsr", NewDFSRCollector, perflibDependencies...)
-}
-
 // DFSRCollector contains the metric and state data of the DFSR collectors.
 type DFSRCollector struct {
 	// Connection source

--- a/collector/dfsr_test.go
+++ b/collector/dfsr_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkDFSRCollector(b *testing.B) {
-	benchmarkCollector(b, "dfsr", NewDFSRCollector)
+	benchmarkCollector(b, "dfsr", newDFSRCollector)
 }

--- a/collector/dhcp.go
+++ b/collector/dhcp.go
@@ -36,7 +36,7 @@ type DhcpCollector struct {
 	FailoverBndupdDropped                            *prometheus.Desc
 }
 
-func NewDhcpCollector() (Collector, error) {
+func newDhcpCollector() (Collector, error) {
 	const subsystem = "dhcp"
 
 	return &DhcpCollector{

--- a/collector/dhcp.go
+++ b/collector/dhcp.go
@@ -7,10 +7,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	registerCollector("dhcp", NewDhcpCollector, "DHCP Server")
-}
-
 // A DhcpCollector is a Prometheus collector perflib DHCP metrics
 type DhcpCollector struct {
 	PacketsReceivedTotal                             *prometheus.Desc

--- a/collector/dhcp_test.go
+++ b/collector/dhcp_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkDHCPCollector(b *testing.B) {
-	benchmarkCollector(b, "dhcp", NewDhcpCollector)
+	benchmarkCollector(b, "dhcp", newDhcpCollector)
 }

--- a/collector/diskdrive.go
+++ b/collector/diskdrive.go
@@ -12,10 +12,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("disk_drive", newDiskDriveInfoCollector)
-}
-
 const (
 	win32DiskQuery = "SELECT DeviceID, Model, Caption, Name, Partitions, Size, Status, Availability FROM WIN32_DiskDrive"
 )

--- a/collector/dns.go
+++ b/collector/dns.go
@@ -11,10 +11,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("dns", NewDNSCollector)
-}
-
 // A DNSCollector is a Prometheus collector for WMI Win32_PerfRawData_DNS_DNS metrics
 type DNSCollector struct {
 	ZoneTransferRequestsReceived  *prometheus.Desc

--- a/collector/dns.go
+++ b/collector/dns.go
@@ -37,8 +37,8 @@ type DNSCollector struct {
 	UnmatchedResponsesReceived    *prometheus.Desc
 }
 
-// NewDNSCollector ...
-func NewDNSCollector() (Collector, error) {
+// newDNSCollector ...
+func newDNSCollector() (Collector, error) {
 	const subsystem = "dns"
 	return &DNSCollector{
 		ZoneTransferRequestsReceived: prometheus.NewDesc(

--- a/collector/dns_test.go
+++ b/collector/dns_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkDNSCollector(b *testing.B) {
-	benchmarkCollector(b, "dns", NewDNSCollector)
+	benchmarkCollector(b, "dns", newDNSCollector)
 }

--- a/collector/exchange.go
+++ b/collector/exchange.go
@@ -13,20 +13,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	registerCollector("exchange", newExchangeCollector,
-		"MSExchange ADAccess Processes",
-		"MSExchangeTransport Queues",
-		"MSExchange HttpProxy",
-		"MSExchange ActiveSync",
-		"MSExchange Availability Service",
-		"MSExchange OWA",
-		"MSExchangeAutodiscover",
-		"MSExchange WorkloadManagement Workloads",
-		"MSExchange RpcClientAccess",
-	)
-}
-
 type exchangeCollector struct {
 	LDAPReadTime                            *prometheus.Desc
 	LDAPSearchTime                          *prometheus.Desc

--- a/collector/fsrmquota.go
+++ b/collector/fsrmquota.go
@@ -6,10 +6,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("fsrmquota", newFSRMQuotaCollector)
-}
-
 type FSRMQuotaCollector struct {
 	QuotasCount *prometheus.Desc
 	Path        *prometheus.Desc

--- a/collector/hyperv.go
+++ b/collector/hyperv.go
@@ -11,10 +11,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("hyperv", NewHyperVCollector)
-}
-
 // HyperVCollector is a Prometheus collector for hyper-v
 type HyperVCollector struct {
 	// Win32_PerfRawData_VmmsVirtualMachineStats_HyperVVirtualMachineHealthSummary

--- a/collector/hyperv.go
+++ b/collector/hyperv.go
@@ -126,8 +126,8 @@ type HyperVCollector struct {
 	VMMemoryRemovedMemory              *prometheus.Desc
 }
 
-// NewHyperVCollector ...
-func NewHyperVCollector() (Collector, error) {
+// newHyperVCollector ...
+func newHyperVCollector() (Collector, error) {
 	buildSubsystemName := func(component string) string { return "hyperv_" + component }
 	return &HyperVCollector{
 		HealthCritical: prometheus.NewDesc(

--- a/collector/hyperv_test.go
+++ b/collector/hyperv_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkHypervCollector(b *testing.B) {
-	benchmarkCollector(b, "hyperv", NewHyperVCollector)
+	benchmarkCollector(b, "hyperv", newHyperVCollector)
 }

--- a/collector/iis.go
+++ b/collector/iis.go
@@ -13,10 +13,6 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-func init() {
-	registerCollector("iis", NewIISCollector, "Web Service", "APP_POOL_WAS", "Web Service Cache", "W3SVC_W3WP")
-}
-
 var (
 	siteWhitelist = kingpin.Flag("collector.iis.site-whitelist", "Regexp of sites to whitelist. Site name must both match whitelist and not match blacklist to be included.").Default(".+").String()
 	siteBlacklist = kingpin.Flag("collector.iis.site-blacklist", "Regexp of sites to blacklist. Site name must both match whitelist and not match blacklist to be included.").String()

--- a/collector/iis.go
+++ b/collector/iis.go
@@ -191,7 +191,7 @@ type IISCollector struct {
 	iis_version simple_version
 }
 
-func NewIISCollector() (Collector, error) {
+func newIISCollector() (Collector, error) {
 	const subsystem = "iis"
 
 	return &IISCollector{

--- a/collector/iis_test.go
+++ b/collector/iis_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkIISCollector(b *testing.B) {
-	benchmarkCollector(b, "iis", NewIISCollector)
+	benchmarkCollector(b, "iis", newIISCollector)
 }

--- a/collector/init.go
+++ b/collector/init.go
@@ -1,0 +1,309 @@
+package collector
+
+// collectorInit represents the required initialisation config for a collector.
+type collectorInit struct {
+	// Name of collector to be initialised
+	name string
+	// Builder function for the collector
+	builder collectorBuilder
+	// Perflib counter names for the collector.
+	// These will be included in the Perflib scrape scope by the exporter.
+	perfCounterNames []string
+}
+
+func getCPUCollectorDeps() string {
+	// See below for 6.05 magic value
+	if getWindowsVersion() > 6.05 {
+		return "Processor Information"
+	}
+	return "Processor"
+
+}
+
+func getDFSRCollectorDeps() []string {
+	// Perflib sources are dynamic, depending on the enabled child collectors
+	var perflibDependencies []string
+	for _, source := range expandEnabledChildCollectors(*dfsrEnabledCollectors) {
+		perflibDependencies = append(perflibDependencies, dfsrGetPerfObjectName(source))
+	}
+
+	return perflibDependencies
+}
+
+var collectors = []collectorInit{
+	{
+		name:             "ad",
+		builder:          NewADCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "adcs",
+		builder:          adcsCollectorMethod,
+		perfCounterNames: []string{"Certification Authority"},
+	},
+	{
+		name:             "adfs",
+		builder:          newADFSCollector,
+		perfCounterNames: []string{"AD FS"},
+	},
+	{
+		name:             "cache",
+		builder:          newCacheCollector,
+		perfCounterNames: []string{"Cache"},
+	},
+	{
+		name:             "container",
+		builder:          NewContainerMetricsCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "cpu",
+		builder:          newCPUCollector,
+		perfCounterNames: []string{getCPUCollectorDeps()},
+	},
+	{
+		name:             "cpu_info",
+		builder:          newCpuInfoCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "cs",
+		builder:          NewCSCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "dfsr",
+		builder:          NewDFSRCollector,
+		perfCounterNames: getDFSRCollectorDeps(),
+	},
+	{
+		name:             "dhcp",
+		builder:          NewDhcpCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "disk_drive",
+		builder:          newDiskDriveInfoCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "dns",
+		builder:          NewDNSCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:    "exchange",
+		builder: newExchangeCollector,
+		perfCounterNames: []string{
+			"MSExchange ADAccess Processes",
+			"MSExchangeTransport Queues",
+			"MSExchange HttpProxy",
+			"MSExchange ActiveSync",
+			"MSExchange Availability Service",
+			"MSExchange OWA",
+			"MSExchangeAutodiscover",
+			"MSExchange WorkloadManagement Workloads",
+			"MSExchange RpcClientAccess",
+		},
+	},
+	{
+		name:             "fsrmquota",
+		builder:          newFSRMQuotaCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "hyperv",
+		builder:          NewHyperVCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:    "iis",
+		builder: NewIISCollector,
+		perfCounterNames: []string{"Web Service",
+			"APP_POOL_WAS",
+			"Web Service Cache",
+			"W3SVC_W3WP",
+		},
+	},
+	{
+		name:             "logical_disk",
+		builder:          NewLogicalDiskCollector,
+		perfCounterNames: []string{"LogicalDisk"},
+	},
+	{
+		name:             "logon",
+		builder:          NewLogonCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "memory",
+		builder:          NewMemoryCollector,
+		perfCounterNames: []string{"Memory"},
+	},
+	{
+		name:             "mscluster_cluster",
+		builder:          newMSCluster_ClusterCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "mscluster_network",
+		builder:          newMSCluster_NetworkCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "mscluster_node",
+		builder:          newMSCluster_NodeCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "mscluster_resource",
+		builder:          newMSCluster_ResourceCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "mscluster_resourcegroup",
+		builder:          newMSCluster_ResourceGroupCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "msmq",
+		builder:          NewMSMQCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "mssql",
+		builder:          NewMSSQLCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "net",
+		builder:          NewNetworkCollector,
+		perfCounterNames: []string{"Network Interface"},
+	},
+	{
+		name:             "netframework_clrexceptions",
+		builder:          NewNETFramework_NETCLRExceptionsCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "netframework_clrinterop",
+		builder:          NewNETFramework_NETCLRInteropCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "netframework_clrjit",
+		builder:          NewNETFramework_NETCLRJitCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "netframework_clrloading",
+		builder:          NewNETFramework_NETCLRLoadingCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "netframework_clrlocksandthreads",
+		builder:          NewNETFramework_NETCLRLocksAndThreadsCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "netframework_clrmemory",
+		builder:          NewNETFramework_NETCLRMemoryCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "netframework_clrremoting",
+		builder:          NewNETFramework_NETCLRRemotingCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "netframework_clrsecurity",
+		builder:          NewNETFramework_NETCLRSecurityCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "os",
+		builder:          NewOSCollector,
+		perfCounterNames: []string{"Paging File"},
+	},
+	{
+		name:             "process",
+		builder:          newProcessCollector,
+		perfCounterNames: []string{"Process"},
+	},
+	{
+		name:             "remote_fx",
+		builder:          NewRemoteFx,
+		perfCounterNames: []string{"RemoteFX Network"},
+	},
+	{
+		name:             "scheduled_task",
+		builder:          NewScheduledTask,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "service",
+		builder:          NewserviceCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "smtp",
+		builder:          NewSMTPCollector,
+		perfCounterNames: []string{"SMTP Server"},
+	},
+	{
+		name:             "system",
+		builder:          NewSystemCollector,
+		perfCounterNames: []string{"System"},
+	},
+	{
+		name:             "teradici_pcoip",
+		builder:          newTeradiciPcoipCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "tcp",
+		builder:          NewTCPCollector,
+		perfCounterNames: []string{"TCPv4"},
+	},
+	{
+		name:    "terminal_services",
+		builder: NewTerminalServicesCollector,
+		perfCounterNames: []string{
+			"Terminal Services",
+			"Terminal Services Session",
+			"Remote Desktop Connection Broker Counterset",
+		},
+	},
+	{
+		name:             "textfile",
+		builder:          NewTextFileCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "thermalzone",
+		builder:          NewThermalZoneCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "time",
+		builder:          newTimeCollector,
+		perfCounterNames: []string{"Windows Time Service"},
+	},
+	{
+		name:             "vmware",
+		builder:          NewVmwareCollector,
+		perfCounterNames: nil,
+	},
+	{
+		name:             "vmware_blast",
+		builder:          newVmwareBlastCollector,
+		perfCounterNames: nil,
+	},
+}
+
+// To be called by the exporter for collector initialisation
+func RegisterCollectors() {
+	for _, v := range collectors {
+		registerCollector(v.name, v.builder, v.perfCounterNames...)
+	}
+}

--- a/collector/init.go
+++ b/collector/init.go
@@ -33,7 +33,7 @@ func getDFSRCollectorDeps() []string {
 var collectors = []collectorInit{
 	{
 		name:             "ad",
-		builder:          NewADCollector,
+		builder:          newADCollector,
 		perfCounterNames: nil,
 	},
 	{
@@ -53,7 +53,7 @@ var collectors = []collectorInit{
 	},
 	{
 		name:             "container",
-		builder:          NewContainerMetricsCollector,
+		builder:          newContainerMetricsCollector,
 		perfCounterNames: nil,
 	},
 	{
@@ -68,17 +68,17 @@ var collectors = []collectorInit{
 	},
 	{
 		name:             "cs",
-		builder:          NewCSCollector,
+		builder:          newCSCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "dfsr",
-		builder:          NewDFSRCollector,
+		builder:          newDFSRCollector,
 		perfCounterNames: getDFSRCollectorDeps(),
 	},
 	{
 		name:             "dhcp",
-		builder:          NewDhcpCollector,
+		builder:          newDhcpCollector,
 		perfCounterNames: nil,
 	},
 	{
@@ -88,7 +88,7 @@ var collectors = []collectorInit{
 	},
 	{
 		name:             "dns",
-		builder:          NewDNSCollector,
+		builder:          newDNSCollector,
 		perfCounterNames: nil,
 	},
 	{
@@ -113,12 +113,12 @@ var collectors = []collectorInit{
 	},
 	{
 		name:             "hyperv",
-		builder:          NewHyperVCollector,
+		builder:          newHyperVCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:    "iis",
-		builder: NewIISCollector,
+		builder: newIISCollector,
 		perfCounterNames: []string{"Web Service",
 			"APP_POOL_WAS",
 			"Web Service Cache",
@@ -127,17 +127,17 @@ var collectors = []collectorInit{
 	},
 	{
 		name:             "logical_disk",
-		builder:          NewLogicalDiskCollector,
+		builder:          newLogicalDiskCollector,
 		perfCounterNames: []string{"LogicalDisk"},
 	},
 	{
 		name:             "logon",
-		builder:          NewLogonCollector,
+		builder:          newLogonCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "memory",
-		builder:          NewMemoryCollector,
+		builder:          newMemoryCollector,
 		perfCounterNames: []string{"Memory"},
 	},
 	{
@@ -167,62 +167,62 @@ var collectors = []collectorInit{
 	},
 	{
 		name:             "msmq",
-		builder:          NewMSMQCollector,
+		builder:          newMSMQCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "mssql",
-		builder:          NewMSSQLCollector,
+		builder:          newMSSQLCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "net",
-		builder:          NewNetworkCollector,
+		builder:          newNetworkCollector,
 		perfCounterNames: []string{"Network Interface"},
 	},
 	{
 		name:             "netframework_clrexceptions",
-		builder:          NewNETFramework_NETCLRExceptionsCollector,
+		builder:          newNETFramework_NETCLRExceptionsCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "netframework_clrinterop",
-		builder:          NewNETFramework_NETCLRInteropCollector,
+		builder:          newNETFramework_NETCLRInteropCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "netframework_clrjit",
-		builder:          NewNETFramework_NETCLRJitCollector,
+		builder:          newNETFramework_NETCLRJitCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "netframework_clrloading",
-		builder:          NewNETFramework_NETCLRLoadingCollector,
+		builder:          newNETFramework_NETCLRLoadingCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "netframework_clrlocksandthreads",
-		builder:          NewNETFramework_NETCLRLocksAndThreadsCollector,
+		builder:          newNETFramework_NETCLRLocksAndThreadsCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "netframework_clrmemory",
-		builder:          NewNETFramework_NETCLRMemoryCollector,
+		builder:          newNETFramework_NETCLRMemoryCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "netframework_clrremoting",
-		builder:          NewNETFramework_NETCLRRemotingCollector,
+		builder:          newNETFramework_NETCLRRemotingCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "netframework_clrsecurity",
-		builder:          NewNETFramework_NETCLRSecurityCollector,
+		builder:          newNETFramework_NETCLRSecurityCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "os",
-		builder:          NewOSCollector,
+		builder:          newOSCollector,
 		perfCounterNames: []string{"Paging File"},
 	},
 	{
@@ -232,27 +232,27 @@ var collectors = []collectorInit{
 	},
 	{
 		name:             "remote_fx",
-		builder:          NewRemoteFx,
+		builder:          newRemoteFx,
 		perfCounterNames: []string{"RemoteFX Network"},
 	},
 	{
 		name:             "scheduled_task",
-		builder:          NewScheduledTask,
+		builder:          newScheduledTask,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "service",
-		builder:          NewserviceCollector,
+		builder:          newserviceCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "smtp",
-		builder:          NewSMTPCollector,
+		builder:          newSMTPCollector,
 		perfCounterNames: []string{"SMTP Server"},
 	},
 	{
 		name:             "system",
-		builder:          NewSystemCollector,
+		builder:          newSystemCollector,
 		perfCounterNames: []string{"System"},
 	},
 	{
@@ -262,12 +262,12 @@ var collectors = []collectorInit{
 	},
 	{
 		name:             "tcp",
-		builder:          NewTCPCollector,
+		builder:          newTCPCollector,
 		perfCounterNames: []string{"TCPv4"},
 	},
 	{
 		name:    "terminal_services",
-		builder: NewTerminalServicesCollector,
+		builder: newTerminalServicesCollector,
 		perfCounterNames: []string{
 			"Terminal Services",
 			"Terminal Services Session",
@@ -276,12 +276,12 @@ var collectors = []collectorInit{
 	},
 	{
 		name:             "textfile",
-		builder:          NewTextFileCollector,
+		builder:          newTextFileCollector,
 		perfCounterNames: nil,
 	},
 	{
 		name:             "thermalzone",
-		builder:          NewThermalZoneCollector,
+		builder:          newThermalZoneCollector,
 		perfCounterNames: nil,
 	},
 	{
@@ -291,7 +291,7 @@ var collectors = []collectorInit{
 	},
 	{
 		name:             "vmware",
-		builder:          NewVmwareCollector,
+		builder:          newVmwareCollector,
 		perfCounterNames: nil,
 	},
 	{

--- a/collector/logical_disk.go
+++ b/collector/logical_disk.go
@@ -46,8 +46,8 @@ type LogicalDiskCollector struct {
 	volumeBlacklistPattern *regexp.Regexp
 }
 
-// NewLogicalDiskCollector ...
-func NewLogicalDiskCollector() (Collector, error) {
+// newLogicalDiskCollector ...
+func newLogicalDiskCollector() (Collector, error) {
 	const subsystem = "logical_disk"
 
 	return &LogicalDiskCollector{

--- a/collector/logical_disk.go
+++ b/collector/logical_disk.go
@@ -12,10 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	registerCollector("logical_disk", NewLogicalDiskCollector, "LogicalDisk")
-}
-
 var (
 	volumeWhitelist = kingpin.Flag(
 		"collector.logical_disk.volume-whitelist",

--- a/collector/logical_disk_test.go
+++ b/collector/logical_disk_test.go
@@ -9,5 +9,5 @@ func BenchmarkLogicalDiskCollector(b *testing.B) {
 	localVolumeWhitelist := ".+"
 	volumeWhitelist = &localVolumeWhitelist
 
-	benchmarkCollector(b, "logical_disk", NewLogicalDiskCollector)
+	benchmarkCollector(b, "logical_disk", newLogicalDiskCollector)
 }

--- a/collector/logon.go
+++ b/collector/logon.go
@@ -16,8 +16,8 @@ type LogonCollector struct {
 	LogonType *prometheus.Desc
 }
 
-// NewLogonCollector ...
-func NewLogonCollector() (Collector, error) {
+// newLogonCollector ...
+func newLogonCollector() (Collector, error) {
 	const subsystem = "logon"
 
 	return &LogonCollector{

--- a/collector/logon.go
+++ b/collector/logon.go
@@ -11,10 +11,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("logon", NewLogonCollector)
-}
-
 // A LogonCollector is a Prometheus collector for WMI metrics
 type LogonCollector struct {
 	LogonType *prometheus.Desc

--- a/collector/logon_test.go
+++ b/collector/logon_test.go
@@ -6,5 +6,5 @@ import (
 
 func BenchmarkLogonCollector(b *testing.B) {
 	// No context name required as collector source is WMI
-	benchmarkCollector(b, "", NewLogonCollector)
+	benchmarkCollector(b, "", newLogonCollector)
 }

--- a/collector/memory.go
+++ b/collector/memory.go
@@ -47,8 +47,8 @@ type MemoryCollector struct {
 	WriteCopiesTotal                *prometheus.Desc
 }
 
-// NewMemoryCollector ...
-func NewMemoryCollector() (Collector, error) {
+// newMemoryCollector ...
+func newMemoryCollector() (Collector, error) {
 	const subsystem = "memory"
 
 	return &MemoryCollector{

--- a/collector/memory.go
+++ b/collector/memory.go
@@ -11,10 +11,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	registerCollector("memory", NewMemoryCollector, "Memory")
-}
-
 // A MemoryCollector is a Prometheus collector for perflib Memory metrics
 type MemoryCollector struct {
 	AvailableBytes                  *prometheus.Desc

--- a/collector/memory_test.go
+++ b/collector/memory_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkMemoryCollector(b *testing.B) {
-	benchmarkCollector(b, "memory", NewMemoryCollector)
+	benchmarkCollector(b, "memory", newMemoryCollector)
 }

--- a/collector/mscluster_cluster.go
+++ b/collector/mscluster_cluster.go
@@ -5,10 +5,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("mscluster_cluster", newMSCluster_ClusterCollector)
-}
-
 // A MSCluster_ClusterCollector is a Prometheus collector for WMI MSCluster_Cluster metrics
 type MSCluster_ClusterCollector struct {
 	AddEvictDelay                           *prometheus.Desc

--- a/collector/mscluster_network.go
+++ b/collector/mscluster_network.go
@@ -5,10 +5,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("mscluster_network", newMSCluster_NetworkCollector)
-}
-
 // A MSCluster_NetworkCollector is a Prometheus collector for WMI MSCluster_Network metrics
 type MSCluster_NetworkCollector struct {
 	Characteristics *prometheus.Desc

--- a/collector/mscluster_node.go
+++ b/collector/mscluster_node.go
@@ -5,10 +5,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("mscluster_node", newMSCluster_NodeCollector)
-}
-
 // A MSCluster_NodeCollector is a Prometheus collector for WMI MSCluster_Node metrics
 type MSCluster_NodeCollector struct {
 	BuildNumber           *prometheus.Desc

--- a/collector/mscluster_resource.go
+++ b/collector/mscluster_resource.go
@@ -5,10 +5,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("mscluster_resource", newMSCluster_ResourceCollector)
-}
-
 // A MSCluster_ResourceCollector is a Prometheus collector for WMI MSCluster_Resource metrics
 type MSCluster_ResourceCollector struct {
 	Characteristics        *prometheus.Desc

--- a/collector/mscluster_resourcegroup.go
+++ b/collector/mscluster_resourcegroup.go
@@ -5,10 +5,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("mscluster_resourcegroup", newMSCluster_ResourceGroupCollector)
-}
-
 // A MSCluster_ResourceGroupCollector is a Prometheus collector for WMI MSCluster_ResourceGroup metrics
 type MSCluster_ResourceGroupCollector struct {
 	AutoFailbackType    *prometheus.Desc

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -12,10 +12,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("msmq", NewMSMQCollector)
-}
-
 var (
 	msmqWhereClause = kingpin.Flag("collector.msmq.msmq-where", "WQL 'where' clause to use in WMI metrics query. Limits the response to the msmqs you specify and reduces the size of the response.").String()
 )

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -27,7 +27,7 @@ type Win32_PerfRawData_MSMQ_MSMQQueueCollector struct {
 }
 
 // NewWin32_PerfRawData_MSMQ_MSMQQueueCollector ...
-func NewMSMQCollector() (Collector, error) {
+func newMSMQCollector() (Collector, error) {
 	const subsystem = "msmq"
 
 	if *msmqWhereClause == "" {

--- a/collector/msmq_test.go
+++ b/collector/msmq_test.go
@@ -6,5 +6,5 @@ import (
 
 func BenchmarkMsmqCollector(b *testing.B) {
 	// No context name required as collector source is WMI
-	benchmarkCollector(b, "", NewMSMQCollector)
+	benchmarkCollector(b, "", newMSMQCollector)
 }

--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -129,10 +129,6 @@ func mssqlGetPerfObjectName(sqlInstance string, collector string) string {
 	return (prefix + suffix)
 }
 
-func init() {
-	registerCollector("mssql", NewMSSQLCollector)
-}
-
 // A MSSQLCollector is a Prometheus collector for various WMI Win32_PerfRawData_MSSQLSERVER_* metrics
 type MSSQLCollector struct {
 	// meta

--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -401,8 +401,8 @@ type MSSQLCollector struct {
 	mssqlChildCollectorFailure int
 }
 
-// NewMSSQLCollector ...
-func NewMSSQLCollector() (Collector, error) {
+// newMSSQLCollector ...
+func newMSSQLCollector() (Collector, error) {
 
 	const subsystem = "mssql"
 

--- a/collector/mssql_test.go
+++ b/collector/mssql_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkMSSQLCollector(b *testing.B) {
-	benchmarkCollector(b, "mssql", NewMSSQLCollector)
+	benchmarkCollector(b, "mssql", newMSSQLCollector)
 }

--- a/collector/net.go
+++ b/collector/net.go
@@ -12,10 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	registerCollector("net", NewNetworkCollector, "Network Interface")
-}
-
 var (
 	nicWhitelist = kingpin.Flag(
 		"collector.net.nic-whitelist",

--- a/collector/net.go
+++ b/collector/net.go
@@ -44,8 +44,8 @@ type NetworkCollector struct {
 	nicBlacklistPattern *regexp.Regexp
 }
 
-// NewNetworkCollector ...
-func NewNetworkCollector() (Collector, error) {
+// newNetworkCollector ...
+func newNetworkCollector() (Collector, error) {
 	const subsystem = "net"
 
 	return &NetworkCollector{

--- a/collector/net_test.go
+++ b/collector/net_test.go
@@ -23,5 +23,5 @@ func BenchmarkNetCollector(b *testing.B) {
 	// Whitelist is not set in testing context (kingpin flags not parsed), causing the collector to skip all interfaces.
 	localNicWhitelist := ".+"
 	nicWhitelist = &localNicWhitelist
-	benchmarkCollector(b, "net", NewNetworkCollector)
+	benchmarkCollector(b, "net", newNetworkCollector)
 }

--- a/collector/netframework_clrexceptions.go
+++ b/collector/netframework_clrexceptions.go
@@ -9,10 +9,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("netframework_clrexceptions", NewNETFramework_NETCLRExceptionsCollector)
-}
-
 // A NETFramework_NETCLRExceptionsCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRExceptions metrics
 type NETFramework_NETCLRExceptionsCollector struct {
 	NumberofExcepsThrown *prometheus.Desc

--- a/collector/netframework_clrexceptions.go
+++ b/collector/netframework_clrexceptions.go
@@ -17,8 +17,8 @@ type NETFramework_NETCLRExceptionsCollector struct {
 	ThrowToCatchDepth    *prometheus.Desc
 }
 
-// NewNETFramework_NETCLRExceptionsCollector ...
-func NewNETFramework_NETCLRExceptionsCollector() (Collector, error) {
+// newNETFramework_NETCLRExceptionsCollector ...
+func newNETFramework_NETCLRExceptionsCollector() (Collector, error) {
 	const subsystem = "netframework_clrexceptions"
 	return &NETFramework_NETCLRExceptionsCollector{
 		NumberofExcepsThrown: prometheus.NewDesc(

--- a/collector/netframework_clrexceptions_test.go
+++ b/collector/netframework_clrexceptions_test.go
@@ -6,5 +6,5 @@ import (
 
 func BenchmarkNetFrameworkNETCLRExceptionsCollector(b *testing.B) {
 	// No context name required as collector source is WMI
-	benchmarkCollector(b, "", NewNETFramework_NETCLRExceptionsCollector)
+	benchmarkCollector(b, "", newNETFramework_NETCLRExceptionsCollector)
 }

--- a/collector/netframework_clrinterop.go
+++ b/collector/netframework_clrinterop.go
@@ -9,10 +9,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("netframework_clrinterop", NewNETFramework_NETCLRInteropCollector)
-}
-
 // A NETFramework_NETCLRInteropCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRInterop metrics
 type NETFramework_NETCLRInteropCollector struct {
 	NumberofCCWs        *prometheus.Desc

--- a/collector/netframework_clrinterop.go
+++ b/collector/netframework_clrinterop.go
@@ -16,8 +16,8 @@ type NETFramework_NETCLRInteropCollector struct {
 	NumberofStubs       *prometheus.Desc
 }
 
-// NewNETFramework_NETCLRInteropCollector ...
-func NewNETFramework_NETCLRInteropCollector() (Collector, error) {
+// newNETFramework_NETCLRInteropCollector ...
+func newNETFramework_NETCLRInteropCollector() (Collector, error) {
 	const subsystem = "netframework_clrinterop"
 	return &NETFramework_NETCLRInteropCollector{
 		NumberofCCWs: prometheus.NewDesc(

--- a/collector/netframework_clrinterop_test.go
+++ b/collector/netframework_clrinterop_test.go
@@ -6,5 +6,5 @@ import (
 
 func BenchmarkNETFrameworkNETCLRInteropCollector(b *testing.B) {
 	// No context name required as collector source is WMI
-	benchmarkCollector(b, "", NewNETFramework_NETCLRInteropCollector)
+	benchmarkCollector(b, "", newNETFramework_NETCLRInteropCollector)
 }

--- a/collector/netframework_clrjit.go
+++ b/collector/netframework_clrjit.go
@@ -9,10 +9,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("netframework_clrjit", NewNETFramework_NETCLRJitCollector)
-}
-
 // A NETFramework_NETCLRJitCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRJit metrics
 type NETFramework_NETCLRJitCollector struct {
 	NumberofMethodsJitted      *prometheus.Desc

--- a/collector/netframework_clrjit.go
+++ b/collector/netframework_clrjit.go
@@ -17,8 +17,8 @@ type NETFramework_NETCLRJitCollector struct {
 	TotalNumberofILBytesJitted *prometheus.Desc
 }
 
-// NewNETFramework_NETCLRJitCollector ...
-func NewNETFramework_NETCLRJitCollector() (Collector, error) {
+// newNETFramework_NETCLRJitCollector ...
+func newNETFramework_NETCLRJitCollector() (Collector, error) {
 	const subsystem = "netframework_clrjit"
 	return &NETFramework_NETCLRJitCollector{
 		NumberofMethodsJitted: prometheus.NewDesc(

--- a/collector/netframework_clrjit_test.go
+++ b/collector/netframework_clrjit_test.go
@@ -6,5 +6,5 @@ import (
 
 func BenchmarkNETFrameworkNETCLRJitCollector(b *testing.B) {
 	// No context name required as collector source is WMI
-	benchmarkCollector(b, "", NewNETFramework_NETCLRJitCollector)
+	benchmarkCollector(b, "", newNETFramework_NETCLRJitCollector)
 }

--- a/collector/netframework_clrloading.go
+++ b/collector/netframework_clrloading.go
@@ -22,8 +22,8 @@ type NETFramework_NETCLRLoadingCollector struct {
 	TotalNumberofLoadFailures *prometheus.Desc
 }
 
-// NewNETFramework_NETCLRLoadingCollector ...
-func NewNETFramework_NETCLRLoadingCollector() (Collector, error) {
+// newNETFramework_NETCLRLoadingCollector ...
+func newNETFramework_NETCLRLoadingCollector() (Collector, error) {
 	const subsystem = "netframework_clrloading"
 	return &NETFramework_NETCLRLoadingCollector{
 		BytesinLoaderHeap: prometheus.NewDesc(

--- a/collector/netframework_clrloading.go
+++ b/collector/netframework_clrloading.go
@@ -9,10 +9,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("netframework_clrloading", NewNETFramework_NETCLRLoadingCollector)
-}
-
 // A NETFramework_NETCLRLoadingCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRLoading metrics
 type NETFramework_NETCLRLoadingCollector struct {
 	BytesinLoaderHeap         *prometheus.Desc

--- a/collector/netframework_clrloading_test.go
+++ b/collector/netframework_clrloading_test.go
@@ -6,5 +6,5 @@ import (
 
 func BenchmarkNETFrameworkNETCLRLoadingCollector(b *testing.B) {
 	// No context name required as collector source is WMI
-	benchmarkCollector(b, "", NewNETFramework_NETCLRLoadingCollector)
+	benchmarkCollector(b, "", newNETFramework_NETCLRLoadingCollector)
 }

--- a/collector/netframework_clrlocksandthreads.go
+++ b/collector/netframework_clrlocksandthreads.go
@@ -9,10 +9,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("netframework_clrlocksandthreads", NewNETFramework_NETCLRLocksAndThreadsCollector)
-}
-
 // A NETFramework_NETCLRLocksAndThreadsCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRLocksAndThreads metrics
 type NETFramework_NETCLRLocksAndThreadsCollector struct {
 	CurrentQueueLength               *prometheus.Desc

--- a/collector/netframework_clrlocksandthreads.go
+++ b/collector/netframework_clrlocksandthreads.go
@@ -20,8 +20,8 @@ type NETFramework_NETCLRLocksAndThreadsCollector struct {
 	TotalNumberofContentions         *prometheus.Desc
 }
 
-// NewNETFramework_NETCLRLocksAndThreadsCollector ...
-func NewNETFramework_NETCLRLocksAndThreadsCollector() (Collector, error) {
+// newNETFramework_NETCLRLocksAndThreadsCollector ...
+func newNETFramework_NETCLRLocksAndThreadsCollector() (Collector, error) {
 	const subsystem = "netframework_clrlocksandthreads"
 	return &NETFramework_NETCLRLocksAndThreadsCollector{
 		CurrentQueueLength: prometheus.NewDesc(

--- a/collector/netframework_clrlocksandthreads_test.go
+++ b/collector/netframework_clrlocksandthreads_test.go
@@ -6,5 +6,5 @@ import (
 
 func BenchmarkNETFrameworkNETCLRLocksAndThreadsCollector(b *testing.B) {
 	// No context name required as collector source is WMI
-	benchmarkCollector(b, "", NewNETFramework_NETCLRLocksAndThreadsCollector)
+	benchmarkCollector(b, "", newNETFramework_NETCLRLocksAndThreadsCollector)
 }

--- a/collector/netframework_clrmemory.go
+++ b/collector/netframework_clrmemory.go
@@ -28,8 +28,8 @@ type NETFramework_NETCLRMemoryCollector struct {
 	PromotedMemoryfromGen1             *prometheus.Desc
 }
 
-// NewNETFramework_NETCLRMemoryCollector ...
-func NewNETFramework_NETCLRMemoryCollector() (Collector, error) {
+// newNETFramework_NETCLRMemoryCollector ...
+func newNETFramework_NETCLRMemoryCollector() (Collector, error) {
 	const subsystem = "netframework_clrmemory"
 	return &NETFramework_NETCLRMemoryCollector{
 		AllocatedBytes: prometheus.NewDesc(

--- a/collector/netframework_clrmemory.go
+++ b/collector/netframework_clrmemory.go
@@ -9,10 +9,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("netframework_clrmemory", NewNETFramework_NETCLRMemoryCollector)
-}
-
 // A NETFramework_NETCLRMemoryCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRMemory metrics
 type NETFramework_NETCLRMemoryCollector struct {
 	AllocatedBytes                     *prometheus.Desc

--- a/collector/netframework_clrmemory_test.go
+++ b/collector/netframework_clrmemory_test.go
@@ -6,5 +6,5 @@ import (
 
 func BenchmarkNETFrameworkNETCLRMemoryCollector(b *testing.B) {
 	// No context name required as collector source is WMI
-	benchmarkCollector(b, "", NewNETFramework_NETCLRMemoryCollector)
+	benchmarkCollector(b, "", newNETFramework_NETCLRMemoryCollector)
 }

--- a/collector/netframework_clrremoting.go
+++ b/collector/netframework_clrremoting.go
@@ -9,10 +9,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("netframework_clrremoting", NewNETFramework_NETCLRRemotingCollector)
-}
-
 // A NETFramework_NETCLRRemotingCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRRemoting metrics
 type NETFramework_NETCLRRemotingCollector struct {
 	Channels                  *prometheus.Desc

--- a/collector/netframework_clrremoting.go
+++ b/collector/netframework_clrremoting.go
@@ -19,8 +19,8 @@ type NETFramework_NETCLRRemotingCollector struct {
 	TotalRemoteCalls          *prometheus.Desc
 }
 
-// NewNETFramework_NETCLRRemotingCollector ...
-func NewNETFramework_NETCLRRemotingCollector() (Collector, error) {
+// newNETFramework_NETCLRRemotingCollector ...
+func newNETFramework_NETCLRRemotingCollector() (Collector, error) {
 	const subsystem = "netframework_clrremoting"
 	return &NETFramework_NETCLRRemotingCollector{
 		Channels: prometheus.NewDesc(

--- a/collector/netframework_clrremoting_test.go
+++ b/collector/netframework_clrremoting_test.go
@@ -6,5 +6,5 @@ import (
 
 func BenchmarkNETFrameworkNETCLRRemotingCollector(b *testing.B) {
 	// No context name required as collector source is WMI
-	benchmarkCollector(b, "", NewNETFramework_NETCLRRemotingCollector)
+	benchmarkCollector(b, "", newNETFramework_NETCLRRemotingCollector)
 }

--- a/collector/netframework_clrsecurity.go
+++ b/collector/netframework_clrsecurity.go
@@ -17,8 +17,8 @@ type NETFramework_NETCLRSecurityCollector struct {
 	TotalRuntimeChecks   *prometheus.Desc
 }
 
-// NewNETFramework_NETCLRSecurityCollector ...
-func NewNETFramework_NETCLRSecurityCollector() (Collector, error) {
+// newNETFramework_NETCLRSecurityCollector ...
+func newNETFramework_NETCLRSecurityCollector() (Collector, error) {
 	const subsystem = "netframework_clrsecurity"
 	return &NETFramework_NETCLRSecurityCollector{
 		NumberLinkTimeChecks: prometheus.NewDesc(

--- a/collector/netframework_clrsecurity.go
+++ b/collector/netframework_clrsecurity.go
@@ -9,10 +9,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("netframework_clrsecurity", NewNETFramework_NETCLRSecurityCollector)
-}
-
 // A NETFramework_NETCLRSecurityCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRSecurity metrics
 type NETFramework_NETCLRSecurityCollector struct {
 	NumberLinkTimeChecks *prometheus.Desc

--- a/collector/netframework_clrsecurity_test.go
+++ b/collector/netframework_clrsecurity_test.go
@@ -6,5 +6,5 @@ import (
 
 func BenchmarkNETFrameworkNETCLRSecurityCollector(b *testing.B) {
 	// No context name required as collector source is WMI
-	benchmarkCollector(b, "", NewNETFramework_NETCLRSecurityCollector)
+	benchmarkCollector(b, "", newNETFramework_NETCLRSecurityCollector)
 }

--- a/collector/os.go
+++ b/collector/os.go
@@ -17,10 +17,6 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-func init() {
-	registerCollector("os", NewOSCollector, "Paging File")
-}
-
 // A OSCollector is a Prometheus collector for WMI metrics
 type OSCollector struct {
 	OSInformation           *prometheus.Desc

--- a/collector/os.go
+++ b/collector/os.go
@@ -40,8 +40,8 @@ type pagingFileCounter struct {
 	UsagePeak float64 `perflib:"% Usage Peak"`
 }
 
-// NewOSCollector ...
-func NewOSCollector() (Collector, error) {
+// newOSCollector ...
+func newOSCollector() (Collector, error) {
 	const subsystem = "os"
 
 	return &OSCollector{

--- a/collector/os_test.go
+++ b/collector/os_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkOSCollector(b *testing.B) {
-	benchmarkCollector(b, "os", NewOSCollector)
+	benchmarkCollector(b, "os", newOSCollector)
 }

--- a/collector/process.go
+++ b/collector/process.go
@@ -15,10 +15,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("process", newProcessCollector, "Process")
-}
-
 var (
 	processWhitelist = kingpin.Flag(
 		"collector.process.whitelist",

--- a/collector/remote_fx.go
+++ b/collector/remote_fx.go
@@ -10,10 +10,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	registerCollector("remote_fx", NewRemoteFx, "RemoteFX Network", "RemoteFX Graphics")
-}
-
 // A RemoteFxNetworkCollector is a Prometheus collector for
 // WMI Win32_PerfRawData_Counters_RemoteFXNetwork & Win32_PerfRawData_Counters_RemoteFXGraphics metrics
 // https://wutils.com/wmi/root/cimv2/win32_perfrawdata_counters_remotefxnetwork/

--- a/collector/remote_fx.go
+++ b/collector/remote_fx.go
@@ -38,8 +38,8 @@ type RemoteFxCollector struct {
 	SourceFramesPerSecond                       *prometheus.Desc
 }
 
-// NewRemoteFx ...
-func NewRemoteFx() (Collector, error) {
+// newRemoteFx ...
+func newRemoteFx() (Collector, error) {
 	const subsystem = "remote_fx"
 	return &RemoteFxCollector{
 		// net

--- a/collector/remote_fx_test.go
+++ b/collector/remote_fx_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkRemoteFXCollector(b *testing.B) {
-	benchmarkCollector(b, "remote_fx", NewRemoteFx)
+	benchmarkCollector(b, "remote_fx", newRemoteFx)
 }

--- a/collector/scheduled_task.go
+++ b/collector/scheduled_task.go
@@ -63,8 +63,8 @@ type ScheduledTask struct {
 
 type ScheduledTasks []ScheduledTask
 
-// NewScheduledTask ...
-func NewScheduledTask() (Collector, error) {
+// newScheduledTask ...
+func newScheduledTask() (Collector, error) {
 	const subsystem = "scheduled_task"
 
 	runtime.LockOSThread()

--- a/collector/scheduled_task.go
+++ b/collector/scheduled_task.go
@@ -63,10 +63,6 @@ type ScheduledTask struct {
 
 type ScheduledTasks []ScheduledTask
 
-func init() {
-	registerCollector("scheduled_task", NewScheduledTask)
-}
-
 // NewScheduledTask ...
 func NewScheduledTask() (Collector, error) {
 	const subsystem = "scheduled_task"

--- a/collector/scheduled_task_test.go
+++ b/collector/scheduled_task_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkScheduledTaskCollector(b *testing.B) {
-	benchmarkCollector(b, "scheduled_task", NewScheduledTask)
+	benchmarkCollector(b, "scheduled_task", newScheduledTask)
 }

--- a/collector/service.go
+++ b/collector/service.go
@@ -16,10 +16,6 @@ import (
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
-func init() {
-	registerCollector("service", NewserviceCollector)
-}
-
 var (
 	serviceWhereClause = kingpin.Flag(
 		"collector.service.services-where",

--- a/collector/service.go
+++ b/collector/service.go
@@ -37,8 +37,8 @@ type serviceCollector struct {
 	queryWhereClause string
 }
 
-// NewserviceCollector ...
-func NewserviceCollector() (Collector, error) {
+// newserviceCollector ...
+func newserviceCollector() (Collector, error) {
 	const subsystem = "service"
 
 	if *serviceWhereClause == "" {

--- a/collector/service_test.go
+++ b/collector/service_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkServiceCollector(b *testing.B) {
-	benchmarkCollector(b, "service", NewserviceCollector)
+	benchmarkCollector(b, "service", newserviceCollector)
 }

--- a/collector/smtp.go
+++ b/collector/smtp.go
@@ -64,7 +64,7 @@ type SMTPCollector struct {
 	serverBlacklistPattern *regexp.Regexp
 }
 
-func NewSMTPCollector() (Collector, error) {
+func newSMTPCollector() (Collector, error) {
 	log.Info("smtp collector is in an experimental state! Metrics for this collector have not been tested.")
 	const subsystem = "smtp"
 

--- a/collector/smtp.go
+++ b/collector/smtp.go
@@ -11,10 +11,6 @@ import (
 	"regexp"
 )
 
-func init() {
-	registerCollector("smtp", NewSMTPCollector, "SMTP Server")
-}
-
 var (
 	serverWhitelist = kingpin.Flag("collector.smtp.server-whitelist", "Regexp of virtual servers to whitelist. Server name must both match whitelist and not match blacklist to be included.").Default(".+").String()
 	serverBlacklist = kingpin.Flag("collector.smtp.server-blacklist", "Regexp of virtual servers to blacklist. Server name must both match whitelist and not match blacklist to be included.").String()

--- a/collector/smtp_test.go
+++ b/collector/smtp_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkSmtpCollector(b *testing.B) {
-	benchmarkCollector(b, "smtp", NewSMTPCollector)
+	benchmarkCollector(b, "smtp", newSMTPCollector)
 }

--- a/collector/system.go
+++ b/collector/system.go
@@ -18,8 +18,8 @@ type SystemCollector struct {
 	Threads                  *prometheus.Desc
 }
 
-// NewSystemCollector ...
-func NewSystemCollector() (Collector, error) {
+// newSystemCollector ...
+func newSystemCollector() (Collector, error) {
 	const subsystem = "system"
 
 	return &SystemCollector{

--- a/collector/system.go
+++ b/collector/system.go
@@ -8,10 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	registerCollector("system", NewSystemCollector, "System")
-}
-
 // A SystemCollector is a Prometheus collector for WMI metrics
 type SystemCollector struct {
 	ContextSwitchesTotal     *prometheus.Desc

--- a/collector/system_test.go
+++ b/collector/system_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkSystemCollector(b *testing.B) {
-	benchmarkCollector(b, "system", NewSystemCollector)
+	benchmarkCollector(b, "system", newSystemCollector)
 }

--- a/collector/tcp.go
+++ b/collector/tcp.go
@@ -8,10 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	registerCollector("tcp", NewTCPCollector, "TCPv4", "TCPv6")
-}
-
 // A TCPCollector is a Prometheus collector for WMI Win32_PerfRawData_Tcpip_TCPv{4,6} metrics
 type TCPCollector struct {
 	ConnectionFailures         *prometheus.Desc

--- a/collector/tcp.go
+++ b/collector/tcp.go
@@ -21,8 +21,8 @@ type TCPCollector struct {
 	SegmentsSentTotal          *prometheus.Desc
 }
 
-// NewTCPCollector ...
-func NewTCPCollector() (Collector, error) {
+// newTCPCollector ...
+func newTCPCollector() (Collector, error) {
 	const subsystem = "tcp"
 
 	return &TCPCollector{

--- a/collector/tcp_test.go
+++ b/collector/tcp_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkTCPCollector(b *testing.B) {
-	benchmarkCollector(b, "tcp", NewTCPCollector)
+	benchmarkCollector(b, "tcp", newTCPCollector)
 }

--- a/collector/teradici_pcoip.go
+++ b/collector/teradici_pcoip.go
@@ -11,10 +11,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("teradici_pcoip", newTeradiciPcoipCollector)
-}
-
 // A teradiciPcoipCollector is a Prometheus collector for WMI metrics:
 // win32_PerfRawData_TeradiciPerf_PCoIPSessionAudioStatistics
 // win32_PerfRawData_TeradiciPerf_PCoIPSessionGeneralStatistics

--- a/collector/terminal_services.go
+++ b/collector/terminal_services.go
@@ -14,10 +14,6 @@ import (
 
 const ConnectionBrokerFeatureID uint32 = 133
 
-func init() {
-	registerCollector("terminal_services", NewTerminalServicesCollector, "Terminal Services", "Terminal Services Session", "Remote Desktop Connection Broker Counterset")
-}
-
 var (
 	connectionBrokerEnabled = isConnectionBrokerServer()
 )

--- a/collector/terminal_services.go
+++ b/collector/terminal_services.go
@@ -61,8 +61,8 @@ type TerminalServicesCollector struct {
 	WorkingSetPeak              *prometheus.Desc
 }
 
-// NewTerminalServicesCollector ...
-func NewTerminalServicesCollector() (Collector, error) {
+// newTerminalServicesCollector ...
+func newTerminalServicesCollector() (Collector, error) {
 	const subsystem = "terminal_services"
 	return &TerminalServicesCollector{
 		LocalSessionCount: prometheus.NewDesc(

--- a/collector/terminal_services_test.go
+++ b/collector/terminal_services_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkTerminalServicesCollector(b *testing.B) {
-	benchmarkCollector(b, "terminal_services", NewTerminalServicesCollector)
+	benchmarkCollector(b, "terminal_services", newTerminalServicesCollector)
 }

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -55,9 +55,9 @@ type textFileCollector struct {
 	mtime *float64
 }
 
-// NewTextFileCollector returns a new Collector exposing metrics read from files
+// newTextFileCollector returns a new Collector exposing metrics read from files
 // in the given textfile directory.
-func NewTextFileCollector() (Collector, error) {
+func newTextFileCollector() (Collector, error) {
 	return &textFileCollector{
 		path: *textFileDirectory,
 	}, nil

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -55,10 +55,6 @@ type textFileCollector struct {
 	mtime *float64
 }
 
-func init() {
-	registerCollector("textfile", NewTextFileCollector)
-}
-
 // NewTextFileCollector returns a new Collector exposing metrics read from files
 // in the given textfile directory.
 func NewTextFileCollector() (Collector, error) {

--- a/collector/thermalzone.go
+++ b/collector/thermalzone.go
@@ -8,10 +8,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("thermalzone", NewThermalZoneCollector)
-}
-
 // A thermalZoneCollector is a Prometheus collector for WMI Win32_PerfRawData_Counters_ThermalZoneInformation metrics
 type thermalZoneCollector struct {
 	PercentPassiveLimit *prometheus.Desc

--- a/collector/thermalzone.go
+++ b/collector/thermalzone.go
@@ -15,8 +15,8 @@ type thermalZoneCollector struct {
 	ThrottleReasons     *prometheus.Desc
 }
 
-// NewThermalZoneCollector ...
-func NewThermalZoneCollector() (Collector, error) {
+// newThermalZoneCollector ...
+func newThermalZoneCollector() (Collector, error) {
 	const subsystem = "thermalzone"
 	return &thermalZoneCollector{
 		Temperature: prometheus.NewDesc(

--- a/collector/thermalzone_test.go
+++ b/collector/thermalzone_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkThermalZoneCollector(b *testing.B) {
-	benchmarkCollector(b, "thermalzone", NewThermalZoneCollector)
+	benchmarkCollector(b, "thermalzone", newThermalZoneCollector)
 }

--- a/collector/time.go
+++ b/collector/time.go
@@ -10,10 +10,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func init() {
-	registerCollector("time", newTimeCollector, "Windows Time Service")
-}
-
 // TimeCollector is a Prometheus collector for Perflib counter metrics
 type TimeCollector struct {
 	ClockFrequencyAdjustmentPPBTotal *prometheus.Desc

--- a/collector/vmware.go
+++ b/collector/vmware.go
@@ -35,8 +35,8 @@ type VmwareCollector struct {
 	HostProcessorSpeedMHz *prometheus.Desc
 }
 
-// NewVmwareCollector constructs a new VmwareCollector
-func NewVmwareCollector() (Collector, error) {
+// newVmwareCollector constructs a new VmwareCollector
+func newVmwareCollector() (Collector, error) {
 	const subsystem = "vmware"
 	return &VmwareCollector{
 		MemActive: prometheus.NewDesc(

--- a/collector/vmware.go
+++ b/collector/vmware.go
@@ -11,10 +11,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("vmware", NewVmwareCollector)
-}
-
 // A VmwareCollector is a Prometheus collector for WMI Win32_PerfRawData_vmGuestLib_VMem/Win32_PerfRawData_vmGuestLib_VCPU metrics
 type VmwareCollector struct {
 	MemActive      *prometheus.Desc

--- a/collector/vmware_blast.go
+++ b/collector/vmware_blast.go
@@ -9,10 +9,6 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-func init() {
-	registerCollector("vmware_blast", newVmwareBlastCollector)
-}
-
 // A vmwareBlastCollector is a Prometheus collector for WMI metrics:
 // win32_PerfRawData_Counters_VMwareBlastAudioCounters
 // win32_PerfRawData_Counters_VMwareBlastCDRCounters

--- a/collector/vmware_test.go
+++ b/collector/vmware_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func BenchmarkVmwareCollector(b *testing.B) {
-	benchmarkCollector(b, "vmware", NewVmwareCollector)
+	benchmarkCollector(b, "vmware", newVmwareCollector)
 }

--- a/exporter.go
+++ b/exporter.go
@@ -333,6 +333,9 @@ func main() {
 
 	initWbem()
 
+	// Initialize collectors before loading
+	collector.RegisterCollectors()
+
 	collectors, err := loadCollectors(*enabledCollectors)
 	if err != nil {
 		log.Fatalf("Couldn't load collectors: %s", err)


### PR DESCRIPTION
Behaviour of init functions has been centralised in `collector/init.go`,
and can be called during exporter startup. This allows the exporter to
control the timing of collector initialisation, rather than relying on
the import & `init()` method.

This should reduce unexpected behaviour arising from the use of
`init()`, such as #551.