### PR TITLE
Added quote information for absolute paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This enables the additional process and container collectors on top of the defau
 
 ### Using a configuration file
 
-YAML configuration files can be specified with the `--config.file` flag. E.G. `.\windows_exporter.exe --config.file=config.yml`
+YAML configuration files can be specified with the `--config.file` flag. e.g. `.\windows_exporter.exe --config.file=config.yml`. If you are using the absolute path, make sure to quote the path, e.g. `.\windows_exporter.exe --config.file="C:\Program Files\windows_exporter\config.yml"`
 
 ```yaml
 collectors:


### PR DESCRIPTION
This had me running in circles because `ioutil.ReadFile` did not read the local file for me when running as a service (i.e. `config.yml` in the same folder as the `windows_exporter.exe`). I had to use absolute paths and additionally quote them.