### PR TITLE
chore(deps): Update wmi to v1.2.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -94,7 +94,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.51.2
           args: "--timeout=5m"
 
       # golangci-lint action doesn't always provide helpful output, so re-run without the action for

--- a/collector/ad.go
+++ b/collector/ad.go
@@ -6,9 +6,9 @@ package collector
 import (
 	"errors"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/cpu_info.go
+++ b/collector/cpu_info.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/diskdrive.go
+++ b/collector/diskdrive.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/dns.go
+++ b/collector/dns.go
@@ -6,9 +6,9 @@ package collector
 import (
 	"errors"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/fsrmquota.go
+++ b/collector/fsrmquota.go
@@ -1,9 +1,9 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/hyperv.go
+++ b/collector/hyperv.go
@@ -6,9 +6,9 @@ package collector
 import (
 	"strings"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/logon.go
+++ b/collector/logon.go
@@ -6,9 +6,9 @@ package collector
 import (
 	"errors"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/mscluster_cluster.go
+++ b/collector/mscluster_cluster.go
@@ -1,8 +1,8 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {
@@ -560,7 +560,6 @@ func newMSCluster_ClusterCollector() (Collector, error) {
 
 // MSCluster_Cluster docs:
 // - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/cluswmi/mscluster-cluster
-//
 type MSCluster_Cluster struct {
 	Name string
 

--- a/collector/mscluster_network.go
+++ b/collector/mscluster_network.go
@@ -1,8 +1,8 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {
@@ -56,7 +56,6 @@ func newMSCluster_NetworkCollector() (Collector, error) {
 
 // MSCluster_Network docs:
 // - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/cluswmi/mscluster-network
-//
 type MSCluster_Network struct {
 	Name string
 

--- a/collector/mscluster_node.go
+++ b/collector/mscluster_node.go
@@ -1,8 +1,8 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {
@@ -119,7 +119,6 @@ func newMSCluster_NodeCollector() (Collector, error) {
 
 // MSCluster_Node docs:
 // - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/cluswmi/mscluster-node
-//
 type MSCluster_Node struct {
 	Name string
 

--- a/collector/mscluster_resource.go
+++ b/collector/mscluster_resource.go
@@ -1,8 +1,8 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {
@@ -133,7 +133,6 @@ func newMSCluster_ResourceCollector() (Collector, error) {
 
 // MSCluster_Resource docs:
 // - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/cluswmi/mscluster-resource
-//
 type MSCluster_Resource struct {
 	Name       string
 	Type       string

--- a/collector/mscluster_resourcegroup.go
+++ b/collector/mscluster_resourcegroup.go
@@ -1,8 +1,8 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {
@@ -114,7 +114,6 @@ func newMSCluster_ResourceGroupCollector() (Collector, error) {
 
 // MSCluster_ResourceGroup docs:
 // - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/cluswmi/mscluster-resourcegroup
-//
 type MSCluster_ResourceGroup struct {
 	Name string
 

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -6,9 +6,9 @@ package collector
 import (
 	"strings"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/collector/netframework_clrexceptions.go
+++ b/collector/netframework_clrexceptions.go
@@ -4,9 +4,9 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/netframework_clrinterop.go
+++ b/collector/netframework_clrinterop.go
@@ -4,9 +4,9 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/netframework_clrjit.go
+++ b/collector/netframework_clrjit.go
@@ -4,9 +4,9 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/netframework_clrloading.go
+++ b/collector/netframework_clrloading.go
@@ -4,9 +4,9 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/netframework_clrlocksandthreads.go
+++ b/collector/netframework_clrlocksandthreads.go
@@ -4,9 +4,9 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/netframework_clrmemory.go
+++ b/collector/netframework_clrmemory.go
@@ -4,9 +4,9 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/netframework_clrremoting.go
+++ b/collector/netframework_clrremoting.go
@@ -4,9 +4,9 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/netframework_clrsecurity.go
+++ b/collector/netframework_clrsecurity.go
@@ -4,9 +4,9 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/process.go
+++ b/collector/process.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/collector/service.go
+++ b/collector/service.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc/mgr"
 	"gopkg.in/alecthomas/kingpin.v2"

--- a/collector/teradici_pcoip.go
+++ b/collector/teradici_pcoip.go
@@ -6,9 +6,9 @@ package collector
 import (
 	"errors"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/terminal_services.go
+++ b/collector/terminal_services.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 const ConnectionBrokerFeatureID uint32 = 133

--- a/collector/thermalzone.go
+++ b/collector/thermalzone.go
@@ -3,9 +3,9 @@ package collector
 import (
 	"errors"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/vmware.go
+++ b/collector/vmware.go
@@ -6,9 +6,9 @@ package collector
 import (
 	"errors"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/collector/vmware_blast.go
+++ b/collector/vmware_blast.go
@@ -4,9 +4,9 @@
 package collector
 
 import (
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/yusufpapurcu/wmi"
 )
 
 func init() {

--- a/exporter.go
+++ b/exporter.go
@@ -20,9 +20,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/StackExchange/wmi"
 	"github.com/prometheus-community/windows_exporter/collector"
 	"github.com/prometheus-community/windows_exporter/config"
+	"github.com/yusufpapurcu/wmi"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/Microsoft/hcsshim v0.9.7
-	github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f
 	github.com/dimchansky/utfbom v1.1.1
 	github.com/go-kit/log v0.2.1
 	github.com/go-ole/go-ole v1.2.6
@@ -14,6 +13,7 @@ require (
 	github.com/prometheus/common v0.39.0
 	github.com/prometheus/exporter-toolkit v0.8.2
 	github.com/sirupsen/logrus v1.9.0
+	github.com/yusufpapurcu/wmi v1.2.2
 	golang.org/x/sys v0.4.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,6 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
-github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f h1:5ZfJxyXo8KyX8DgGXC5B7ILL8y51fci/qYz2B4j8iLY=
-github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -744,6 +742,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
+github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=

--- a/headers/netapi32/netapi32.go
+++ b/headers/netapi32/netapi32.go
@@ -8,7 +8,7 @@ import (
 )
 
 // WKSTAInfo102 is a wrapper of WKSTA_Info_102
-//https://docs.microsoft.com/en-us/windows/win32/api/lmwksta/ns-lmwksta-wksta_info_102
+// https://docs.microsoft.com/en-us/windows/win32/api/lmwksta/ns-lmwksta-wksta_info_102
 type wKSTAInfo102 struct {
 	wki102_platform_id     uint32
 	wki102_computername    *uint16

--- a/initiate/initiate.go
+++ b/initiate/initiate.go
@@ -1,4 +1,4 @@
-//This package allows us to initiate Time Sensitive components (Like registering the windows service) as early as possible in the startup process
+// This package allows us to initiate Time Sensitive components (Like registering the windows service) as early as possible in the startup process
 package initiate
 
 import (

--- a/tools/collector-generator/collector.template
+++ b/tools/collector-generator/collector.template
@@ -1,6 +1,6 @@
 package collector
 import (
-    "github.com/StackExchange/wmi"
+    "github.com/yusufpapurcu/wmi"
     "github.com/prometheus/client_golang/prometheus"
     "github.com/prometheus-community/windows_exporter/log"
 )


### PR DESCRIPTION
This includes a move from github.com/StackExchange/wmi to github.com/yusufpapurcu/wmi, as the StackExchange repository has been archived.

This PR makes #1141 redundant.