### PR TITLE
feat: Allow default metrics to be disabled

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -269,6 +269,10 @@ func main() {
 			"telemetry.path",
 			"URL path for surfacing collected metrics.",
 		).Default("/metrics").String()
+		disableExporterMetrics = kingpin.Flag(
+			"web.disable-exporter-metrics",
+			"Exclude metrics about the exporter itself (promhttp_*, process_*, go_*).",
+		).Bool()
 		maxRequests = kingpin.Flag(
 			"telemetry.max-requests",
 			"Maximum number of concurrent requests. 0 to disable.",
@@ -347,7 +351,8 @@ func main() {
 	log.Infof("Enabled collectors: %v", strings.Join(keys(collectors), ", "))
 
 	h := &metricsHandler{
-		timeoutMargin: *timeoutMargin,
+		timeoutMargin:          *timeoutMargin,
+		includeExporterMetrics: *disableExporterMetrics,
 		collectorFactory: func(timeout time.Duration, requestedCollectors []string) (error, *windowsCollector) {
 			filteredCollectors := make(map[string]collector.Collector)
 			// scrape all enabled collectors if no collector is requested
@@ -450,8 +455,9 @@ func withConcurrencyLimit(n int, next http.HandlerFunc) http.HandlerFunc {
 }
 
 type metricsHandler struct {
-	timeoutMargin    float64
-	collectorFactory func(timeout time.Duration, requestedCollectors []string) (error, *windowsCollector)
+	timeoutMargin          float64
+	includeExporterMetrics bool
+	collectorFactory       func(timeout time.Duration, requestedCollectors []string) (error, *windowsCollector)
 }
 
 func (mh *metricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -479,11 +485,13 @@ func (mh *metricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	reg.MustRegister(wc)
-	reg.MustRegister(
-		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
-		collectors.NewGoCollector(),
-		version.NewCollector("windows_exporter"),
-	)
+	if !mh.includeExporterMetrics {
+		reg.MustRegister(
+			collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+			collectors.NewGoCollector(),
+			version.NewCollector("windows_exporter"),
+		)
+	}
 
 	h := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
 	h.ServeHTTP(w, r)

--- a/tools/e2e-output.txt
+++ b/tools/e2e-output.txt
@@ -1,69 +1,3 @@
-# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
-# TYPE go_gc_duration_seconds summary
-# HELP go_goroutines Number of goroutines that currently exist.
-# TYPE go_goroutines gauge
-# HELP go_info Information about the Go environment.
-# TYPE go_info gauge
-# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
-# TYPE go_memstats_alloc_bytes gauge
-# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
-# TYPE go_memstats_alloc_bytes_total counter
-# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
-# TYPE go_memstats_buck_hash_sys_bytes gauge
-# HELP go_memstats_frees_total Total number of frees.
-# TYPE go_memstats_frees_total counter
-# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
-# TYPE go_memstats_gc_sys_bytes gauge
-# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
-# TYPE go_memstats_heap_alloc_bytes gauge
-# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
-# TYPE go_memstats_heap_idle_bytes gauge
-# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
-# TYPE go_memstats_heap_inuse_bytes gauge
-# HELP go_memstats_heap_objects Number of allocated objects.
-# TYPE go_memstats_heap_objects gauge
-# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
-# TYPE go_memstats_heap_released_bytes gauge
-# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
-# TYPE go_memstats_heap_sys_bytes gauge
-# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
-# TYPE go_memstats_last_gc_time_seconds gauge
-# HELP go_memstats_lookups_total Total number of pointer lookups.
-# TYPE go_memstats_lookups_total counter
-# HELP go_memstats_mallocs_total Total number of mallocs.
-# TYPE go_memstats_mallocs_total counter
-# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
-# TYPE go_memstats_mcache_inuse_bytes gauge
-# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
-# TYPE go_memstats_mcache_sys_bytes gauge
-# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
-# TYPE go_memstats_mspan_inuse_bytes gauge
-# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
-# TYPE go_memstats_mspan_sys_bytes gauge
-# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
-# TYPE go_memstats_next_gc_bytes gauge
-# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
-# TYPE go_memstats_other_sys_bytes gauge
-# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
-# TYPE go_memstats_stack_inuse_bytes gauge
-# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
-# TYPE go_memstats_stack_sys_bytes gauge
-# HELP go_memstats_sys_bytes Number of bytes obtained from system.
-# TYPE go_memstats_sys_bytes gauge
-# HELP go_threads Number of OS threads created.
-# TYPE go_threads gauge
-# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
-# TYPE process_cpu_seconds_total counter
-# HELP process_max_fds Maximum number of open file descriptors.
-# TYPE process_max_fds gauge
-# HELP process_open_fds Number of open file descriptors.
-# TYPE process_open_fds gauge
-# HELP process_resident_memory_bytes Resident memory size in bytes.
-# TYPE process_resident_memory_bytes gauge
-# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
-# TYPE process_start_time_seconds gauge
-# HELP process_virtual_memory_bytes Virtual memory size in bytes.
-# TYPE process_virtual_memory_bytes gauge
 # HELP test_alpha_total Some random metric.
 # TYPE test_alpha_total counter
 test_alpha_total 42
@@ -99,8 +33,6 @@ test_alpha_total 42
 # TYPE windows_cs_logical_processors gauge
 # HELP windows_cs_physical_memory_bytes ComputerSystem.TotalPhysicalMemory
 # TYPE windows_cs_physical_memory_bytes gauge
-# HELP windows_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which windows_exporter was built, and the goos and goarch for the build.
-# TYPE windows_exporter_build_info gauge
 # HELP windows_exporter_collector_duration_seconds windows_exporter: Duration of a collection.
 # TYPE windows_exporter_collector_duration_seconds gauge
 # HELP windows_exporter_collector_success windows_exporter: Whether the collector was successful.

--- a/tools/end-to-end-test.ps1
+++ b/tools/end-to-end-test.ps1
@@ -25,7 +25,7 @@ $skip_re = "^(go_|windows_exporter_build_info|windows_exporter_collector_duratio
 $exporter_proc = Start-Process `
     -PassThru `
     -FilePath ..\windows_exporter.exe `
-    -ArgumentList "--log.level=debug --collector.textfile.directory=$($textfile_dir)" `
+    -ArgumentList "--log.level=debug --web.disable-exporter-metrics --collector.textfile.directory=$($textfile_dir)" `
     -WindowStyle Hidden `
     -RedirectStandardOutput "$($temp_dir)/windows_exporter.log" `
     -RedirectStandardError "$($temp_dir)/windows_exporter_error.log"


### PR DESCRIPTION
Introduces a new `--disable-exporter-metrics` to allow users to disable metrics included by the Prometheus client library (promhttp_*, process_*, go_*)

Resolves #1159 