### PR TITLE
fix!: Set correct diskdrive collector/metric name

### DIFF
--- a/collector/diskdrive.go
+++ b/collector/diskdrive.go
@@ -26,7 +26,7 @@ type DiskDriveInfoCollector struct {
 }
 
 func newDiskDriveInfoCollector() (Collector, error) {
-	const subsystem = "disk_drive"
+	const subsystem = "diskdrive"
 
 	return &DiskDriveInfoCollector{
 		DiskInfo: prometheus.NewDesc(

--- a/collector/init.go
+++ b/collector/init.go
@@ -82,7 +82,7 @@ var collectors = []collectorInit{
 		perfCounterNames: nil,
 	},
 	{
-		name:             "disk_drive",
+		name:             "diskdrive",
 		builder:          newDiskDriveInfoCollector,
 		perfCounterNames: nil,
 	},


### PR DESCRIPTION
Previous name did not match documentation and WMI class.

Resolves #1169 