### PR TITLE
Service custom labels

### DIFF
--- a/collector/init.go
+++ b/collector/init.go
@@ -1,5 +1,9 @@
 package collector
 
+import (
+	"github.com/prometheus-community/windows_exporter/config"
+)
+
 // collectorInit represents the required initialisation config for a collector.
 type collectorInit struct {
 	// Name of collector to be initialised
@@ -9,6 +13,8 @@ type collectorInit struct {
 	// Perflib counter names for the collector.
 	// These will be included in the Perflib scrape scope by the exporter.
 	perfCounterNames []string
+	// builder fonction to intercept parameters for a collector
+	config_hooks map[string]config.ConfigHook
 }
 
 func getCPUCollectorDeps() string {
@@ -244,6 +250,7 @@ var collectors = []collectorInit{
 		name:             "service",
 		builder:          newserviceCollector,
 		perfCounterNames: nil,
+		config_hooks:     ServiceBuildHook(),
 	},
 	{
 		name:             "smtp",
@@ -304,6 +311,6 @@ var collectors = []collectorInit{
 // To be called by the exporter for collector initialisation
 func RegisterCollectors() {
 	for _, v := range collectors {
-		registerCollector(v.name, v.builder, v.perfCounterNames...)
+		registerCollector(v.name, v.builder, v.config_hooks, v.perfCounterNames...)
 	}
 }

--- a/collector/service.go
+++ b/collector/service.go
@@ -4,11 +4,13 @@
 package collector
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"syscall"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/prometheus-community/windows_exporter/config"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/yusufpapurcu/wmi"
@@ -16,15 +18,26 @@ import (
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
+type ServiceDef struct {
+	Name         string
+	CustomLabels map[string]string
+}
+
 var (
 	serviceWhereClause = kingpin.Flag(
 		"collector.service.services-where",
 		"WQL 'where' clause to use in WMI metrics query. Limits the response to the services you specify and reduces the size of the response.",
 	).Default("").String()
+	serviceList = kingpin.Flag(
+		"collector.service.services-list",
+		"comma separated list of service name used to build WQL 'where' clause to use in WMI metrics query. Limits the response to the services you specify and reduces the size of the response.",
+	).Default("").String()
 	useAPI = kingpin.Flag(
 		"collector.service.use-api",
 		"Use API calls to collect service data instead of WMI. Flag 'collector.service.services-where' won't be effective.",
 	).Default("false").Bool()
+	services        = make(map[string]*ServiceDef)
+	services_labels = make([]string, 0)
 )
 
 // A serviceCollector is a Prometheus collector for WMI Win32_Service metrics
@@ -37,40 +50,193 @@ type serviceCollector struct {
 	queryWhereClause string
 }
 
+// Build service list for name
+func expandServiceWhere(services string) string {
+
+	separated := strings.Split(services, ",")
+	unique := map[string]bool{}
+	for _, s := range separated {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			unique[s] = true
+		}
+	}
+	var b bytes.Buffer
+
+	i := 0
+	for s := range unique {
+		i += 1
+		b.WriteString("Name='")
+		b.WriteString(s)
+		b.WriteString("'")
+		if i < len(unique) {
+			b.WriteString(" or ")
+		}
+
+	}
+	return b.String()
+}
+
+func ServiceBuildHook() map[string]config.ConfigHook {
+	config_hooks := &config.ConfigHook{
+		ConfigAttrs: []string{"collector", "service", "services"},
+		Hook:        ServiceBuildMap,
+	}
+	entry := make(map[string]config.ConfigHook)
+	entry["services-list"] = *config_hooks
+	return entry
+}
+
+func ServiceBuildMap(data interface{}) map[string]string {
+	ret := make(map[string]string)
+	switch typed := data.(type) {
+	case map[interface{}]interface{}:
+		ret = flatten(data)
+
+	// form is a dict of service's name maybe with custom labels
+	case map[string]interface{}:
+		for name, raw_labels := range typed {
+			labels := flatten(raw_labels)
+			service := &ServiceDef{
+				Name:         name,
+				CustomLabels: labels,
+			}
+			services[strings.ToLower(service.Name)] = service
+		}
+
+	// form is a list of services' name
+	case []interface{}:
+		for _, fv := range typed {
+			var name string
+			tmp := flatten(fv)
+			// tmp is a pseudo map with a key set and no value: collect first key
+			for k := range tmp {
+				name = k
+				break
+			}
+			service := &ServiceDef{
+				Name:         name,
+				CustomLabels: nil,
+			}
+			services[strings.ToLower(service.Name)] = service
+
+			// serviceHash[fmt.Sprint(idx)] = flatten(fv)
+		}
+
+	default:
+		ret["unknown_parameter"] = "1"
+		// serviceHash[fmt.Sprint(typed)] = 1
+	}
+
+	// build a list of all custom labels for each service
+	exists := make(map[string]bool)
+	for _, svc := range services {
+		// fill the exists map with all labels' names
+		for name := range svc.CustomLabels {
+			exists[name] = true
+		}
+	}
+	// check custom labels: each name must be present for each service
+	for _, svc := range services {
+		for name := range svc.CustomLabels {
+			if _, ok := exists[name]; !ok {
+				log.Warn("label: %s not present for service '%s'", name, svc.Name)
+				exists[name] = false
+			}
+		}
+	}
+	services_labels = make([]string, 0, len(exists))
+	for name := range exists {
+		services_labels = append(services_labels, name)
+	}
+	return ret
+}
+
+// convert map value to something that can be use as labels of service def
+func flatten(data interface{}) map[string]string {
+	ret := make(map[string]string)
+	switch typed := data.(type) {
+	// value is a map of we hope of strings
+	case map[string]interface{}:
+		for fk, fv := range typed {
+			ret[fk] = fmt.Sprint(fv)
+		}
+	// value is a string or nothing (list)
+	default:
+		if typed != nil {
+			ret[fmt.Sprint(typed)] = "1"
+		} else {
+			ret = nil
+		}
+	}
+	return ret
+}
+
 // newserviceCollector ...
 func newserviceCollector() (Collector, error) {
 	const subsystem = "service"
 
-	if *serviceWhereClause == "" {
+	if *serviceWhereClause == "" && *serviceList == "" && len(services) == 0 {
 		log.Warn("No where-clause specified for service collector. This will generate a very large number of metrics!")
 	}
+
+	if *serviceWhereClause == "" && *serviceList != "" {
+		*serviceWhereClause = expandServiceWhere(*serviceList)
+	} else if len(services) > 0 {
+		servList := make([]string, 0, len(services))
+		for _, svc := range services {
+			if svc != nil {
+				servList = append(servList, svc.Name)
+			}
+		}
+		svc := strings.Join(servList, ",")
+		*serviceWhereClause = expandServiceWhere(svc)
+	}
+
+	if *serviceWhereClause != "" {
+		log.Debug(fmt.Sprintf("serviceWhereClause='%s'", *serviceWhereClause))
+	}
+
 	if *useAPI {
 		log.Warn("API collection is enabled.")
+	}
+
+	var var_labels [4][]string
+	var_labels[0] = []string{"name", "display_name", "process_id", "run_as"}
+	var_labels[1] = []string{"name", "state"}
+	var_labels[2] = []string{"name", "start_mode"}
+	var_labels[3] = []string{"name", "status"}
+	if len(services_labels) > 0 {
+		for _, label := range services_labels {
+			for idx, metric_label := range var_labels {
+				var_labels[idx] = append(metric_label, label)
+			}
+		}
 	}
 
 	return &serviceCollector{
 		Information: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "info"),
 			"A metric with a constant '1' value labeled with service information",
-			[]string{"name", "display_name", "process_id", "run_as"},
+			var_labels[0],
 			nil,
 		),
 		State: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "state"),
 			"The state of the service (State)",
-			[]string{"name", "state"},
+			var_labels[1],
 			nil,
 		),
 		StartMode: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "start_mode"),
 			"The start mode of the service (StartMode)",
-			[]string{"name", "start_mode"},
+			var_labels[2],
 			nil,
 		),
 		Status: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "status"),
 			"The status of the service (Status)",
-			[]string{"name", "status"},
+			var_labels[3],
 			nil,
 		),
 		queryWhereClause: *serviceWhereClause,
@@ -163,61 +329,101 @@ func (c *serviceCollector) collectWMI(ch chan<- prometheus.Metric) error {
 		return err
 	}
 	for _, service := range dst {
-		pid := fmt.Sprintf("%d", uint64(service.ProcessId))
+		// build the custom labels with their values for the service
+		var custom_labels []string
+		service_name := strings.ToLower(service.Name)
+		if len(services_labels) > 0 {
+			custom_labels = make([]string, len(services_labels))
+			if svc, ok := services[service_name]; ok {
+				// we find the service name in service definition list
+				for idx, label := range services_labels {
+					if val, tst := svc.CustomLabels[label]; tst {
+						custom_labels[idx] = val
+					}
+				}
+			} else {
+				// we don't find the service name !?!? not possible but...
+				for idx := range services_labels {
+					custom_labels[idx] = ""
+				}
 
-		runAs := ""
-		if service.StartName != nil {
-			runAs = *service.StartName
+			}
 		}
+
+		// Information metric
+		labels := make([]string, 4)
+		// service name
+		labels[0] = service_name
+		// service display name
+		labels[1] = service.DisplayName
+		// service pid
+		labels[2] = fmt.Sprintf("%d", uint64(service.ProcessId))
+		// service runAs
+		if service.StartName != nil {
+			labels[3] = *service.StartName
+		} else {
+			labels[3] = ""
+		}
+		if len(custom_labels) > 0 {
+			labels = append(labels, custom_labels...)
+		}
+
 		ch <- prometheus.MustNewConstMetric(
 			c.Information,
 			prometheus.GaugeValue,
-			1.0,
-			strings.ToLower(service.Name),
-			service.DisplayName,
-			pid,
-			runAs,
+			1.0, labels...,
 		)
+
+		// State metric
+		labels = make([]string, 2)
+		// service name
+		labels[0] = service_name
+		labels[1] = ""
+		if len(custom_labels) > 0 {
+			labels = append(labels, custom_labels...)
+		}
 
 		for _, state := range allStates {
 			isCurrentState := 0.0
 			if state == strings.ToLower(service.State) {
 				isCurrentState = 1.0
 			}
+			labels[1] = state
 			ch <- prometheus.MustNewConstMetric(
 				c.State,
 				prometheus.GaugeValue,
 				isCurrentState,
-				strings.ToLower(service.Name),
-				state,
+				labels...,
 			)
 		}
 
+		// StartMode metric
 		for _, startMode := range allStartModes {
 			isCurrentStartMode := 0.0
 			if startMode == strings.ToLower(service.StartMode) {
 				isCurrentStartMode = 1.0
 			}
+			labels[1] = startMode
 			ch <- prometheus.MustNewConstMetric(
 				c.StartMode,
 				prometheus.GaugeValue,
 				isCurrentStartMode,
-				strings.ToLower(service.Name),
-				startMode,
+				labels...,
 			)
 		}
 
+		// service status metric
 		for _, status := range allStatuses {
 			isCurrentStatus := 0.0
 			if status == strings.ToLower(service.Status) {
 				isCurrentStatus = 1.0
 			}
+			labels[1] = status
 			ch <- prometheus.MustNewConstMetric(
 				c.Status,
 				prometheus.GaugeValue,
 				isCurrentStatus,
-				strings.ToLower(service.Name),
-				status,
+				labels...,
 			)
 		}
 	}

--- a/collector/terminal_services.go
+++ b/collector/terminal_services.go
@@ -5,6 +5,7 @@ package collector
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/prometheus-community/windows_exporter/log"
@@ -262,101 +263,102 @@ func (c *TerminalServicesCollector) collectTSSessionCounters(ctx *ScrapeContext,
 		return nil, err
 	}
 
-	for _, d := range dst {
+	for idx, d := range dst {
 		// only connect metrics for remote named sessions
 		n := strings.ToLower(d.Name)
 		if n == "" || n == "services" || n == "console" {
 			continue
 		}
+		name := fmt.Sprintf("%s-%d", d.Name, idx)
 		ch <- prometheus.MustNewConstMetric(
 			c.HandleCount,
 			prometheus.GaugeValue,
 			d.HandleCount,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.PageFaultsPersec,
 			prometheus.CounterValue,
 			d.PageFaultsPersec,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.PageFileBytes,
 			prometheus.GaugeValue,
 			d.PageFileBytes,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.PageFileBytesPeak,
 			prometheus.GaugeValue,
 			d.PageFileBytesPeak,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.PercentPrivilegedTime,
 			prometheus.CounterValue,
 			d.PercentPrivilegedTime,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.PercentProcessorTime,
 			prometheus.CounterValue,
 			d.PercentProcessorTime,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.PercentUserTime,
 			prometheus.CounterValue,
 			d.PercentUserTime,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.PoolNonpagedBytes,
 			prometheus.GaugeValue,
 			d.PoolNonpagedBytes,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.PoolPagedBytes,
 			prometheus.GaugeValue,
 			d.PoolPagedBytes,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.PrivateBytes,
 			prometheus.GaugeValue,
 			d.PrivateBytes,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.ThreadCount,
 			prometheus.GaugeValue,
 			d.ThreadCount,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.VirtualBytes,
 			prometheus.GaugeValue,
 			d.VirtualBytes,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.VirtualBytesPeak,
 			prometheus.GaugeValue,
 			d.VirtualBytesPeak,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.WorkingSet,
 			prometheus.GaugeValue,
 			d.WorkingSet,
-			d.Name,
+			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.WorkingSetPeak,
 			prometheus.GaugeValue,
 			d.WorkingSetPeak,
-			d.Name,
+			name,
 		)
 	}
 	return nil, nil

--- a/collector/textfile_test.go
+++ b/collector/textfile_test.go
@@ -1,10 +1,11 @@
 package collector
 
 import (
-	"github.com/dimchansky/utfbom"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
+
+	"github.com/dimchansky/utfbom"
 
 	dto "github.com/prometheus/client_model/go"
 )
@@ -12,7 +13,7 @@ import (
 func TestCRFilter(t *testing.T) {
 	sr := strings.NewReader("line 1\r\nline 2")
 	cr := carriageReturnFilteringReader{r: sr}
-	b, err := ioutil.ReadAll(cr)
+	b, err := io.ReadAll(cr)
 	if err != nil {
 		t.Error(err)
 	}

--- a/collector/thermalzone.go
+++ b/collector/thermalzone.go
@@ -75,7 +75,7 @@ func (c *thermalZoneCollector) collect(ch chan<- prometheus.Metric) (*prometheus
 
 	// ThermalZone collector has been known to 'successfully' return an empty result.
 	if len(dst) == 0 {
-		return nil, errors.New("Empty results set for collector")
+		return nil, errors.New("empty results set for collector")
 	}
 
 	for _, info := range dst {

--- a/collector/time.go
+++ b/collector/time.go
@@ -22,7 +22,7 @@ type TimeCollector struct {
 
 func newTimeCollector() (Collector, error) {
 	if getWindowsVersion() <= 6.1 {
-		return nil, errors.New("Windows version older than Server 2016 detected. The time collector will not run and should be disabled via CLI flags or configuration file")
+		return nil, errors.New("windows version older than Server 2016 detected. The time collector will not run and should be disabled via CLI flags or configuration file")
 
 	}
 	const subsystem = "time"

--- a/docs/collector.service.md
+++ b/docs/collector.service.md
@@ -159,6 +159,7 @@ groups:
 In this example, `instance` is the target label of the host. So each alert will be processed per host, which is then used in the alert description.
 
 ### example with custom labels
+
 If you use custom labels for services defined on each host you may have:
 
 config file:

--- a/docs/collector.service.md
+++ b/docs/collector.service.md
@@ -18,9 +18,37 @@ Example: `--collector.service.services-where="Name='windows_exporter'"`
 
 Example config win_exporter.yml for multiple services: `services-where: Name='SQLServer' OR Name='Couchbase' OR Name='Spooler' OR Name='ActiveMQ'`
 
+### `--collector.service.services-list`
+
+A comma separated list of services names to monitor. It builds a "services-where" WMI filter on list on service name.
+
+Example: `--collector.service.services-list="SQLServer, Couchbase, Spooler,ActiveMQ"` is equivalent to the previous example.
+
 ### `--collector.service.use-api`
 
 Uses API calls instead of WMI for performance optimization. **Note** the previous flag (`--collector.service.services-where`) won't have any effect on this mode.
+
+### service list with custom labels (config file only)
+
+Define a dictionnary of services to monitor, and for each of them a specific value of labels.
+
+```yml
+collector:
+  service:
+    services:
+      windows_exporter:
+        application: prometheus
+        custom1: val1
+      pushprox_client:
+        application: prometheus
+        custom1: val1
+      winRM:
+        application: windows
+        custom1: val2
+      Dhcp:
+        application: windows
+        custom1: val3
+```
 
 ## Metrics
 
@@ -36,6 +64,7 @@ For the values of the `state`, `start_mode`, `status` and `run_as` labels, see b
 ### States
 
 A service can be in the following states:
+
 - `stopped`
 - `start pending`
 - `stop pending`
@@ -48,6 +77,7 @@ A service can be in the following states:
 ### Start modes
 
 A service can have the following start modes:
+
 - `boot`
 - `system`
 - `auto`
@@ -57,6 +87,7 @@ A service can have the following start modes:
 ### Status (not available in API mode)
 
 A service can have any of the following statuses:
+
 - `ok`
 - `error`
 - `degraded`
@@ -80,19 +111,25 @@ It corresponds to the `StartName` attribute of the `Win32_Service` class.
 `StartName` attribute can be NULL and in such case the label is reported as an empty string. Notice that if the attribute is NULL the service is logged on as the `LocalSystem` account or, for kernel or system-level drive, it runs with a default object name created by the I/O system based on the service name, for example, DWDOM\Admin.
 
 ### Example metric
+
 Lists the services that have a 'disabled' start mode.
-```
+
+```prometheus
 windows_service_start_mode{exported_name=~"(mssqlserver|sqlserveragent)",start_mode="disabled"}
 ```
 
 ## Useful queries
+
 Counts the number of Microsoft SQL Server/Agent Processes
-```
+
+```prometheus
 count(windows_service_state{exported_name=~"(sqlserveragent|mssqlserver)",state="running"})
 ```
 
 ## Alerting examples
+
 **prometheus.rules**
+
 ```yaml
 groups:
 - name: Microsoft SQL Server Alerts
@@ -118,4 +155,42 @@ groups:
       summary: "Service {{ $labels.exported_name }} down"
       description: "Service {{ $labels.exported_name }} on instance {{ $labels.instance }} has been down for more than 3 minutes."
 ```
+
 In this example, `instance` is the target label of the host. So each alert will be processed per host, which is then used in the alert description.
+
+### example with custom labels
+If you use custom labels for services defined on each host you may have:
+
+config file:
+
+```yml
+collector:
+  service:
+    services:
+      windows_exporter:
+        application: prometheus
+      pushprox_client:
+        application: prometheus
+      winRM:
+        application: windows
+      Dhcp:
+        application: windows
+```
+
+Then generic alert services:
+
+```yml
+groups:
+- name: Window Server Alerts
+  rules:
+
+  # Sends an alert when the 'sqlserveragent' service is not in the running state for 3 minutes.
+  - alert: WindowServiceNotRunning
+    expr: windows_service_state{state="running"} == 0
+    for: 3m
+    labels:
+      severity: high
+    annotations:
+      summary: "Service {{ $labels.name }} for {{ $labels.application }} down for 3 min."
+      description: "Service {{ $labels.name }} for Application {{ $labels.application }} on instance {{ $labels.instance }} has been down for more than 3 minutes."
+```

--- a/exporter.go
+++ b/exporter.go
@@ -298,8 +298,14 @@ func main() {
 	// to load the specified file(s).
 	kingpin.Parse()
 	log.Debug("Logging has Started")
+
+	initWbem()
+
+	// Initialize collectors before loading
+	collector.RegisterCollectors()
+
 	if *configFile != "" {
-		resolver, err := config.NewResolver(*configFile)
+		resolver, err := config.NewResolver(*configFile, collector.ConfigHooks())
 		if err != nil {
 			log.Fatalf("could not load config file: %v\n", err)
 		}
@@ -330,11 +336,6 @@ func main() {
 		}
 		return
 	}
-
-	initWbem()
-
-	// Initialize collectors before loading
-	collector.RegisterCollectors()
 
 	collectors, err := loadCollectors(*enabledCollectors)
 	if err != nil {


### PR DESCRIPTION
this PR adds some feature to service collector:
 - add config parameter **collector.service.services-list** with a comma separated list of service names:
 ```yml
collector:
  service:
    services-list: windows_exporter, winRM, pushprox_client, Dhcp
```
the param will only be checked if services-where is not set.
the list will be used to build a service-where query based on Name and is equivalent to:
```yml
collector:
  service:
    services-where: "Name = 'elmt_1' or Name = "elmt_X' or ..."
```
 - add a new parameter that can only be set in config file: 
It allows to set any number of custom labels value for each service:
e.g.:
```yml
collector:
  service:
    services:
      windows_exporter:
        application: prometheus
        custom1: val1
      pushprox_client:
        application: prometheus
        custom1: val1
      winRM:
        application: windows
        custom1: val2
      Dhcp:
        application: windows
        custom1: val3
```
Use case: allow to build a generic Prometheus alert on not running service and to use the specified associated labels to drive a specific behavior. For me they are used to route for a specific documentation based on context.<br>
Label's names must be identical for each service. Not identical labels names are removed !
This parameter as a lower priority than service-where and service-list.
It accepts a dict (see above example) or a list; in this case it behaves like services-list.
e.g.:
```yml
collector:
  service:
    services:
      - dhcp
      - pushprox_client
      - windows_exporter
      - winRM
```
