### PR TITLE
Fix telemetry.addr deprecated since v0.21.0

### DIFF
--- a/docs/example_config.yml
+++ b/docs/example_config.yml
@@ -12,6 +12,7 @@ log:
 scrape:
   timeout-margin: 0.5
 telemetry:
-  addr: ":9182"
   path: /metrics
   max-requests: 5
+web:
+  listen-address: ":9182"


### PR DESCRIPTION
The file `example_config.yml` was not modified since v0.21.0 where `--telemetry.addr` was deprecated in favor of `--web.listen-address`.
This PR fix #1178.