### PR TITLE
fix Terminal Service duplicate session names under load.

### DIFF
--- a/collector/terminal_services.go
+++ b/collector/terminal_services.go
@@ -261,6 +261,7 @@ func (c *TerminalServicesCollector) collectTSSessionCounters(ctx *ScrapeContext,
 	if err != nil {
 		return nil, err
 	}
+	names := make(map[string]bool)
 
 	for _, d := range dst {
 		// only connect metrics for remote named sessions
@@ -268,6 +269,12 @@ func (c *TerminalServicesCollector) collectTSSessionCounters(ctx *ScrapeContext,
 		if n == "" || n == "services" || n == "console" {
 			continue
 		}
+		// don't add name already present in labels list
+		if _, ok := names[n]; ok {
+			continue
+		}
+		names[n] = true
+
 		ch <- prometheus.MustNewConstMetric(
 			c.HandleCount,
 			prometheus.GaugeValue,


### PR DESCRIPTION
On prod env (30 hosts with more than 40 cnx each), perflibTerminalServicesSession's names are reused and caused duplicated labels names.
use a map to maintain the known names and remove them.