### PR TITLE
Remove fluent-style kingpin

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/leoluk/perflib_exporter/perflib"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -51,6 +52,8 @@ func getWindowsVersion() float64 {
 }
 
 type collectorBuilder func() (Collector, error)
+type flagsBuilder func(*kingpin.Application)
+type perfCounterNamesBuilder func() []string
 
 var (
 	builders                = make(map[string]collectorBuilder)

--- a/collector/dfsr.go
+++ b/collector/dfsr.go
@@ -9,7 +9,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var dfsrEnabledCollectors = kingpin.Flag("collectors.dfsr.sources-enabled", "Comma-seperated list of DFSR Perflib sources to use.").Default("connection,folder,volume").String()
+const (
+	FlagDfsrEnabledCollectors = "collectors.dfsr.sources-enabled"
+)
+
+var dfsrEnabledCollectors *string
 
 // DFSRCollector contains the metric and state data of the DFSR collectors.
 type DFSRCollector struct {
@@ -80,6 +84,11 @@ func dfsrGetPerfObjectName(collector string) string {
 		suffix = "Replication Service Volumes"
 	}
 	return (prefix + suffix)
+}
+
+// newDFSRCollectorFlags is registered
+func newDFSRCollectorFlags(app *kingpin.Application) {
+	dfsrEnabledCollectors = app.Flag(FlagDfsrEnabledCollectors, "Comma-seperated list of DFSR Perflib sources to use.").Default("connection,folder,volume").String()
 }
 
 // newDFSRCollector is registered

--- a/collector/exchange.go
+++ b/collector/exchange.go
@@ -13,6 +13,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	FlagExchangeListAllCollectors = "collectors.exchange.list"
+	FlagExchangeCollectorsEnabled = "collectors.exchange.enabled"
+)
+
 type exchangeCollector struct {
 	LDAPReadTime                            *prometheus.Desc
 	LDAPSearchTime                          *prometheus.Desc
@@ -69,16 +74,23 @@ var (
 		"RpcClientAccess",
 	}
 
-	argExchangeListAllCollectors = kingpin.Flag(
-		"collectors.exchange.list",
+	argExchangeListAllCollectors *bool
+
+	argExchangeCollectorsEnabled *string
+)
+
+// newExchangeCollectorFlags ...
+func newExchangeCollectorFlags(app *kingpin.Application) {
+	argExchangeListAllCollectors = app.Flag(
+		FlagExchangeListAllCollectors,
 		"List the collectors along with their perflib object name/ids",
 	).Bool()
 
-	argExchangeCollectorsEnabled = kingpin.Flag(
-		"collectors.exchange.enabled",
+	argExchangeCollectorsEnabled = app.Flag(
+		FlagExchangeCollectorsEnabled,
 		"Comma-separated list of collectors to use. Defaults to all, if not specified.",
 	).Default("").String()
-)
+}
 
 // newExchangeCollector returns a new Collector
 func newExchangeCollector() (Collector, error) {

--- a/collector/iis.go
+++ b/collector/iis.go
@@ -13,11 +13,18 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
+const (
+	FlagISSSiteBlacklist = "collector.iis.site-blacklist"
+	FlagISSSiteWhitelist = "collector.iis.site-whitelist"
+	FlagISSAppBlacklist  = "collector.iis.app-blacklist"
+	FlagISSAppWhitelist  = "collector.iis.app-whitelist"
+)
+
 var (
-	siteWhitelist = kingpin.Flag("collector.iis.site-whitelist", "Regexp of sites to whitelist. Site name must both match whitelist and not match blacklist to be included.").Default(".+").String()
-	siteBlacklist = kingpin.Flag("collector.iis.site-blacklist", "Regexp of sites to blacklist. Site name must both match whitelist and not match blacklist to be included.").String()
-	appWhitelist  = kingpin.Flag("collector.iis.app-whitelist", "Regexp of apps to whitelist. App name must both match whitelist and not match blacklist to be included.").Default(".+").String()
-	appBlacklist  = kingpin.Flag("collector.iis.app-blacklist", "Regexp of apps to blacklist. App name must both match whitelist and not match blacklist to be included.").String()
+	siteWhitelist *string
+	siteBlacklist *string
+	appWhitelist  *string
+	appBlacklist  *string
 )
 
 type simple_version struct {
@@ -189,6 +196,13 @@ type IISCollector struct {
 	appBlacklistPattern *regexp.Regexp
 
 	iis_version simple_version
+}
+
+func newIISCollectorFlags(app *kingpin.Application) {
+	siteWhitelist = kingpin.Flag(FlagISSSiteWhitelist, "Regexp of sites to whitelist. Site name must both match whitelist and not match blacklist to be included.").Default(".+").String()
+	siteBlacklist = kingpin.Flag(FlagISSSiteBlacklist, "Regexp of sites to blacklist. Site name must both match whitelist and not match blacklist to be included.").String()
+	appWhitelist = kingpin.Flag(FlagISSAppWhitelist, "Regexp of apps to whitelist. App name must both match whitelist and not match blacklist to be included.").Default(".+").String()
+	appBlacklist = kingpin.Flag(FlagISSAppBlacklist, "Regexp of apps to blacklist. App name must both match whitelist and not match blacklist to be included.").String()
 }
 
 func newIISCollector() (Collector, error) {

--- a/collector/logical_disk.go
+++ b/collector/logical_disk.go
@@ -12,15 +12,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	FlagLogicalDiskVolumeBlacklist = "collector.logical_disk.volume-blacklist"
+	FlagLogicalDiskVolumeWhitelist = "collector.logical_disk.volume-whitelist"
+)
+
 var (
-	volumeWhitelist = kingpin.Flag(
-		"collector.logical_disk.volume-whitelist",
-		"Regexp of volumes to whitelist. Volume name must both match whitelist and not match blacklist to be included.",
-	).Default(".+").String()
-	volumeBlacklist = kingpin.Flag(
-		"collector.logical_disk.volume-blacklist",
-		"Regexp of volumes to blacklist. Volume name must both match whitelist and not match blacklist to be included.",
-	).Default("").String()
+	volumeWhitelist *string
+	volumeBlacklist *string
 )
 
 // A LogicalDiskCollector is a Prometheus collector for perflib logicalDisk metrics
@@ -44,6 +43,18 @@ type LogicalDiskCollector struct {
 
 	volumeWhitelistPattern *regexp.Regexp
 	volumeBlacklistPattern *regexp.Regexp
+}
+
+// newLogicalDiskCollectorFlags ...
+func newLogicalDiskCollectorFlags(app *kingpin.Application) {
+	volumeWhitelist = app.Flag(
+		FlagLogicalDiskVolumeWhitelist,
+		"Regexp of volumes to whitelist. Volume name must both match whitelist and not match blacklist to be included.",
+	).Default(".+").String()
+	volumeBlacklist = app.Flag(
+		FlagLogicalDiskVolumeBlacklist,
+		"Regexp of volumes to blacklist. Volume name must both match whitelist and not match blacklist to be included.",
+	).Default("").String()
 }
 
 // newLogicalDiskCollector ...

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -12,8 +12,12 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
+const (
+	FlagMsmqWhereClause = "collector.msmq.msmq-where"
+)
+
 var (
-	msmqWhereClause = kingpin.Flag("collector.msmq.msmq-where", "WQL 'where' clause to use in WMI metrics query. Limits the response to the msmqs you specify and reduces the size of the response.").String()
+	msmqWhereClause *string
 )
 
 // A Win32_PerfRawData_MSMQ_MSMQQueueCollector is a Prometheus collector for WMI Win32_PerfRawData_MSMQ_MSMQQueue metrics
@@ -24,6 +28,11 @@ type Win32_PerfRawData_MSMQ_MSMQQueueCollector struct {
 	MessagesinQueue        *prometheus.Desc
 
 	queryWhereClause string
+}
+
+// newMSMQCollectorFlags ..
+func newMSMQCollectorFlags(app *kingpin.Application) {
+	msmqWhereClause = app.Flag(FlagMsmqWhereClause, "WQL 'where' clause to use in WMI metrics query. Limits the response to the msmqs you specify and reduces the size of the response.").String()
 }
 
 // NewWin32_PerfRawData_MSMQ_MSMQQueueCollector ...

--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -17,16 +17,15 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-var (
-	mssqlEnabledCollectors = kingpin.Flag(
-		"collectors.mssql.classes-enabled",
-		"Comma-separated list of mssql WMI classes to use.").
-		Default(mssqlAvailableClassCollectors()).String()
+const (
+	FlagMssqlEnabledCollectors = "collectors.mssql.classes-enabled"
+	FlagMssqlPrintCollectors   = "collectors.mssql.class-print"
+)
 
-	mssqlPrintCollectors = kingpin.Flag(
-		"collectors.mssql.class-print",
-		"If true, print available mssql WMI classes and exit.  Only displays if the mssql collector is enabled.",
-	).Bool()
+var (
+	mssqlEnabledCollectors *string
+
+	mssqlPrintCollectors *bool
 )
 
 type mssqlInstancesType map[string]string
@@ -399,6 +398,19 @@ type MSSQLCollector struct {
 	mssqlInstances             mssqlInstancesType
 	mssqlCollectors            mssqlCollectorsMap
 	mssqlChildCollectorFailure int
+}
+
+// newMSSQLCollectorFlags ...
+func newMSSQLCollectorFlags(app *kingpin.Application) {
+	mssqlEnabledCollectors = app.Flag(
+		FlagMssqlEnabledCollectors,
+		"Comma-separated list of mssql WMI classes to use.").
+		Default(mssqlAvailableClassCollectors()).String()
+
+	mssqlPrintCollectors = app.Flag(
+		FlagMssqlPrintCollectors,
+		"If true, print available mssql WMI classes and exit.  Only displays if the mssql collector is enabled.",
+	).Bool()
 }
 
 // newMSSQLCollector ...

--- a/collector/net.go
+++ b/collector/net.go
@@ -12,15 +12,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	FlagNicBlacklist = "collector.net.nic-blacklist"
+	FlagNicWhitelist = "collector.net.nic-whitelist"
+)
+
 var (
-	nicWhitelist = kingpin.Flag(
-		"collector.net.nic-whitelist",
-		"Regexp of NIC:s to whitelist. NIC name must both match whitelist and not match blacklist to be included.",
-	).Default(".+").String()
-	nicBlacklist = kingpin.Flag(
-		"collector.net.nic-blacklist",
-		"Regexp of NIC:s to blacklist. NIC name must both match whitelist and not match blacklist to be included.",
-	).Default("").String()
+	nicWhitelist        *string
+	nicBlacklist        *string
 	nicNameToUnderscore = regexp.MustCompile("[^a-zA-Z0-9]")
 )
 
@@ -42,6 +41,18 @@ type NetworkCollector struct {
 
 	nicWhitelistPattern *regexp.Regexp
 	nicBlacklistPattern *regexp.Regexp
+}
+
+// newNetworkCollectorFlags ...
+func newNetworkCollectorFlags(app *kingpin.Application) {
+	nicWhitelist = app.Flag(
+		FlagNicWhitelist,
+		"Regexp of NIC:s to whitelist. NIC name must both match whitelist and not match blacklist to be included.",
+	).Default(".+").String()
+	nicBlacklist = app.Flag(
+		FlagNicBlacklist,
+		"Regexp of NIC:s to blacklist. NIC name must both match whitelist and not match blacklist to be included.",
+	).Default("").String()
 }
 
 // newNetworkCollector ...

--- a/collector/process.go
+++ b/collector/process.go
@@ -15,15 +15,14 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
+const (
+	FlagProcessBlacklist = "collector.process.blacklist"
+	FlagProcessWhitelist = "collector.process.whitelist"
+)
+
 var (
-	processWhitelist = kingpin.Flag(
-		"collector.process.whitelist",
-		"Regexp of processes to include. Process name must both match whitelist and not match blacklist to be included.",
-	).Default(".*").String()
-	processBlacklist = kingpin.Flag(
-		"collector.process.blacklist",
-		"Regexp of processes to exclude. Process name must both match whitelist and not match blacklist to be included.",
-	).Default("").String()
+	processWhitelist *string
+	processBlacklist *string
 )
 
 type processCollector struct {
@@ -45,6 +44,18 @@ type processCollector struct {
 
 	processWhitelistPattern *regexp.Regexp
 	processBlacklistPattern *regexp.Regexp
+}
+
+// newProcessCollectorFlags ...
+func newProcessCollectorFlags(app *kingpin.Application) {
+	processWhitelist = app.Flag(
+		FlagProcessWhitelist,
+		"Regexp of processes to include. Process name must both match whitelist and not match blacklist to be included.",
+	).Default(".*").String()
+	processBlacklist = app.Flag(
+		FlagProcessBlacklist,
+		"Regexp of processes to exclude. Process name must both match whitelist and not match blacklist to be included.",
+	).Default("").String()
 }
 
 // NewProcessCollector ...

--- a/collector/scheduled_task.go
+++ b/collector/scheduled_task.go
@@ -16,15 +16,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	FlagScheduledTaskBlacklist = "collector.scheduled_task.blacklist"
+	FlagScheduledTaskWhitelist = "collector.scheduled_task.whitelist"
+)
+
 var (
-	taskWhitelist = kingpin.Flag(
-		"collector.scheduled_task.whitelist",
-		"Regexp of tasks to whitelist. Task path must both match whitelist and not match blacklist to be included.",
-	).Default(".+").String()
-	taskBlacklist = kingpin.Flag(
-		"collector.scheduled_task.blacklist",
-		"Regexp of tasks to blacklist. Task path must both match whitelist and not match blacklist to be included.",
-	).String()
+	taskWhitelist *string
+	taskBlacklist *string
 )
 
 type ScheduledTaskCollector struct {
@@ -62,6 +61,18 @@ type ScheduledTask struct {
 }
 
 type ScheduledTasks []ScheduledTask
+
+// newScheduledTask ...
+func newScheduledTaskFlags(app *kingpin.Application) {
+	taskWhitelist = app.Flag(
+		FlagScheduledTaskWhitelist,
+		"Regexp of tasks to whitelist. Task path must both match whitelist and not match blacklist to be included.",
+	).Default(".+").String()
+	taskBlacklist = app.Flag(
+		FlagScheduledTaskBlacklist,
+		"Regexp of tasks to blacklist. Task path must both match whitelist and not match blacklist to be included.",
+	).String()
+}
 
 // newScheduledTask ...
 func newScheduledTask() (Collector, error) {

--- a/collector/service.go
+++ b/collector/service.go
@@ -16,15 +16,14 @@ import (
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
+const (
+	FlagServiceWhereClause = "collector.service.services-where"
+	FlagServiceUseAPI      = "collector.service.use-api"
+)
+
 var (
-	serviceWhereClause = kingpin.Flag(
-		"collector.service.services-where",
-		"WQL 'where' clause to use in WMI metrics query. Limits the response to the services you specify and reduces the size of the response.",
-	).Default("").String()
-	useAPI = kingpin.Flag(
-		"collector.service.use-api",
-		"Use API calls to collect service data instead of WMI. Flag 'collector.service.services-where' won't be effective.",
-	).Default("false").Bool()
+	serviceWhereClause *string
+	useAPI             *bool
 )
 
 // A serviceCollector is a Prometheus collector for WMI Win32_Service metrics
@@ -35,6 +34,18 @@ type serviceCollector struct {
 	Status      *prometheus.Desc
 
 	queryWhereClause string
+}
+
+// newServiceCollectorFlags ...
+func newServiceCollectorFlags(app *kingpin.Application) {
+	serviceWhereClause = app.Flag(
+		FlagServiceWhereClause,
+		"WQL 'where' clause to use in WMI metrics query. Limits the response to the services you specify and reduces the size of the response.",
+	).Default("").String()
+	useAPI = app.Flag(
+		FlagServiceUseAPI,
+		"Use API calls to collect service data instead of WMI. Flag 'collector.service.services-where' won't be effective.",
+	).Default("false").Bool()
 }
 
 // newserviceCollector ...

--- a/collector/smtp.go
+++ b/collector/smtp.go
@@ -11,9 +11,14 @@ import (
 	"regexp"
 )
 
+const (
+	FlagSmtpServerBlacklist = "collector.smtp.server-blacklist"
+	FlagSmtpServerWhitelist = "collector.smtp.server-whitelist"
+)
+
 var (
-	serverWhitelist = kingpin.Flag("collector.smtp.server-whitelist", "Regexp of virtual servers to whitelist. Server name must both match whitelist and not match blacklist to be included.").Default(".+").String()
-	serverBlacklist = kingpin.Flag("collector.smtp.server-blacklist", "Regexp of virtual servers to blacklist. Server name must both match whitelist and not match blacklist to be included.").String()
+	serverWhitelist *string
+	serverBlacklist *string
 )
 
 type SMTPCollector struct {
@@ -62,6 +67,11 @@ type SMTPCollector struct {
 
 	serverWhitelistPattern *regexp.Regexp
 	serverBlacklistPattern *regexp.Regexp
+}
+
+func newSMTPCollectorFlags(app *kingpin.Application) {
+	serverWhitelist = app.Flag(FlagSmtpServerWhitelist, "Regexp of virtual servers to whitelist. Server name must both match whitelist and not match blacklist to be included.").Default(".+").String()
+	serverBlacklist = app.Flag(FlagSmtpServerBlacklist, "Regexp of virtual servers to blacklist. Server name must both match whitelist and not match blacklist to be included.").String()
 }
 
 func newSMTPCollector() (Collector, error) {

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -35,11 +35,12 @@ import (
 	"github.com/prometheus/common/expfmt"
 )
 
+const (
+	FlagTextFileDirectory = "collector.textfile.directory"
+)
+
 var (
-	textFileDirectory = kingpin.Flag(
-		"collector.textfile.directory",
-		"Directory to read text files with metrics from.",
-	).Default(getDefaultPath()).String()
+	textFileDirectory *string
 
 	mtimeDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "textfile", "mtime_seconds"),
@@ -53,6 +54,14 @@ type textFileCollector struct {
 	path string
 	// Only set for testing to get predictable output.
 	mtime *float64
+}
+
+// newTextFileCollectorFlags ...
+func newTextFileCollectorFlags(app *kingpin.Application) {
+	textFileDirectory = app.Flag(
+		FlagTextFileDirectory,
+		"Directory to read text files with metrics from.",
+	).Default(getDefaultPath()).String()
 }
 
 // newTextFileCollector returns a new Collector exposing metrics read from files


### PR DESCRIPTION
This PR remove the fluent-style usage of kingpin by an dedicated instance of kingpin. This allow programs to embed windows_exporter and pass a customized kingpin instance to all collectors.

At the moment, its hard to embedded windows_exporter in an other application. While its possible to feed the `kingpin.CommandLine` instance outside from windows_exporter, there are conflicts with other exporters do the same.

PR tested in a Windows 10 client machine.

Example Code for injected collector configuration into the embedded windows_exporter instance:

```go
// toExporterConfig converts integration Configs into windows_exporter configs.
func (c *Config) toExporterConfig(app *kingpin.Application) {
	app.GetFlag(collector.FlagDfsrEnabledCollectors).StringVar(&c.Dfsr.SourcesEnabled)
	app.GetFlag(collector.FlagExchangeCollectorsEnabled).StringVar(&c.Exchange.EnabledList)
	app.GetFlag(collector.FlagISSSiteBlacklist).StringVar(&c.IIS.SiteBlackList)
	app.GetFlag(collector.FlagISSSiteWhitelist).StringVar(&c.IIS.SiteWhiteList)
	app.GetFlag(collector.FlagISSAppBlacklist).StringVar(&c.IIS.AppBlackList)
	app.GetFlag(collector.FlagISSAppWhitelist).StringVar(&c.IIS.AppWhiteList)
	app.GetFlag(collector.FlagLogicalDiskVolumeBlacklist).StringVar(&c.LogicalDisk.BlackList)
	app.GetFlag(collector.FlagLogicalDiskVolumeWhitelist).StringVar(&c.LogicalDisk.WhiteList)
	app.GetFlag(collector.FlagMsmqWhereClause).StringVar(&c.MSMQ.Where)
	app.GetFlag(collector.FlagMssqlEnabledCollectors).StringVar(&c.MSSQL.EnabledClasses)
	app.GetFlag(collector.FlagNicBlacklist).StringVar(&c.Network.BlackList)
	app.GetFlag(collector.FlagNicWhitelist).StringVar(&c.Network.WhiteList)
	app.GetFlag(collector.FlagProcessBlacklist).StringVar(&c.Process.BlackList)
	app.GetFlag(collector.FlagProcessWhitelist).StringVar(&c.Process.WhiteList)
	app.GetFlag(collector.FlagScheduledTaskBlacklist).StringVar(&c.Process.BlackList)
	app.GetFlag(collector.FlagScheduledTaskWhitelist).StringVar(&c.Process.WhiteList)
	app.GetFlag(collector.FlagServiceWhereClause).StringVar(&c.Service.Where)
	app.GetFlag(collector.FlagServiceUseAPI).StringVar(&c.Service.UseApi)
	app.GetFlag(collector.FlagSmtpServerBlacklist).StringVar(&c.SMTP.BlackList)
	app.GetFlag(collector.FlagNicWhitelist).StringVar(&c.SMTP.WhiteList)
	app.GetFlag(collector.FlagTextFileDirectory).StringVar(&c.TextFile.TextFileDirectory)
}
```