### PR TITLE
Add service custom labels

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -56,10 +56,10 @@ type collectorBuilder func() (Collector, error)
 var (
 	builders                = make(map[string]collectorBuilder)
 	perfCounterDependencies = make(map[string]string)
-	config_hooks            = make(map[string]config.ConfigHook)
+	config_hooks            = make(map[string]config.CfgHook)
 )
 
-func registerCollector(name string, builder collectorBuilder, hooks map[string]config.ConfigHook, perfCounterNames ...string) {
+func registerCollector(name string, builder collectorBuilder, hooks map[string]config.CfgHook, perfCounterNames ...string) {
 	builders[name] = builder
 	addPerfCounterDependencies(name, perfCounterNames)
 	for k, v := range hooks {
@@ -82,7 +82,7 @@ func Available() []string {
 	}
 	return cs
 }
-func ConfigHooks() map[string]config.ConfigHook {
+func CfgHooks() map[string]config.CfgHook {
 	return config_hooks
 }
 func Build(collector string) (Collector, error) {

--- a/collector/init.go
+++ b/collector/init.go
@@ -13,8 +13,8 @@ type collectorInit struct {
 	// Perflib counter names for the collector.
 	// These will be included in the Perflib scrape scope by the exporter.
 	perfCounterNames []string
-	// builder fonction to intercept parameters for a collector
-	config_hooks map[string]config.ConfigHook
+	// builder function to intercept parameters for a collector
+	config_hooks map[string]config.CfgHook
 }
 
 func getCPUCollectorDeps() string {

--- a/collector/init.go
+++ b/collector/init.go
@@ -1,5 +1,9 @@
 package collector
 
+import (
+	"github.com/prometheus-community/windows_exporter/config"
+)
+
 // collectorInit represents the required initialisation config for a collector.
 type collectorInit struct {
 	// Name of collector to be initialised
@@ -9,6 +13,8 @@ type collectorInit struct {
 	// Perflib counter names for the collector.
 	// These will be included in the Perflib scrape scope by the exporter.
 	perfCounterNames []string
+	// builder fonction to intercept parameters for a collector
+	config_hooks map[string]config.ConfigHook
 }
 
 func getCPUCollectorDeps() string {
@@ -244,6 +250,7 @@ var collectors = []collectorInit{
 		name:             "service",
 		builder:          newserviceCollector,
 		perfCounterNames: nil,
+		config_hooks:     ServiceBuildHook(),
 	},
 	{
 		name:             "smtp",
@@ -304,6 +311,6 @@ var collectors = []collectorInit{
 // To be called by the exporter for collector initialisation
 func RegisterCollectors() {
 	for _, v := range collectors {
-		registerCollector(v.name, v.builder, v.perfCounterNames...)
+		registerCollector(v.name, v.builder, v.config_hooks, v.perfCounterNames...)
 	}
 }

--- a/collector/service.go
+++ b/collector/service.go
@@ -77,12 +77,12 @@ func expandServiceWhere(services string) string {
 	return b.String()
 }
 
-func ServiceBuildHook() map[string]config.ConfigHook {
-	config_hooks := &config.ConfigHook{
+func ServiceBuildHook() map[string]config.CfgHook {
+	config_hooks := &config.CfgHook{
 		ConfigAttrs: []string{"collector", "service", "services"},
 		Hook:        ServiceBuildMap,
 	}
-	entry := make(map[string]config.ConfigHook)
+	entry := make(map[string]config.CfgHook)
 	entry["services-list"] = *config_hooks
 	return entry
 }

--- a/collector/service.go
+++ b/collector/service.go
@@ -4,11 +4,13 @@
 package collector
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"syscall"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/prometheus-community/windows_exporter/config"
 	"github.com/prometheus-community/windows_exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/yusufpapurcu/wmi"
@@ -16,15 +18,26 @@ import (
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
+type ServiceDef struct {
+	Name         string
+	CustomLabels map[string]string
+}
+
 var (
 	serviceWhereClause = kingpin.Flag(
 		"collector.service.services-where",
 		"WQL 'where' clause to use in WMI metrics query. Limits the response to the services you specify and reduces the size of the response.",
 	).Default("").String()
+	serviceList = kingpin.Flag(
+		"collector.service.services-list",
+		"comma separated list of service name used to build WQL 'where' clause to use in WMI metrics query. Limits the response to the services you specify and reduces the size of the response.",
+	).Default("").String()
 	useAPI = kingpin.Flag(
 		"collector.service.use-api",
 		"Use API calls to collect service data instead of WMI. Flag 'collector.service.services-where' won't be effective.",
 	).Default("false").Bool()
+	services        = make(map[string]*ServiceDef)
+	services_labels = make([]string, 0)
 )
 
 // A serviceCollector is a Prometheus collector for WMI Win32_Service metrics
@@ -37,40 +50,193 @@ type serviceCollector struct {
 	queryWhereClause string
 }
 
+// Build service list for name
+func expandServiceWhere(services string) string {
+
+	separated := strings.Split(services, ",")
+	unique := map[string]bool{}
+	for _, s := range separated {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			unique[s] = true
+		}
+	}
+	var b bytes.Buffer
+
+	i := 0
+	for s := range unique {
+		i += 1
+		b.WriteString("Name='")
+		b.WriteString(s)
+		b.WriteString("'")
+		if i < len(unique) {
+			b.WriteString(" or ")
+		}
+
+	}
+	return b.String()
+}
+
+func ServiceBuildHook() map[string]config.ConfigHook {
+	config_hooks := &config.ConfigHook{
+		ConfigAttrs: []string{"collector", "service", "services"},
+		Hook:        ServiceBuildMap,
+	}
+	entry := make(map[string]config.ConfigHook)
+	entry["services-list"] = *config_hooks
+	return entry
+}
+
+func ServiceBuildMap(data interface{}) map[string]string {
+	ret := make(map[string]string)
+	switch typed := data.(type) {
+	case map[interface{}]interface{}:
+		ret = flatten(data)
+
+	// form is a dict of service's name maybe with custom labels
+	case map[string]interface{}:
+		for name, raw_labels := range typed {
+			labels := flatten(raw_labels)
+			service := &ServiceDef{
+				Name:         name,
+				CustomLabels: labels,
+			}
+			services[strings.ToLower(service.Name)] = service
+		}
+
+	// form is a list of services' name
+	case []interface{}:
+		for _, fv := range typed {
+			var name string
+			tmp := flatten(fv)
+			// tmp is a pseudo map with a key set and no value: collect first key
+			for k := range tmp {
+				name = k
+				break
+			}
+			service := &ServiceDef{
+				Name:         name,
+				CustomLabels: nil,
+			}
+			services[strings.ToLower(service.Name)] = service
+
+			// serviceHash[fmt.Sprint(idx)] = flatten(fv)
+		}
+
+	default:
+		ret["unknown_parameter"] = "1"
+		// serviceHash[fmt.Sprint(typed)] = 1
+	}
+
+	// build a list of all custom labels for each service
+	exists := make(map[string]bool)
+	for _, svc := range services {
+		// fill the exists map with all labels' names
+		for name := range svc.CustomLabels {
+			exists[name] = true
+		}
+	}
+	// check custom labels: each name must be present for each service
+	for _, svc := range services {
+		for name := range svc.CustomLabels {
+			if _, ok := exists[name]; !ok {
+				log.Warn("label: %s not present for service '%s'", name, svc.Name)
+				exists[name] = false
+			}
+		}
+	}
+	services_labels = make([]string, 0, len(exists))
+	for name := range exists {
+		services_labels = append(services_labels, name)
+	}
+	return ret
+}
+
+// convert map value to something that can be use as labels of service def
+func flatten(data interface{}) map[string]string {
+	ret := make(map[string]string)
+	switch typed := data.(type) {
+	// value is a map of we hope of strings
+	case map[string]interface{}:
+		for fk, fv := range typed {
+			ret[fk] = fmt.Sprint(fv)
+		}
+	// value is a string or nothing (list)
+	default:
+		if typed != nil {
+			ret[fmt.Sprint(typed)] = "1"
+		} else {
+			ret = nil
+		}
+	}
+	return ret
+}
+
 // newserviceCollector ...
 func newserviceCollector() (Collector, error) {
 	const subsystem = "service"
 
-	if *serviceWhereClause == "" {
+	if *serviceWhereClause == "" && *serviceList == "" && len(services) == 0 {
 		log.Warn("No where-clause specified for service collector. This will generate a very large number of metrics!")
 	}
+
+	if *serviceWhereClause == "" && *serviceList != "" {
+		*serviceWhereClause = expandServiceWhere(*serviceList)
+	} else if len(services) > 0 {
+		servList := make([]string, 0, len(services))
+		for _, svc := range services {
+			if svc != nil {
+				servList = append(servList, svc.Name)
+			}
+		}
+		svc := strings.Join(servList, ",")
+		*serviceWhereClause = expandServiceWhere(svc)
+	}
+
+	if *serviceWhereClause != "" {
+		log.Debug(fmt.Sprintf("serviceWhereClause='%s'", *serviceWhereClause))
+	}
+
 	if *useAPI {
 		log.Warn("API collection is enabled.")
+	}
+
+	var var_labels [4][]string
+	var_labels[0] = []string{"name", "display_name", "process_id", "run_as"}
+	var_labels[1] = []string{"name", "state"}
+	var_labels[2] = []string{"name", "start_mode"}
+	var_labels[3] = []string{"name", "status"}
+	if len(services_labels) > 0 {
+		for _, label := range services_labels {
+			for idx, metric_label := range var_labels {
+				var_labels[idx] = append(metric_label, label)
+			}
+		}
 	}
 
 	return &serviceCollector{
 		Information: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "info"),
 			"A metric with a constant '1' value labeled with service information",
-			[]string{"name", "display_name", "process_id", "run_as"},
+			var_labels[0],
 			nil,
 		),
 		State: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "state"),
 			"The state of the service (State)",
-			[]string{"name", "state"},
+			var_labels[1],
 			nil,
 		),
 		StartMode: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "start_mode"),
 			"The start mode of the service (StartMode)",
-			[]string{"name", "start_mode"},
+			var_labels[2],
 			nil,
 		),
 		Status: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "status"),
 			"The status of the service (Status)",
-			[]string{"name", "status"},
+			var_labels[3],
 			nil,
 		),
 		queryWhereClause: *serviceWhereClause,
@@ -163,61 +329,100 @@ func (c *serviceCollector) collectWMI(ch chan<- prometheus.Metric) error {
 		return err
 	}
 	for _, service := range dst {
-		pid := fmt.Sprintf("%d", uint64(service.ProcessId))
-
-		runAs := ""
-		if service.StartName != nil {
-			runAs = *service.StartName
+		// build the custom labels with their values for the service
+		var custom_labels []string
+		service_name := strings.ToLower(service.Name)
+		if len(services_labels) > 0 {
+			custom_labels = make([]string, len(services_labels))
+			if svc, ok := services[service_name]; ok {
+				// we find the service name in service definition list
+				for idx, label := range services_labels {
+					if val, tst := svc.CustomLabels[label]; tst {
+						custom_labels[idx] = val
+					}
+				}
+			} else {
+				// we don't find the service name !?!? not possible but...
+				for idx := range services_labels {
+					custom_labels[idx] = ""
+				}
+			}
 		}
+
+		// Information metric
+		labels := make([]string, 4)
+		// service name
+		labels[0] = service_name
+		// service display name
+		labels[1] = service.DisplayName
+		// service pid
+		labels[2] = fmt.Sprintf("%d", uint64(service.ProcessId))
+		// service runAs
+		if service.StartName != nil {
+			labels[3] = *service.StartName
+		} else {
+			labels[3] = ""
+		}
+		if len(custom_labels) > 0 {
+			labels = append(labels, custom_labels...)
+		}
+
 		ch <- prometheus.MustNewConstMetric(
 			c.Information,
 			prometheus.GaugeValue,
-			1.0,
-			strings.ToLower(service.Name),
-			service.DisplayName,
-			pid,
-			runAs,
+			1.0, labels...,
 		)
+
+		// State metric
+		labels = make([]string, 2)
+		// service name
+		labels[0] = service_name
+		labels[1] = ""
+		if len(custom_labels) > 0 {
+			labels = append(labels, custom_labels...)
+		}
 
 		for _, state := range allStates {
 			isCurrentState := 0.0
 			if state == strings.ToLower(service.State) {
 				isCurrentState = 1.0
 			}
+			labels[1] = state
 			ch <- prometheus.MustNewConstMetric(
 				c.State,
 				prometheus.GaugeValue,
 				isCurrentState,
-				strings.ToLower(service.Name),
-				state,
+				labels...,
 			)
 		}
 
+		// StartMode metric
 		for _, startMode := range allStartModes {
 			isCurrentStartMode := 0.0
 			if startMode == strings.ToLower(service.StartMode) {
 				isCurrentStartMode = 1.0
 			}
+			labels[1] = startMode
 			ch <- prometheus.MustNewConstMetric(
 				c.StartMode,
 				prometheus.GaugeValue,
 				isCurrentStartMode,
-				strings.ToLower(service.Name),
-				startMode,
+				labels...,
 			)
 		}
 
+		// service status metric
 		for _, status := range allStatuses {
 			isCurrentStatus := 0.0
 			if status == strings.ToLower(service.Status) {
 				isCurrentStatus = 1.0
 			}
+			labels[1] = status
 			ch <- prometheus.MustNewConstMetric(
 				c.Status,
 				prometheus.GaugeValue,
 				isCurrentStatus,
-				strings.ToLower(service.Name),
-				status,
+				labels...,
 			)
 		}
 	}
@@ -271,43 +476,82 @@ func (c *serviceCollector) collectAPI(ch chan<- prometheus.Metric) error {
 			continue
 		}
 
-		pid := fmt.Sprintf("%d", uint64(serviceStatus.ProcessId))
+		// build the custom labels with their values for the service
+		var custom_labels []string
+		service_name := strings.ToLower(service)
+		if len(services_labels) > 0 {
+			custom_labels = make([]string, len(services_labels))
+			if svc, ok := services[service_name]; ok {
+				// we find the service name in service definition list
+				for idx, label := range services_labels {
+					if val, tst := svc.CustomLabels[label]; tst {
+						custom_labels[idx] = val
+					}
+				}
+			} else {
+				// we don't find the service name !?!? not possible but...
+				for idx := range services_labels {
+					custom_labels[idx] = ""
+				}
+			}
+		}
 
+		// Information metric
+		labels := make([]string, 4)
+		// service name
+		labels[0] = service_name
+		// service display name
+		labels[1] = serviceConfig.DisplayName
+		// service pid
+		labels[2] = fmt.Sprintf("%d", uint64(serviceStatus.ProcessId))
+		// service runAs
+		labels[3] = serviceConfig.ServiceStartName
+
+		if len(custom_labels) > 0 {
+			labels = append(labels, custom_labels...)
+		}
 		ch <- prometheus.MustNewConstMetric(
 			c.Information,
 			prometheus.GaugeValue,
 			1.0,
-			strings.ToLower(service),
-			serviceConfig.DisplayName,
-			pid,
-			serviceConfig.ServiceStartName,
+			labels...,
 		)
+
+		// State metric
+		labels = make([]string, 2)
+		// service name
+		labels[0] = service_name
+		labels[1] = ""
+		if len(custom_labels) > 0 {
+			labels = append(labels, custom_labels...)
+		}
 
 		for _, state := range apiStateValues {
 			isCurrentState := 0.0
 			if state == apiStateValues[uint(serviceStatus.State)] {
 				isCurrentState = 1.0
 			}
+			labels[1] = state
 			ch <- prometheus.MustNewConstMetric(
 				c.State,
 				prometheus.GaugeValue,
 				isCurrentState,
-				strings.ToLower(service),
-				state,
+				labels...,
 			)
 		}
 
+		// StartMode metric
 		for _, startMode := range apiStartModeValues {
 			isCurrentStartMode := 0.0
 			if startMode == apiStartModeValues[serviceConfig.StartType] {
 				isCurrentStartMode = 1.0
 			}
+			labels[1] = startMode
 			ch <- prometheus.MustNewConstMetric(
 				c.StartMode,
 				prometheus.GaugeValue,
 				isCurrentStartMode,
-				strings.ToLower(service),
-				startMode,
+				labels...,
 			)
 		}
 	}

--- a/collector/service.go
+++ b/collector/service.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	FlagServiceWhereClause = "collector.service.services-where"
+	FlagServiceList        = "collector.service.services-list"
 	FlagServiceUseAPI      = "collector.service.use-api"
 )
 
@@ -30,13 +31,10 @@ type ServiceDef struct {
 
 var (
 	serviceWhereClause *string
-	serviceList        = kingpin.Flag(
-		"collector.service.services-list",
-		"comma separated list of service name used to build WQL 'where' clause to use in WMI metrics query. Limits the response to the services you specify and reduces the size of the response.",
-	).Default("").String()
-	useAPI          *bool
-	services        = make(map[string]*ServiceDef)
-	services_labels = make([]string, 0)
+	serviceList        *string
+	useAPI             *bool
+	services           = make(map[string]*ServiceDef)
+	services_labels    = make([]string, 0)
 )
 
 // A serviceCollector is a Prometheus collector for WMI Win32_Service metrics
@@ -59,6 +57,10 @@ func newServiceCollectorFlags(app *kingpin.Application) {
 		FlagServiceUseAPI,
 		"Use API calls to collect service data instead of WMI. Flag 'collector.service.services-where' won't be effective.",
 	).Default("false").Bool()
+	serviceList = app.Flag(
+		FlagServiceList,
+		"comma separated list of service name used to build WQL 'where' clause to use in WMI metrics query. Limits the response to the services you specify and reduces the size of the response.",
+	).Default("").String()
 }
 
 // Build service list for name

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -309,6 +309,7 @@ fileLoop:
 		// a failure does not appear fresh.
 		info, err := f.Info()
 		if err != nil {
+			log.Errorf("File Info error in file %s: %s. Skipping file processing.", f.Name(), err)
 			error = 1.0
 			continue
 		}

--- a/collector/textfile_test.go
+++ b/collector/textfile_test.go
@@ -1,10 +1,11 @@
 package collector
 
 import (
-	"github.com/dimchansky/utfbom"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
+
+	"github.com/dimchansky/utfbom"
 
 	dto "github.com/prometheus/client_model/go"
 )
@@ -12,7 +13,7 @@ import (
 func TestCRFilter(t *testing.T) {
 	sr := strings.NewReader("line 1\r\nline 2")
 	cr := carriageReturnFilteringReader{r: sr}
-	b, err := ioutil.ReadAll(cr)
+	b, err := io.ReadAll(cr)
 	if err != nil {
 		t.Error(err)
 	}

--- a/collector/thermalzone.go
+++ b/collector/thermalzone.go
@@ -75,7 +75,7 @@ func (c *thermalZoneCollector) collect(ch chan<- prometheus.Metric) (*prometheus
 
 	// ThermalZone collector has been known to 'successfully' return an empty result.
 	if len(dst) == 0 {
-		return nil, errors.New("Empty results set for collector")
+		return nil, errors.New("empty results set for collector")
 	}
 
 	for _, info := range dst {

--- a/collector/time.go
+++ b/collector/time.go
@@ -22,7 +22,7 @@ type TimeCollector struct {
 
 func newTimeCollector() (Collector, error) {
 	if getWindowsVersion() <= 6.1 {
-		return nil, errors.New("Windows version older than Server 2016 detected. The time collector will not run and should be disabled via CLI flags or configuration file")
+		return nil, errors.New("windows version older than Server 2016 detected. The time collector will not run and should be disabled via CLI flags or configuration file")
 
 	}
 	const subsystem = "time"

--- a/config/config.go
+++ b/config/config.go
@@ -32,16 +32,16 @@ type Resolver struct {
 
 type HookFunc func(interface{}) map[string]string
 
-type ConfigHook struct {
+type CfgHook struct {
 	ConfigAttrs []string
 	Hook        HookFunc
 }
 
-type ConfigHooks map[string]ConfigHook
+type CfgHooks map[string]CfgHook
 
-func (c *ConfigHook) match(key string, val interface{}, level int) (bool, interface{}) {
-	var ok bool = false
+func (c *CfgHook) match(key string, val interface{}, level int) (bool, interface{}) {
 	var res interface{}
+	ok := false
 	if level < len(c.ConfigAttrs) {
 		if c.ConfigAttrs[level] == key {
 			level++
@@ -74,9 +74,9 @@ func (c *ConfigHook) match(key string, val interface{}, level int) (bool, interf
 	return ok, res
 }
 
-func (c *ConfigHooks) Match(key string, val interface{}) (map[string]interface{}, bool) {
-	var ok bool = false
+func (c *CfgHooks) Match(key string, val interface{}) (map[string]interface{}, bool) {
 	var value interface{}
+	ok := false
 	params := make(map[string]interface{})
 
 	for varname, hook := range *c {
@@ -89,7 +89,7 @@ func (c *ConfigHooks) Match(key string, val interface{}) (map[string]interface{}
 }
 
 // NewResolver returns a Resolver structure.
-func NewResolver(file string, hooks ConfigHooks) (*Resolver, error) {
+func NewResolver(file string, hooks CfgHooks) (*Resolver, error) {
 	flags := map[string]string{}
 	log.Infof("Loading configuration file: %v", file)
 	if _, err := os.Stat(file); err != nil {

--- a/docs/collector.service.md
+++ b/docs/collector.service.md
@@ -30,7 +30,7 @@ Uses API calls instead of WMI for performance optimization. **Note** the previou
 
 ### service list with custom labels (config file only)
 
-Define a dictionnary of services to monitor, and for each of them a specific value of labels.
+Define a dictionary of services to monitor, and for each of them a specific value of labels.
 
 ```yml
 collector:

--- a/exporter.go
+++ b/exporter.go
@@ -298,8 +298,14 @@ func main() {
 	// to load the specified file(s).
 	kingpin.Parse()
 	log.Debug("Logging has Started")
+
+	initWbem()
+
+	// Initialize collectors before loading
+	collector.RegisterCollectors()
+
 	if *configFile != "" {
-		resolver, err := config.NewResolver(*configFile)
+		resolver, err := config.NewResolver(*configFile, collector.ConfigHooks())
 		if err != nil {
 			log.Fatalf("could not load config file: %v\n", err)
 		}
@@ -330,11 +336,6 @@ func main() {
 		}
 		return
 	}
-
-	initWbem()
-
-	// Initialize collectors before loading
-	collector.RegisterCollectors()
 
 	collectors, err := loadCollectors(*enabledCollectors)
 	if err != nil {


### PR DESCRIPTION
replace previous PR [PR#1180](https://github.com/prometheus-community/windows_exporter/pull/1180), [PR#1185](https://github.com/prometheus-community/windows_exporter/pull/1185)

This PR adds some feature to service collector:
 - add config parameter **collector.service.services-list** with a comma separated list of service names:
 ```yml
collector:
  service:
    services-list: windows_exporter, winRM, pushprox_client, Dhcp
```
the param will only be checked if services-where is not set.
the list will be used to build a service-where query based on Name and is equivalent to:
```yml
collector:
  service:
    services-where: "Name = 'elmt_1' or Name = "elmt_X' or ..."
```
 - add a new parameter that can only be set in config file: 
It allows to set any number of custom labels value for each service:
e.g.:
```yml
collector:
  service:
    services:
      windows_exporter:
        application: prometheus
        custom1: val1
      pushprox_client:
        application: prometheus
        custom1: val1
      winRM:
        application: windows
        custom1: val2
      Dhcp:
        application: windows
        custom1: val3
```
Use case: allow to build a generic Prometheus alert on not running service and to use the specified associated labels to drive a specific behavior. For me they are used to route for a specific documentation based on context.<br>
Label's names must be identical for each service. Not identical labels names are removed !
This parameter as a lower priority than service-where and service-list.
It accepts a dict (see above example) or a list; in this case it behaves like services-list.
e.g.:
```yml
collector:
  service:
    services:
      - dhcp
      - pushprox_client
      - windows_exporter
      - winRM
```


Then generic alert services:

```yml
groups:
- name: Window Server Alerts
  rules:

  # Sends an alert when the 'sqlserveragent' service is not in the running state for 3 minutes.
  - alert: WindowServiceNotRunning
    expr: windows_service_state{state="running"} == 0
    for: 3m
    labels:
      severity: high
    annotations:
      summary: "Service {{ $labels.name }} for {{ $labels.application }} down for 3 min."
      description: "Service {{ $labels.name }} for Application {{ $labels.application }} on instance {{ $labels.instance }} has been down for more than 3 minutes."
```
