### PR TITLE
add service cmd flag and custom labels, add process metric (process_gorup_count) add process custom labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,15 @@ The prometheus metrics will be exposed on [localhost:9182](http://localhost:9182
 
 ### Enable only service collector and specify a custom query
 
-    .\windows_exporter.exe --collectors.enabled "service" --collector.service.services-where "Name='windows_exporter'"
+```shell
+.\windows_exporter.exe --collectors.enabled "service" --collector.service.services-where "Name='windows_exporter'"
+```
+
+or
+
+```shell
+.\windows_exporter.exe --collectors.enabled "service" --collector.service.services-list "windows_exporter"
+```
 
 ### Enable only process collector and specify a custom query
 

--- a/collector/process.go
+++ b/collector/process.go
@@ -203,6 +203,17 @@ func (c *processCollector) Match(proc_name string) (bool, *ProcessDef) {
 	}
 	return ok, proc
 }
+func (pdef *ProcessDef) Debug(logger log.Logger) {
+	inc_pat := "_"
+	exc_pat := "_"
+	if pdef.Include != nil {
+		inc_pat = pdef.Include.String()
+	}
+	if pdef.Exclude != nil {
+		exc_pat = pdef.Exclude.String()
+	}
+	_ = level.Debug(logger).Log("msg", fmt.Sprintf("process Matcher '%s' include: '%s' exclude: '%s'", pdef.Name, inc_pat, exc_pat))
+}
 
 // NewProcessCollector ...
 func newProcessCollector(logger log.Logger) (Collector, error) {
@@ -242,18 +253,12 @@ func newProcessCollector(logger log.Logger) (Collector, error) {
 				Exclude:      exclude,
 				CustomLabels: nil,
 			}
+			pdef := processes["default"]
+			pdef.Debug(logger)
 		} else {
 			if len(processes) > 0 {
 				for _, pdef := range processes {
-					inc_pat := "_"
-					exc_pat := "_"
-					if pdef.Include != nil {
-						inc_pat = pdef.Include.String()
-					}
-					if pdef.Exclude != nil {
-						exc_pat = pdef.Exclude.String()
-					}
-					_ = level.Debug(logger).Log("msg", fmt.Sprintf("process Matcher '%s' include: '%s' exclude: '%s'", pdef.Name, inc_pat, exc_pat))
+					pdef.Debug(logger)
 				}
 			}
 		}

--- a/collector/process.go
+++ b/collector/process.go
@@ -428,6 +428,7 @@ func (c *processCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metr
 		dst_wp        []WorkerProcess
 		pdef          *ProcessDef
 		custom_labels []string
+		labels        []string
 	)
 	if *enableWorkerProcess {
 		q_wp := queryAll(&dst_wp, c.logger)
@@ -479,7 +480,7 @@ func (c *processCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metr
 		labels_value[0] = processName
 		labels_value[1] = pid
 		labels_value[2] = cpid
-		if pdef != nil && len(c.ProcessesLabels) > 0 {
+		if len(c.ProcessesLabels) > 0 {
 			custom_labels = make([]string, len(c.ProcessesLabels))
 			// we find the service name in service definition list
 			for idx, label := range c.ProcessesLabels {
@@ -488,14 +489,13 @@ func (c *processCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metr
 				}
 			}
 
-		} else {
-			// we don't find the service name !?!? not possible but...
-			for idx := range services_labels {
-				custom_labels[idx] = ""
-			}
 		}
 
-		labels := append(labels_value, custom_labels...)
+		if len(custom_labels) > 0 {
+			labels = append(labels_value, custom_labels...)
+		} else {
+			labels = labels_value
+		}
 
 		// metrics with var_labels[0] format
 		ch <- prometheus.MustNewConstMetric(

--- a/collector/process.go
+++ b/collector/process.go
@@ -181,7 +181,7 @@ func ProcessBuildMap(logger log.Logger, data interface{}) map[string]string {
 // check if process name is matching one of include or exclude pattern of processDef
 func (c *processCollector) Match(proc_name string) (bool, *ProcessDef) {
 	var (
-		ok   bool = false
+		ok   = false
 		proc *ProcessDef
 	)
 	for _, p := range c.Processes {

--- a/collector/process.go
+++ b/collector/process.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus-community/windows_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/yusufpapurcu/wmi"
 )
@@ -25,6 +26,14 @@ const (
 	FlagProcessInclude = "collector.process.include"
 )
 
+type ProcessDef struct {
+	Name         string
+	Include      *regexp.Regexp
+	Exclude      *regexp.Regexp
+	CustomLabels map[string]string
+	Count        int
+}
+
 var (
 	processOldInclude *string
 	processOldExclude *string
@@ -36,6 +45,8 @@ var (
 	processExcludeSet bool
 
 	enableWorkerProcess *bool
+	processes           = make(map[string]*ProcessDef)
+	processes_labels    = make([]string, 0)
 )
 
 type processCollector struct {
@@ -56,9 +67,10 @@ type processCollector struct {
 	WorkingSetPrivate *prometheus.Desc
 	WorkingSetPeak    *prometheus.Desc
 	WorkingSet        *prometheus.Desc
+	ProcessGroupCount *prometheus.Desc
 
-	processIncludePattern *regexp.Regexp
-	processExcludePattern *regexp.Regexp
+	Processes       map[string]*ProcessDef
+	ProcessesLabels []string
 }
 
 // newProcessCollectorFlags ...
@@ -94,6 +106,104 @@ func newProcessCollectorFlags(app *kingpin.Application) {
 	).Hidden().String()
 }
 
+func ProcessBuildHook() map[string]config.CfgHook {
+	config_hooks := &config.CfgHook{
+		ConfigAttrs: []string{"collector", "process", "processes"},
+		Hook:        ProcessBuildMap,
+	}
+	entry := make(map[string]config.CfgHook)
+	entry["processes-list"] = *config_hooks
+	return entry
+}
+
+func ProcessBuildMap(logger log.Logger, data interface{}) map[string]string {
+	ret := make(map[string]string)
+	switch typed := data.(type) {
+	case map[interface{}]interface{}:
+		ret = flatten(data)
+
+	// form is a dict of service's name maybe with custom labels
+	case map[string]interface{}:
+		for name, raw_labels := range typed {
+			var (
+				include, exclude *regexp.Regexp
+			)
+			labels := flatten(raw_labels)
+			if inc, ok := labels["include"]; ok {
+				if inc != "" {
+					include = regexp.MustCompile(fmt.Sprintf("^(?:%s)$", inc))
+				}
+				delete(labels, "include")
+			}
+			if exc, ok := labels["exclude"]; ok {
+				if exc != "" {
+					exclude = regexp.MustCompile(fmt.Sprintf("^(?:%s)$", exc))
+				}
+				delete(labels, "exclude")
+			}
+			process := &ProcessDef{
+				Name:         name,
+				Include:      include,
+				Exclude:      exclude,
+				CustomLabels: labels,
+			}
+
+			processes[strings.ToLower(process.Name)] = process
+		}
+	default:
+		ret["unknown_parameter"] = "1"
+	}
+
+	// build a list of all custom labels for each component
+	exists := make(map[string]bool)
+	for _, proc := range processes {
+		// fill the exists map with all labels' names
+		for name := range proc.CustomLabels {
+			exists[name] = true
+		}
+	}
+	// check custom labels: each name must be present for each component
+	for _, proc := range processes {
+		for name := range proc.CustomLabels {
+			if _, ok := exists[name]; !ok {
+				_ = level.Warn(logger).Log("errmsg", "label: %s not present for process pattern '%s'", name, proc.Name)
+				exists[name] = false
+			}
+		}
+	}
+	processes_labels = make([]string, 0, len(exists))
+	for name := range exists {
+		processes_labels = append(processes_labels, name)
+	}
+	return ret
+}
+
+// check if process name is matching one of include or exclude pattern of processDef
+func (c *processCollector) Match(proc_name string) (bool, *ProcessDef) {
+	var (
+		ok   bool = false
+		proc *ProcessDef
+	)
+	for _, p := range c.Processes {
+		// when include pattern is defined check if proc_name match include pattern
+		if p.Include != nil && p.Include.MatchString(proc_name) {
+			ok = true
+			proc = p
+		}
+
+		if p.Exclude != nil {
+			if p.Exclude.MatchString(proc_name) {
+				ok = false
+				proc = nil
+			}
+		} else if ok {
+			// exclude not defined and proc is in include we got procDef
+			break
+		}
+	}
+	return ok, proc
+}
+
 // NewProcessCollector ...
 func newProcessCollector(logger log.Logger) (Collector, error) {
 	const subsystem = "process"
@@ -115,105 +225,153 @@ func newProcessCollector(logger log.Logger) (Collector, error) {
 			return nil, errors.New("--collector.process.whitelist and --collector.process.include are mutually exclusive")
 		}
 	}
-
-	if *processInclude == ".*" && *processExclude == "" {
+	if *processInclude == ".*" && *processExclude == "" && len(processes) <= 0 {
 		_ = level.Warn(logger).Log("msg", "No filters specified for process collector. This will generate a very large number of metrics!")
+	} else {
+		if *processInclude != ".*" || *processExclude != "" {
+			var include, exclude *regexp.Regexp
+			if *processInclude != "" {
+				include = regexp.MustCompile(fmt.Sprintf("^(?:%s)$", *processInclude))
+			}
+			if *processExclude != "" {
+				exclude = regexp.MustCompile(fmt.Sprintf("^(?:%s)$", *processExclude))
+			}
+			processes["default"] = &ProcessDef{
+				Name:         "default",
+				Include:      include,
+				Exclude:      exclude,
+				CustomLabels: nil,
+			}
+		} else {
+			if len(processes) > 0 {
+				for _, pdef := range processes {
+					inc_pat := "_"
+					exc_pat := "_"
+					if pdef.Include != nil {
+						inc_pat = pdef.Include.String()
+					}
+					if pdef.Exclude != nil {
+						exc_pat = pdef.Exclude.String()
+					}
+					_ = level.Debug(logger).Log("msg", fmt.Sprintf("process Matcher '%s' include: '%s' exclude: '%s'", pdef.Name, inc_pat, exc_pat))
+				}
+			}
+		}
 	}
 
+	var var_labels [4][]string
+	var_labels[0] = []string{"process", "process_id", "creating_process_id"}
+	var_labels[1] = []string{"process", "process_id", "creating_process_id", "mode"}
+	var_labels[2] = []string{"process", "process_id", "creating_process_id", "pool"}
+	var_labels[3] = []string{"group"}
+	if len(processes_labels) > 0 {
+		for _, label := range processes_labels {
+			for idx, metric_label := range var_labels {
+				var_labels[idx] = append(metric_label, label)
+			}
+		}
+	}
 	return &processCollector{
 		logger: logger,
 		StartTime: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "start_time"),
 			"Time of process start.",
-			[]string{"process", "process_id", "creating_process_id"},
+			var_labels[0],
 			nil,
 		),
 		CPUTimeTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "cpu_time_total"),
 			"Returns elapsed time that all of the threads of this process used the processor to execute instructions by mode (privileged, user).",
-			[]string{"process", "process_id", "creating_process_id", "mode"},
+			var_labels[1],
 			nil,
 		),
 		HandleCount: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "handles"),
 			"Total number of handles the process has open. This number is the sum of the handles currently open by each thread in the process.",
-			[]string{"process", "process_id", "creating_process_id"},
+			var_labels[0],
 			nil,
 		),
 		IOBytesTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "io_bytes_total"),
 			"Bytes issued to I/O operations in different modes (read, write, other).",
-			[]string{"process", "process_id", "creating_process_id", "mode"},
+			var_labels[1],
 			nil,
 		),
 		IOOperationsTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "io_operations_total"),
 			"I/O operations issued in different modes (read, write, other).",
-			[]string{"process", "process_id", "creating_process_id", "mode"},
+			var_labels[1],
 			nil,
 		),
 		PageFaultsTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "page_faults_total"),
 			"Page faults by the threads executing in this process.",
-			[]string{"process", "process_id", "creating_process_id"},
+			var_labels[0],
 			nil,
 		),
 		PageFileBytes: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "page_file_bytes"),
 			"Current number of bytes this process has used in the paging file(s).",
-			[]string{"process", "process_id", "creating_process_id"},
+			var_labels[0],
 			nil,
 		),
 		PoolBytes: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "pool_bytes"),
 			"Pool Bytes is the last observed number of bytes in the paged or nonpaged pool.",
-			[]string{"process", "process_id", "creating_process_id", "pool"},
+			var_labels[2],
 			nil,
 		),
 		PriorityBase: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "priority_base"),
 			"Current base priority of this process. Threads within a process can raise and lower their own base priority relative to the process base priority of the process.",
-			[]string{"process", "process_id", "creating_process_id"},
+			var_labels[0],
 			nil,
 		),
 		PrivateBytes: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "private_bytes"),
 			"Current number of bytes this process has allocated that cannot be shared with other processes.",
-			[]string{"process", "process_id", "creating_process_id"},
+			var_labels[0],
 			nil,
 		),
 		ThreadCount: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "threads"),
 			"Number of threads currently active in this process.",
-			[]string{"process", "process_id", "creating_process_id"},
+			var_labels[0],
 			nil,
 		),
 		VirtualBytes: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "virtual_bytes"),
 			"Current size, in bytes, of the virtual address space that the process is using.",
-			[]string{"process", "process_id", "creating_process_id"},
+			var_labels[0],
 			nil,
 		),
 		WorkingSetPrivate: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "working_set_private_bytes"),
 			"Size of the working set, in bytes, that is use for this process only and not shared nor shareable by other processes.",
-			[]string{"process", "process_id", "creating_process_id"},
+			var_labels[0],
 			nil,
 		),
 		WorkingSetPeak: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "working_set_peak_bytes"),
 			"Maximum size, in bytes, of the Working Set of this process at any point in time. The Working Set is the set of memory pages touched recently by the threads in the process.",
-			[]string{"process", "process_id", "creating_process_id"},
+			var_labels[0],
 			nil,
 		),
 		WorkingSet: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "working_set_bytes"),
 			"Maximum number of bytes in the working set of this process at any point in time. The working set is the set of memory pages touched recently by the threads in the process.",
-			[]string{"process", "process_id", "creating_process_id"},
+			var_labels[0],
 			nil,
 		),
-		processIncludePattern: regexp.MustCompile(fmt.Sprintf("^(?:%s)$", *processInclude)),
-		processExcludePattern: regexp.MustCompile(fmt.Sprintf("^(?:%s)$", *processExclude)),
+		ProcessGroupCount: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "group_count"),
+			"Number of processes found for the matching patterns.",
+			var_labels[3],
+			nil,
+		),
+
+		Processes:       processes,
+		ProcessesLabels: processes_labels,
 	}, nil
 }
 
@@ -261,7 +419,11 @@ func (c *processCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metr
 		return err
 	}
 
-	var dst_wp []WorkerProcess
+	var (
+		dst_wp        []WorkerProcess
+		pdef          *ProcessDef
+		custom_labels []string
+	)
 	if *enableWorkerProcess {
 		q_wp := queryAll(&dst_wp, c.logger)
 		if err := wmi.QueryNamespace(q_wp, &dst_wp, "root\\WebAdministration"); err != nil {
@@ -269,12 +431,32 @@ func (c *processCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metr
 		}
 	}
 
+	// we have 3 models for labels
+	//var_labels[0] = []string{"process", "process_id", "creating_process_id"}
+	//var_labels[1] = []string{"process", "process_id", "creating_process_id", "mode"}
+	//var_labels[2] = []string{"process", "process_id", "creating_process_id", "pool"}
+	// for processs_group_count
+	//var_labels[3] = []string{"group"}
+
+	// reset counter for processes_group
+	for _, procdef := range c.Processes {
+		procdef.Count = 0
+	}
+
 	for _, process := range data {
-		if process.Name == "_Total" ||
-			c.processExcludePattern.MatchString(process.Name) ||
-			!c.processIncludePattern.MatchString(process.Name) {
+		if process.Name == "_Total" {
 			continue
 		}
+		if ok, procdef := c.Match(process.Name); !ok {
+			continue
+		} else {
+			pdef = procdef
+			// increment group counter
+			if pdef != nil {
+				pdef.Count++
+			}
+		}
+
 		// Duplicate processes are suffixed # and an index number. Remove those.
 		processName := strings.Split(process.Name, "#")[0]
 		pid := strconv.FormatUint(uint64(process.IDProcess), 10)
@@ -288,204 +470,209 @@ func (c *processCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metr
 				}
 			}
 		}
+		labels_value := make([]string, 3)
+		labels_value[0] = processName
+		labels_value[1] = pid
+		labels_value[2] = cpid
+		if pdef != nil && len(c.ProcessesLabels) > 0 {
+			custom_labels = make([]string, len(c.ProcessesLabels))
+			// we find the service name in service definition list
+			for idx, label := range c.ProcessesLabels {
+				if val, tst := pdef.CustomLabels[label]; tst {
+					custom_labels[idx] = val
+				}
+			}
 
+		} else {
+			// we don't find the service name !?!? not possible but...
+			for idx := range services_labels {
+				custom_labels[idx] = ""
+			}
+		}
+
+		labels := append(labels_value, custom_labels...)
+
+		// metrics with var_labels[0] format
 		ch <- prometheus.MustNewConstMetric(
 			c.StartTime,
 			prometheus.GaugeValue,
 			process.ElapsedTime,
-			processName,
-			pid,
-			cpid,
+			labels...,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.HandleCount,
 			prometheus.GaugeValue,
 			process.HandleCount,
-			processName,
-			pid,
-			cpid,
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.CPUTimeTotal,
-			prometheus.CounterValue,
-			process.PercentPrivilegedTime,
-			processName,
-			pid,
-			cpid,
-			"privileged",
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.CPUTimeTotal,
-			prometheus.CounterValue,
-			process.PercentUserTime,
-			processName,
-			pid,
-			cpid,
-			"user",
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.IOBytesTotal,
-			prometheus.CounterValue,
-			process.IOOtherBytesPerSec,
-			processName,
-			pid,
-			cpid,
-			"other",
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.IOOperationsTotal,
-			prometheus.CounterValue,
-			process.IOOtherOperationsPerSec,
-			processName,
-			pid,
-			cpid,
-			"other",
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.IOBytesTotal,
-			prometheus.CounterValue,
-			process.IOReadBytesPerSec,
-			processName,
-			pid,
-			cpid,
-			"read",
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.IOOperationsTotal,
-			prometheus.CounterValue,
-			process.IOReadOperationsPerSec,
-			processName,
-			pid,
-			cpid,
-			"read",
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.IOBytesTotal,
-			prometheus.CounterValue,
-			process.IOWriteBytesPerSec,
-			processName,
-			pid,
-			cpid,
-			"write",
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.IOOperationsTotal,
-			prometheus.CounterValue,
-			process.IOWriteOperationsPerSec,
-			processName,
-			pid,
-			cpid,
-			"write",
+			labels...,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.PageFaultsTotal,
 			prometheus.CounterValue,
 			process.PageFaultsPerSec,
-			processName,
-			pid,
-			cpid,
+			labels...,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.PageFileBytes,
 			prometheus.GaugeValue,
 			process.PageFileBytes,
-			processName,
-			pid,
-			cpid,
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.PoolBytes,
-			prometheus.GaugeValue,
-			process.PoolNonpagedBytes,
-			processName,
-			pid,
-			cpid,
-			"nonpaged",
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.PoolBytes,
-			prometheus.GaugeValue,
-			process.PoolPagedBytes,
-			processName,
-			pid,
-			cpid,
-			"paged",
+			labels...,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.PriorityBase,
 			prometheus.GaugeValue,
 			process.PriorityBase,
-			processName,
-			pid,
-			cpid,
+			labels...,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.PrivateBytes,
 			prometheus.GaugeValue,
 			process.PrivateBytes,
-			processName,
-			pid,
-			cpid,
+			labels...,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.ThreadCount,
 			prometheus.GaugeValue,
 			process.ThreadCount,
-			processName,
-			pid,
-			cpid,
+			labels...,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.VirtualBytes,
 			prometheus.GaugeValue,
 			process.VirtualBytes,
-			processName,
-			pid,
-			cpid,
+			labels...,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.WorkingSetPrivate,
 			prometheus.GaugeValue,
 			process.WorkingSetPrivate,
-			processName,
-			pid,
-			cpid,
+			labels...,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.WorkingSetPeak,
 			prometheus.GaugeValue,
 			process.WorkingSetPeak,
-			processName,
-			pid,
-			cpid,
+			labels...,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.WorkingSet,
 			prometheus.GaugeValue,
 			process.WorkingSet,
-			processName,
-			pid,
-			cpid,
+			labels...,
+		)
+
+		// metrics with var_labels[1] format
+		labels_value = append(labels_value, "privileged")
+		labels = append(labels_value, custom_labels...)
+		ch <- prometheus.MustNewConstMetric(
+			c.CPUTimeTotal,
+			prometheus.CounterValue,
+			process.PercentPrivilegedTime,
+			labels...,
+		)
+
+		labels_value[3] = "user"
+		labels = append(labels_value, custom_labels...)
+		ch <- prometheus.MustNewConstMetric(
+			c.CPUTimeTotal,
+			prometheus.CounterValue,
+			process.PercentUserTime,
+			labels...,
+		)
+
+		labels_value[3] = "other"
+		labels = append(labels_value, custom_labels...)
+		ch <- prometheus.MustNewConstMetric(
+			c.IOBytesTotal,
+			prometheus.CounterValue,
+			process.IOOtherBytesPerSec,
+			labels...,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.IOOperationsTotal,
+			prometheus.CounterValue,
+			process.IOOtherOperationsPerSec,
+			labels...,
+		)
+
+		labels_value[3] = "read"
+		labels = append(labels_value, custom_labels...)
+		ch <- prometheus.MustNewConstMetric(
+			c.IOBytesTotal,
+			prometheus.CounterValue,
+			process.IOReadBytesPerSec,
+			labels...,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.IOOperationsTotal,
+			prometheus.CounterValue,
+			process.IOReadOperationsPerSec,
+			labels...,
+		)
+
+		labels_value[3] = "write"
+		labels = append(labels_value, custom_labels...)
+		ch <- prometheus.MustNewConstMetric(
+			c.IOBytesTotal,
+			prometheus.CounterValue,
+			process.IOWriteBytesPerSec,
+			labels...,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.IOOperationsTotal,
+			prometheus.CounterValue,
+			process.IOWriteOperationsPerSec,
+			labels...,
+		)
+
+		labels_value[3] = "nonpaged"
+		labels = append(labels_value, custom_labels...)
+		ch <- prometheus.MustNewConstMetric(
+			c.PoolBytes,
+			prometheus.GaugeValue,
+			process.PoolNonpagedBytes,
+			labels...,
+		)
+
+		labels_value[3] = "paged"
+		labels = append(labels_value, custom_labels...)
+		ch <- prometheus.MustNewConstMetric(
+			c.PoolBytes,
+			prometheus.GaugeValue,
+			process.PoolPagedBytes,
+			labels...,
+		)
+
+	}
+	// add metric for processes_group
+	for _, procdef := range c.Processes {
+		labels_value := []string{procdef.Name}
+
+		custom_labels = make([]string, len(c.ProcessesLabels))
+		// we find the service name in service definition list
+		for idx, label := range c.ProcessesLabels {
+			if val, tst := procdef.CustomLabels[label]; tst {
+				custom_labels[idx] = val
+			}
+		}
+		labels := append(labels_value, custom_labels...)
+		ch <- prometheus.MustNewConstMetric(
+			c.ProcessGroupCount,
+			prometheus.GaugeValue,
+			float64(procdef.Count),
+			labels...,
 		)
 	}
 

--- a/collector/service.go
+++ b/collector/service.go
@@ -81,7 +81,7 @@ func expandServiceWhere(services string) string {
 
 	i := 0
 	for s := range unique {
-		i += 1
+		i++
 		b.WriteString("Name='")
 		b.WriteString(s)
 		b.WriteString("'")
@@ -484,7 +484,7 @@ func (c *serviceCollector) collectAPI(ch chan<- prometheus.Metric) error {
 		// Get Service Configuration.
 		serviceConfig, err := serviceManager.Config()
 		if err != nil {
-			_ = level.Warn(c.logger).Log("msg", fmt.Sprintf("Get ervice %s config error:  %#v", service, err))
+			_ = level.Warn(c.logger).Log("msg", fmt.Sprintf("Get service %s config error:  %#v", service, err))
 			continue
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -87,7 +87,7 @@ func (c *CfgHook) match(key string, val interface{}, level int) (bool, interface
 	return ok, res
 }
 
-// try to find if a key from config file has a matching entry point sequence that correponds to a Hook function.
+// try to find if a key from config file has a matching entry point sequence that corresponds to a Hook function.
 // loop on key,val from config map(level 0) to lookup up for a hook
 //
 // e.g.: map[collector][service][services] => "collector", "service", "services"

--- a/docs/collector.process.md
+++ b/docs/collector.process.md
@@ -52,7 +52,7 @@ This will match all processes named `firefox`, `FIREFOX` or `chrome` .
 
 Define a dictionary of process to monitor, and for each of them a specific set of labels.
 
-:warning: This option is overriden if command line flags "collector.process.include" or "collector.process.exclude" are set.
+:warning: This option is overridden if command line flags "collector.process.include" or "collector.process.exclude" are set.
 
 - syntax is:
 
@@ -131,7 +131,7 @@ Name | Description | Type | Labels
 `windows_process_working_set_private_bytes` | Size of the working set, in bytes, that is use for this process only and not shared nor shareable by other processes. | gauge | `process`, `process_id`, `creating_process_id`
 `windows_process_working_set_peak_bytes` | Maximum size, in bytes, of the Working Set of this process at any point in time. The Working Set is the set of memory pages touched recently by the threads in the process. If free memory in the computer is above a threshold, pages are left in the Working Set of a process even if they are not in use. When free memory falls below a threshold, pages are trimmed from Working Sets. If they are needed they will then be soft-faulted back into the Working Set before they leave main memory. | gauge | `process`, `process_id`, `creating_process_id`
 `windows_process_working_set_bytes` | Maximum number of bytes in the working set of this process at any point in time. The working set is the set of memory pages touched recently by the threads in the process. If free memory in the computer is above a threshold, pages are left in the working set of a process even if they are not in use. When free memory falls below a threshold, pages are trimmed from working sets. If they are needed, they are then soft-faulted back into the working set before they leave main memory. | gauge | `process`, `process_id`, `creating_process_id`
-`windows_process_group_count` | Number of process matching the patterns (include, exclude).If no process matchs the value will be set to 0. This metric wan be used to monitor the presence of process | gauge | `process group name` or `default` when using default config  option `--collector.process.include` `--collector.process.exclude`
+`windows_process_group_count` | Number of process matching the patterns (include, exclude).If no process matches the value will be set to 0. This metric wan be used to monitor the presence of process | gauge | `process group name` or `default` when using default config  option `--collector.process.include` `--collector.process.exclude`
 
 ### Example metric
 

--- a/docs/collector.service.md
+++ b/docs/collector.service.md
@@ -22,6 +22,36 @@ Example config win_exporter.yml for multiple services: `services-where: Name='SQ
 
 Uses API calls instead of WMI for performance optimization. **Note** the previous flag (`--collector.service.services-where`) won't have any effect on this mode.
 
+### `--collector.service.services-list`
+
+A comma separated list of services names to monitor. It builds a "services-where" WMI filter on list on service name.
+
+Example: `--collector.service.services-list="SQLServer, Couchbase, Spooler,ActiveMQ"` is equivalent to the previous example.
+
+## Custom Configuration
+
+### service list with custom labels (config file only)
+
+Define a dictionary of services to monitor, and for each of them a specific set of labels.
+
+```yml
+collector:
+  service:
+    services:
+      windows_exporter:
+        application: prometheus
+        custom1: val1
+      pushprox_client:
+        application: prometheus
+        custom1: val1
+      winRM:
+        application: windows
+        custom1: val2
+      Dhcp:
+        application: windows
+        custom1: val3
+```
+
 ## Metrics
 
 Name | Description | Type | Labels
@@ -36,6 +66,7 @@ For the values of the `state`, `start_mode`, `status` and `run_as` labels, see b
 ### States
 
 A service can be in the following states:
+
 - `stopped`
 - `start pending`
 - `stop pending`
@@ -48,6 +79,7 @@ A service can be in the following states:
 ### Start modes
 
 A service can have the following start modes:
+
 - `boot`
 - `system`
 - `auto`
@@ -57,6 +89,7 @@ A service can have the following start modes:
 ### Status (not available in API mode)
 
 A service can have any of the following statuses:
+
 - `ok`
 - `error`
 - `degraded`
@@ -80,19 +113,25 @@ It corresponds to the `StartName` attribute of the `Win32_Service` class.
 `StartName` attribute can be NULL and in such case the label is reported as an empty string. Notice that if the attribute is NULL the service is logged on as the `LocalSystem` account or, for kernel or system-level drive, it runs with a default object name created by the I/O system based on the service name, for example, DWDOM\Admin.
 
 ### Example metric
+
 Lists the services that have a 'disabled' start mode.
-```
+
+```prometheus
 windows_service_start_mode{exported_name=~"(mssqlserver|sqlserveragent)",start_mode="disabled"}
 ```
 
 ## Useful queries
+
 Counts the number of Microsoft SQL Server/Agent Processes
-```
+
+```prometheus
 count(windows_service_state{exported_name=~"(sqlserveragent|mssqlserver)",state="running"})
 ```
 
 ## Alerting examples
-**prometheus.rules**
+
+### prometheus.rules
+
 ```yaml
 groups:
 - name: Microsoft SQL Server Alerts
@@ -118,4 +157,43 @@ groups:
       summary: "Service {{ $labels.exported_name }} down"
       description: "Service {{ $labels.exported_name }} on instance {{ $labels.instance }} has been down for more than 3 minutes."
 ```
+
 In this example, `instance` is the target label of the host. So each alert will be processed per host, which is then used in the alert description.
+
+### example with custom labels
+
+If you use custom labels for services defined on each host you may have:
+
+config file:
+
+```yml
+collector:
+  service:
+    services:
+      windows_exporter:
+        application: prometheus
+      pushprox_client:
+        application: prometheus
+      winRM:
+        application: windows
+      Dhcp:
+        application: windows
+```
+
+Then generic alert services:
+
+```yml
+groups:
+- name: Window Server Alerts
+  rules:
+
+  # Sends an alert when any of the  service is not in the running state for 3 minutes.
+  - alert: WindowServiceNotRunning
+    expr: windows_service_state{state="running"} == 0
+    for: 3m
+    labels:
+      severity: high
+    annotations:
+      summary: "Service {{ $labels.name }} for {{ $labels.application }} down for 3 min."
+      description: "Service {{ $labels.name }} for Application {{ $labels.application }} on instance {{ $labels.instance }} has been down for more than 3 minutes."
+```

--- a/exporter.go
+++ b/exporter.go
@@ -155,8 +155,14 @@ func main() {
 	}
 
 	_ = level.Debug(logger).Log("msg", "Logging has Started")
+
+	initWbem(logger)
+
+	// Initialize collectors before loading
+	collector.RegisterCollectors(logger)
+
 	if *configFile != "" {
-		resolver, err := config.NewResolver(*configFile, logger, *insecure_skip_verify)
+		resolver, err := config.NewResolver(*configFile, logger, *insecure_skip_verify, collector.CfgHooks())
 		if err != nil {
 			_ = level.Error(logger).Log("msg", "could not load config file", "err", err)
 			os.Exit(1)
@@ -195,11 +201,6 @@ func main() {
 		}
 		return
 	}
-
-	initWbem(logger)
-
-	// Initialize collectors before loading
-	collector.RegisterCollectors(logger)
 
 	collectors, err := loadCollectors(*enabledCollectors, logger)
 	if err != nil {


### PR DESCRIPTION
replace previous PR [PR#1180](https://github.com/prometheus-community/windows_exporter/pull/1180), [PR#1185](https://github.com/prometheus-community/windows_exporter/pull/1185)

This PR adds some feature to service collector: (see [service](docs/collector.service.md))
 - add config parameter **collector.service.services-list** with a comma separated list of service names:
 ```yml
collector:
  service:
    services-list: windows_exporter, winRM, pushprox_client, Dhcp
```
the param will only be checked if services-where is not set.
the list will be used to build a service-where query based on Name and is equivalent to:
```yml
collector:
  service:
    services-where: "Name = 'elmt_1' or Name = "elmt_X' or ..."
```
 - add a new parameter that can only be set in config file: 
It allows to set any number of custom labels value for each service:
e.g.:
```yml
collector:
  service:
    services:
      windows_exporter:
        application: prometheus
        custom1: val1
      pushprox_client:
        application: prometheus
        custom1: val1
      winRM:
        application: windows
        custom1: val2
      Dhcp:
        application: windows
        custom1: val3
```
Use case: allow to build a generic Prometheus alert on not running service and to use the specified associated labels to drive a specific behavior. For me they are used to route for a specific documentation based on context.<br>
Label's names must be identical for each service. Not identical labels names are removed !
This parameter as a lower priority than service-where and service-list.
It accepts a dict (see above example) or a list; in this case it behaves like services-list.
e.g.:
```yml
collector:
  service:
    services:
      - dhcp
      - pushprox_client
      - windows_exporter
      - winRM
```


Then generic alert services:

```yml
groups:
- name: Window Server Alerts
  rules:

  # Sends an alert when the 'sqlserveragent' service is not in the running state for 3 minutes.
  - alert: WindowServiceNotRunning
    expr: windows_service_state{state="running"} == 0
    for: 3m
    labels:
      severity: high
    annotations:
      summary: "Service {{ $labels.name }} for {{ $labels.application }} down for 3 min."
      description: "Service {{ $labels.name }} for Application {{ $labels.application }} on instance {{ $labels.instance }} has been down for more than 3 minutes."
```
This PR adds some feature to process collector:
It allows to defined "process group" and to set any number of custom labels value for each group:
e.g.: (see [process](docs/collector.process.md))

```yml
  collector:
    process:
      processes:
      browsers:
        include: "(?i)(firefox|chrome).*"
        exclude: "(?i)safari"
        application: browsers
        custom1: val4
      Visual Studio Code:
        include: "(?i)code.*"
        application: "vscode"
        custom1: val5
```
the custom labels will be added to each windows_process_metrics
```text
# HELP windows_process_handles Total number of handles the process has open. This number is the sum of the handles currently open by each thread in the process.
# TYPE windows_process_handles gauge
windows_process_handles{application="browsers",creating_process_id="15988",custom1="val4",process="firefox",process_id="11184"} 257
windows_process_handles{application="browsers",creating_process_id="15988",custom1="val4",process="firefox",process_id="11588"} 256
windows_process_handles{application="browsers",creating_process_id="15988",custom1="val4",process="firefox",process_id="12428"} 320
windows_process_handles{application="browsers",creating_process_id="15988",custom1="val4",process="firefox",process_id="12536"} 333
windows_process_handles{application="browsers",creating_process_id="15988",custom1="val4",process="firefox",process_id="12544"} 323
windows_process_handles{application="browsers",creating_process_id="15988",custom1="val4",process="firefox",process_id="13620"} 346
windows_process_handles{application="browsers",creating_process_id="15988",custom1="val4",process="firefox",process_id="16700"} 366
....
windows_process_handles{application="vscode",creating_process_id="10392",custom1="val5",process="Code",process_id="9172"} 2474
windows_process_handles{application="vscode",creating_process_id="22356",custom1="val5",process="Code",process_id="12076"} 182
windows_process_handles{application="vscode",creating_process_id="22356",custom1="val5",process="Code",process_id="13124"} 186
windows_process_handles{application="vscode",creating_process_id="22356",custom1="val5",process="Code",process_id="24212"} 247
windows_process_handles{application="vscode",creating_process_id="9172",custom1="val5",process="Code",process_id="10664"} 296
windows_process_handles{application="vscode",creating_process_id="9172",custom1="val5",process="Code",process_id="11028"} 229
windows_process_handles{application="vscode",creating_process_id="9172",custom1="val5",process="Code",process_id="13516"} 236
```
It also adds a metric named `windows_process_group_count` that count number of matching processes for each group:

```text
# HELP windows_process_group_count Number of processes found for the matching patterns.
# TYPE windows_process_group_count gauge
windows_process_group_count{application="browsers",custom1="val4",group="browsers"} 29
windows_process_group_count{application="vscode",custom1="val5",group="Visual Studio Code"} 12
```
This metric should be used to define a generic alert if occurrence of the metric is equal to 0, instead of a specific alert absent(windows_process_handles{process="firefox"} == 1