### PR TITLE
fix: add missing vswitch packets_sent_total

### DIFF
--- a/collector/hyperv.go
+++ b/collector/hyperv.go
@@ -1374,6 +1374,12 @@ func (c *HyperVCollector) collectVmSwitch(ch chan<- prometheus.Metric) (*prometh
 			obj.Name,
 		)
 		ch <- prometheus.MustNewConstMetric(
+			c.PacketsSent,
+			prometheus.CounterValue,
+			float64(obj.PacketsSentPersec),
+			obj.Name,
+		)
+		ch <- prometheus.MustNewConstMetric(
 			c.PurgedMacAddresses,
 			prometheus.CounterValue,
 			float64(obj.PurgedMacAddresses),


### PR DESCRIPTION
`windows_hyperv_vswitch_packets_sent_total ` is in the [docs](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.hyperv.md#metrics) but not being collected. This PR fixes the problem.