### PR TITLE
fix: Remove default value from deprecated IIS flag

### DIFF
--- a/collector/iis.go
+++ b/collector/iis.go
@@ -220,7 +220,7 @@ type IISCollector struct {
 }
 
 func newIISCollectorFlags(app *kingpin.Application) {
-	oldSiteInclude = app.Flag(FlagIISSiteOldInclude, "DEPRECATED: Use --collector.iis.site-include").Default(".+").Hidden().String()
+	oldSiteInclude = app.Flag(FlagIISSiteOldInclude, "DEPRECATED: Use --collector.iis.site-include").Hidden().String()
 	oldSiteExclude = app.Flag(FlagIISSiteOldExclude, "DEPRECATED: Use --collector.iis.site-exclude").Hidden().String()
 	oldAppInclude = app.Flag(FlagIISAppOldInclude, "DEPRECATED: Use --collector.iis.app-include").Hidden().String()
 	oldAppExclude = app.Flag(FlagIISAppOldExclude, "DEPRECATED: Use --collector.iis.app-exclude").Hidden().String()


### PR DESCRIPTION
Default value prevented use of the new `collector.iis.site-include` flag.

Resolves #1254 