### PR TITLE
Textfile collector: collect files from multiple paths

### DIFF
--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -64,7 +64,7 @@ type textFileCollector struct {
 func newTextFileCollectorFlags(app *kingpin.Application) {
 	textFileDirectory = app.Flag(
 		FlagTextFileDirectory,
-		"Directory or Directories to read text files with metrics from.",
+		"DEPRECATED: Use --collector.textfile.directories",
 	).Default("").String()
 	textFileDirectories = app.Flag(
 		FlagTextFileDirectories,

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -280,7 +280,7 @@ func (c *textFileCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Met
 				_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("Processing file: %s", path))
 				families_array, err := scrapeFile(path, c.logger)
 				if err != nil {
-					_ = level.Error(c.logger).Log("msg", fmt.Sprintf("Error screaping file: %q. Skip File.", path), "err", err)
+					_ = level.Error(c.logger).Log("msg", fmt.Sprintf("Error scraping file: %q. Skip File.", path), "err", err)
 					errorMetric = 1.0
 					return nil
 				}

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -294,10 +294,9 @@ func (c *textFileCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Met
 					_ = level.Error(c.logger).Log("msg", fmt.Sprintf("Duplicate filename detected: %q. Skip File.", path))
 					errorMetric = 1.0
 					return nil
-				} else {
-					mtimes[fileInfo.Name()] = fileInfo.ModTime()
-					metricFamilies = append(metricFamilies, families_array...)
 				}
+				mtimes[fileInfo.Name()] = fileInfo.ModTime()
+				metricFamilies = append(metricFamilies, families_array...)
 			}
 			return nil
 		})

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -65,7 +65,7 @@ func newTextFileCollectorFlags(app *kingpin.Application) {
 	textFileDirectory = app.Flag(
 		FlagTextFileDirectory,
 		"DEPRECATED: Use --collector.textfile.directories",
-	).Default("").String()
+	).Default("").Hidden().String()
 	textFileDirectories = app.Flag(
 		FlagTextFileDirectories,
 		"Directory or Directories to read text files with metrics from.",

--- a/collector/textfile_test.go
+++ b/collector/textfile_test.go
@@ -177,7 +177,10 @@ func TestMultipleDirectories(t *testing.T) {
 		for {
 			var metric dto.Metric
 			val := <-metrics
-			val.Write(&metric)
+			err := val.Write(&metric)
+			if err != nil {
+				t.Errorf("Unexpected error %s", err)
+			}
 			got += metric.String()
 		}
 	}()
@@ -208,7 +211,10 @@ func TestDuplicateFileName(t *testing.T) {
 		for {
 			var metric dto.Metric
 			val := <-metrics
-			val.Write(&metric)
+			err := val.Write(&metric)
+			if err != nil {
+				t.Errorf("Unexpected error %s", err)
+			}
 			got += metric.String()
 		}
 	}()

--- a/docs/collector.textfile.md
+++ b/docs/collector.textfile.md
@@ -10,15 +10,25 @@ Enabled by default? | Yes
 
 ## Flags
 
-### `--collector.textfile.directory`
+### `--collector.textfile.directory` 
+:warning: DEPRECATED Use `--collector.textfile.directories`
 
-The directory containing the files to be ingested. Only files with the extension `.prom` are read. The `.prom` file must end with an empty line feed to work properly.
+<br>
+
+### `--collector.textfile.directories`
+One or multiple directories containing the files to be ingested. 
+
+E.G. `--collector.textfile.directories="C:\MyDir1,C:\MyDir2"`
 
 Default value: `C:\Program Files\windows_exporter\textfile_inputs`
 
 Required: No
 
-## Metrics
+> **Note:**
+> - If there are duplicated filenames among the directories, only the first one found will be read. For any other files with the same name, the `windows_textfile_scrape_error` metric will be set to 1 and a error message will be logged.
+> - Only files with the extension `.prom` are read. The `.prom` file must end with an empty line feed to work properly.
+
+
 
 Metrics will primarily come from the files on disk. The below listed metrics
 are collected to give information about the reading of the metrics themselves.
@@ -38,7 +48,7 @@ _This collector does not yet have any useful queries added, we would appreciate 
 _This collector does not yet have alerting examples, we would appreciate your help adding them!_
 
 # Example use
-This Powershell script, when run in the `collector.textfile.directory` (default `C:\Program Files\windows_exporter\textfile_inputs`), generates a valid `.prom` file that should successfully ingested by windows_exporter.
+This Powershell script, when run in the `--collector.textfile.directories` (default `C:\Program Files\windows_exporter\textfile_inputs`), generates a valid `.prom` file that should successfully ingested by windows_exporter.
 
 ```Powershell
 $alpha = 42

--- a/tools/textfile-test/duplicate-filename/file.prom
+++ b/tools/textfile-test/duplicate-filename/file.prom
@@ -1,0 +1,3 @@
+# HELP windows_test Some Test
+# TYPE windows_test gauge
+windows_test{flag="file"} 1

--- a/tools/textfile-test/duplicate-filename/sub/file.prom
+++ b/tools/textfile-test/duplicate-filename/sub/file.prom
@@ -1,0 +1,3 @@
+# HELP windows_test Some Test
+# TYPE windows_test gauge
+windows_test{flag="sub_file"} 2

--- a/tools/textfile-test/multiple-dirs/dir1/dir1.prom
+++ b/tools/textfile-test/multiple-dirs/dir1/dir1.prom
@@ -1,0 +1,3 @@
+# HELP windows_test Some Test
+# TYPE windows_test gauge
+windows_test{flag="dir1"} 1

--- a/tools/textfile-test/multiple-dirs/dir2/dir2.prom
+++ b/tools/textfile-test/multiple-dirs/dir2/dir2.prom
@@ -1,0 +1,3 @@
+# HELP windows_test Some Test
+# TYPE windows_test gauge
+windows_test{flag="dir2"} 2

--- a/tools/textfile-test/multiple-dirs/dir3/dir3.prom
+++ b/tools/textfile-test/multiple-dirs/dir3/dir3.prom
@@ -1,0 +1,3 @@
+# HELP windows_test Some Test
+# TYPE windows_test gauge
+windows_test{flag="dir3"} 3

--- a/tools/textfile-test/multiple-dirs/dir3/dir3sub/dir3sub.prom
+++ b/tools/textfile-test/multiple-dirs/dir3/dir3sub/dir3sub.prom
@@ -1,0 +1,3 @@
+# HELP windows_test Some Test
+# TYPE windows_test gauge
+windows_test{flag="dir3sub"} 3


### PR DESCRIPTION
Regarding #1236 and more

Added Features:
- collect files from multiple paths
- walkDir func for all paths to collect files from subdirs
- new flag command `collector.textfile.directories`

About the `collector.textfile.directories` commmand:
For now it is possible to use `collector.textfile.directories`, `collector.textfile.directory` or both. They have the same functionality and in case both commands would be used, the dirs are concatenated. I am not sure if that is ok so lets discuss 😉

As soon all is settled, I'll update the docs - `collector.textfile.md` 😊