### PR TITLE
fix: config file CLI argument for relative paths -> v0.23.1 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
+	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/go-kit/log"
@@ -40,11 +40,8 @@ type Resolver struct {
 func NewResolver(file string, logger log.Logger, insecure_skip_verify bool) (*Resolver, error) {
 	flags := map[string]string{}
 	var fileBytes []byte
-	url, err := url.ParseRequestURI(file)
-	if err != nil {
-		return nil, err
-	}
-	if url.Scheme == "http" || url.Scheme == "https" {
+	var err error
+	if strings.HasPrefix(file, "http") || strings.HasPrefix(file, "https") {
 		_ = level.Info(logger).Log("msg", fmt.Sprintf("Loading configuration file from URL: %v", file))
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure_skip_verify},

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ func NewResolver(file string, logger log.Logger, insecure_skip_verify bool) (*Re
 	flags := map[string]string{}
 	var fileBytes []byte
 	var err error
-	if strings.HasPrefix(file, "http") || strings.HasPrefix(file, "https") {
+	if strings.HasPrefix(file, "http://") || strings.HasPrefix(file, "https://") {
 		_ = level.Info(logger).Log("msg", fmt.Sprintf("Loading configuration file from URL: %v", file))
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure_skip_verify},


### PR DESCRIPTION
Fix for #1263, there was an unnecessary check with `url.ParseRequestURI`. If you throw in gibberish it'll fail anyways.   