### PR TITLE
fix: Windows service can't stop without an error

### DIFF
--- a/initiate/initiate.go
+++ b/initiate/initiate.go
@@ -32,14 +32,14 @@ loop:
 				changes <- c.CurrentStatus
 			case svc.Stop, svc.Shutdown:
 				_ = logger.Info(100, "Service Stop Received")
-				s.stopCh <- true
+				changes <- svc.Status{State: svc.StopPending}
 				break loop
 			default:
 				_ = logger.Error(102, fmt.Sprintf("unexpected control request #%d", c))
 			}
 		}
 	}
-	changes <- svc.Status{State: svc.StopPending}
+	s.stopCh <- true
 	return
 }
 
@@ -57,7 +57,7 @@ func init() {
 	}
 
 	if isService {
-		logger, err := eventlog.Open("windows_exporter")
+		logger, err = eventlog.Open("windows_exporter")
 		if err != nil {
 			os.Exit(2)
 		}

--- a/initiate/initiate.go
+++ b/initiate/initiate.go
@@ -48,7 +48,7 @@ var StopCh = make(chan bool)
 func init() {
 	isService, err := svc.IsWindowsService()
 	if err != nil {
-		logger, err := eventlog.Open("windows_exporter")
+		logger, err = eventlog.Open("windows_exporter")
 		if err != nil {
 			os.Exit(2)
 		}


### PR DESCRIPTION
ok I was not entirely right with my theory in #1258. The real reason for the stop error is that this line is a nil pointer:
https://github.com/prometheus-community/windows_exporter/blob/8d615956074d9329eb33ece5ec19fc00a8d2af48/initiate/initiate.go#L34

This logline uses the global `logger` variable which is never set, it is only set inside of the `init()` function. Therefore the log attempt on line 34 will cause a nil pointer, the exe dies and no signal will be send and so on. 
This global variable was added with v23: https://github.com/prometheus-community/windows_exporter/commit/8509bc69a60bb6b608d390fabdf6e4d64b939b2e

Nevertheless, what I wrote in #1258 is also possible. I have tested with:
```go
loop:
	for {
		select {
		case c := <-r:
			switch c.Cmd {
			case svc.Interrogate:
				changes <- c.CurrentStatus
			case svc.Stop, svc.Shutdown:
				_ = logger.Info(100, "Service Stop Received")
				s.stopCh <- true
				time.Sleep(1 * time.Millisecond)
				changes <- svc.Status{State: svc.StopPending}
				break loop
			default:
				_ = logger.Error(102, fmt.Sprintf("unexpected control request #%d", c))
			}
		}
	}
	return
```
Only one milisecond was enough to cause the same error as in #1258.

So this PR includes:
 - fix: for global `logger` variable
 - prevention of possible error in the stop process 
  
  