### PR TITLE
Check for nil strings and include wrappers around each.

### DIFF
--- a/pkg/collector/exchange/exchange.go
+++ b/pkg/collector/exchange/exchange.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus-community/windows_exporter/pkg/perflib"
 	"github.com/prometheus-community/windows_exporter/pkg/types"
+	"github.com/prometheus-community/windows_exporter/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -211,7 +212,7 @@ func (c *collector) Build() error {
 		os.Exit(0)
 	}
 
-	if *c.exchangeCollectorsEnabled == "" {
+	if utils.IsEmpty(c.exchangeCollectorsEnabled) {
 		for _, collectorName := range exchangeAllCollectorNames {
 			c.enabledCollectors = append(c.enabledCollectors, collectorName)
 		}

--- a/pkg/collector/iis/iis.go
+++ b/pkg/collector/iis/iis.go
@@ -9,12 +9,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/prometheus-community/windows_exporter/pkg/perflib"
-	"github.com/prometheus-community/windows_exporter/pkg/types"
-
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus-community/windows_exporter/pkg/perflib"
+	"github.com/prometheus-community/windows_exporter/pkg/types"
+	"github.com/prometheus-community/windows_exporter/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/windows/registry"
 )
@@ -308,7 +308,7 @@ func (c *collector) GetPerfCounter() ([]string, error) {
 }
 
 func (c *collector) Build() error {
-	if *c.oldSiteExclude != "" {
+	if utils.HasValue(c.oldSiteExclude) {
 		if !c.siteExcludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.iis.site-blacklist is DEPRECATED and will be removed in a future release, use --collector.iis.site-exclude")
 			*c.siteExclude = *c.oldSiteExclude
@@ -316,7 +316,7 @@ func (c *collector) Build() error {
 			return errors.New("--collector.iis.site-blacklist and --collector.iis.site-exclude are mutually exclusive")
 		}
 	}
-	if *c.oldSiteInclude != "" {
+	if utils.HasValue(c.oldSiteInclude) {
 		if !c.siteIncludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.iis.site-whitelist is DEPRECATED and will be removed in a future release, use --collector.iis.site-include")
 			*c.siteInclude = *c.oldSiteInclude
@@ -325,7 +325,7 @@ func (c *collector) Build() error {
 		}
 	}
 
-	if *c.oldAppExclude != "" {
+	if utils.HasValue(c.oldAppExclude) {
 		if !c.appExcludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.iis.app-blacklist is DEPRECATED and will be removed in a future release, use --collector.iis.app-exclude")
 			*c.appExclude = *c.oldAppExclude
@@ -333,7 +333,7 @@ func (c *collector) Build() error {
 			return errors.New("--collector.iis.app-blacklist and --collector.iis.app-exclude are mutually exclusive")
 		}
 	}
-	if *c.oldAppInclude != "" {
+	if utils.HasValue(c.oldAppInclude) {
 		if !c.appIncludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.iis.app-whitelist is DEPRECATED and will be removed in a future release, use --collector.iis.app-include")
 			*c.appInclude = *c.oldAppInclude

--- a/pkg/collector/logical_disk/logical_disk.go
+++ b/pkg/collector/logical_disk/logical_disk.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus-community/windows_exporter/pkg/perflib"
 	"github.com/prometheus-community/windows_exporter/pkg/types"
+	"github.com/prometheus-community/windows_exporter/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -125,7 +126,7 @@ func (c *collector) GetPerfCounter() ([]string, error) {
 }
 
 func (c *collector) Build() error {
-	if *c.volumeOldExclude != "" {
+	if utils.HasValue(c.volumeOldExclude) {
 		if !c.volumeExcludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.logical_disk.volume-blacklist is DEPRECATED and will be removed in a future release, use --collector.logical_disk.volume-exclude")
 			*c.volumeExclude = *c.volumeOldExclude
@@ -133,7 +134,7 @@ func (c *collector) Build() error {
 			return errors.New("--collector.logical_disk.volume-blacklist and --collector.logical_disk.volume-exclude are mutually exclusive")
 		}
 	}
-	if *c.volumeOldInclude != "" {
+	if utils.HasValue(c.volumeOldInclude) {
 		if !c.volumeIncludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.logical_disk.volume-whitelist is DEPRECATED and will be removed in a future release, use --collector.logical_disk.volume-include")
 			*c.volumeInclude = *c.volumeOldInclude

--- a/pkg/collector/msmq/msmq.go
+++ b/pkg/collector/msmq/msmq.go
@@ -5,12 +5,12 @@ package msmq
 import (
 	"strings"
 
-	"github.com/prometheus-community/windows_exporter/pkg/types"
-	"github.com/prometheus-community/windows_exporter/pkg/wmi"
-
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus-community/windows_exporter/pkg/types"
+	"github.com/prometheus-community/windows_exporter/pkg/utils"
+	"github.com/prometheus-community/windows_exporter/pkg/wmi"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -72,7 +72,7 @@ func (c *collector) GetPerfCounter() ([]string, error) {
 }
 
 func (c *collector) Build() error {
-	if *c.queryWhereClause == "" {
+	if utils.IsEmpty(c.queryWhereClause) {
 		_ = level.Warn(c.logger).Log("msg", "No where-clause specified for msmq collector. This will generate a very large number of metrics!")
 	}
 

--- a/pkg/collector/net/net.go
+++ b/pkg/collector/net/net.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus-community/windows_exporter/pkg/perflib"
 	"github.com/prometheus-community/windows_exporter/pkg/types"
+	"github.com/prometheus-community/windows_exporter/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -125,7 +126,7 @@ func (c *collector) GetPerfCounter() ([]string, error) {
 }
 
 func (c *collector) Build() error {
-	if *c.nicOldExclude != "" {
+	if utils.HasValue(c.nicOldExclude) {
 		if !c.nicExcludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.net.nic-blacklist is DEPRECATED and will be removed in a future release, use --collector.net.nic-exclude")
 			*c.nicExclude = *c.nicOldExclude
@@ -133,7 +134,7 @@ func (c *collector) Build() error {
 			return errors.New("--collector.net.nic-blacklist and --collector.net.nic-exclude are mutually exclusive")
 		}
 	}
-	if *c.nicOldInclude != "" {
+	if utils.HasValue(c.nicOldInclude) {
 		if !c.nicIncludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.net.nic-whitelist is DEPRECATED and will be removed in a future release, use --collector.net.nic-include")
 			*c.nicInclude = *c.nicOldInclude

--- a/pkg/collector/process/process.go
+++ b/pkg/collector/process/process.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus-community/windows_exporter/pkg/perflib"
 	"github.com/prometheus-community/windows_exporter/pkg/types"
+	"github.com/prometheus-community/windows_exporter/pkg/utils"
 	"github.com/prometheus-community/windows_exporter/pkg/wmi"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -133,7 +134,7 @@ func (c *collector) GetPerfCounter() ([]string, error) {
 }
 
 func (c *collector) Build() error {
-	if *c.processOldExclude != "" {
+	if utils.HasValue(c.processOldExclude) {
 		if !c.processExcludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.process.blacklist is DEPRECATED and will be removed in a future release, use --collector.process.exclude")
 			*c.processExclude = *c.processOldExclude
@@ -141,7 +142,7 @@ func (c *collector) Build() error {
 			return errors.New("--collector.process.blacklist and --collector.process.exclude are mutually exclusive")
 		}
 	}
-	if *c.processOldInclude != "" {
+	if utils.HasValue(c.processOldInclude) {
 		if !c.processIncludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.process.whitelist is DEPRECATED and will be removed in a future release, use --collector.process.include")
 			*c.processInclude = *c.processOldInclude
@@ -150,7 +151,7 @@ func (c *collector) Build() error {
 		}
 	}
 
-	if *c.processInclude == ".*" && *c.processExclude == "" {
+	if c.processInclude != nil && *c.processInclude == ".*" && utils.IsEmpty(c.processExclude) {
 		_ = level.Warn(c.logger).Log("msg", "No filters specified for process collector. This will generate a very large number of metrics!")
 	}
 

--- a/pkg/collector/scheduled_task/scheduled_task.go
+++ b/pkg/collector/scheduled_task/scheduled_task.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-ole/go-ole"
 	"github.com/go-ole/go-ole/oleutil"
 	"github.com/prometheus-community/windows_exporter/pkg/types"
+	"github.com/prometheus-community/windows_exporter/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -141,7 +142,7 @@ func (c *collector) GetPerfCounter() ([]string, error) {
 }
 
 func (c *collector) Build() error {
-	if *c.taskOldExclude != "" {
+	if utils.HasValue(c.taskOldExclude) {
 		if !c.taskExcludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.scheduled_task.blacklist is DEPRECATED and will be removed in a future release, use --collector.scheduled_task.exclude")
 			*c.taskExclude = *c.taskOldExclude
@@ -149,7 +150,7 @@ func (c *collector) Build() error {
 			return errors.New("--collector.scheduled_task.blacklist and --collector.scheduled_task.exclude are mutually exclusive")
 		}
 	}
-	if *c.taskOldInclude != "" {
+	if utils.HasValue(c.taskOldInclude) {
 		if !c.taskIncludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.scheduled_task.whitelist is DEPRECATED and will be removed in a future release, use --collector.scheduled_task.include")
 			*c.taskInclude = *c.taskOldInclude

--- a/pkg/collector/service/service.go
+++ b/pkg/collector/service/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus-community/windows_exporter/pkg/types"
+	"github.com/prometheus-community/windows_exporter/pkg/utils"
 	"github.com/prometheus-community/windows_exporter/pkg/wmi"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/windows"
@@ -88,7 +89,7 @@ func (c *collector) GetPerfCounter() ([]string, error) {
 }
 
 func (c *collector) Build() error {
-	if *c.serviceWhereClause == "" {
+	if utils.IsEmpty(c.serviceWhereClause) {
 		_ = level.Warn(c.logger).Log("msg", "No where-clause specified for service collector. This will generate a very large number of metrics!")
 	}
 	if *c.useAPI {

--- a/pkg/collector/smtp/smtp.go
+++ b/pkg/collector/smtp/smtp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus-community/windows_exporter/pkg/perflib"
 	"github.com/prometheus-community/windows_exporter/pkg/types"
+	"github.com/prometheus-community/windows_exporter/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -152,7 +153,7 @@ func (c *collector) GetPerfCounter() ([]string, error) {
 func (c *collector) Build() error {
 	_ = level.Info(c.logger).Log("msg", "smtp collector is in an experimental state! Metrics for this collector have not been tested.")
 
-	if *c.serverOldExclude != "" {
+	if utils.HasValue(c.serverOldExclude) {
 		if !c.serverExcludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.smtp.server-blacklist is DEPRECATED and will be removed in a future release, use --collector.smtp.server-exclude")
 			*c.serverExclude = *c.serverOldExclude
@@ -160,7 +161,7 @@ func (c *collector) Build() error {
 			return errors.New("--collector.smtp.server-blacklist and --collector.smtp.server-exclude are mutually exclusive")
 		}
 	}
-	if *c.serverOldInclude != "" {
+	if utils.HasValue(c.serverOldInclude) {
 		if !c.serverIncludeSet {
 			_ = level.Warn(c.logger).Log("msg", "--collector.smtp.server-whitelist is DEPRECATED and will be removed in a future release, use --collector.smtp.server-include")
 			*c.serverInclude = *c.serverOldInclude

--- a/pkg/collector/textfile/textfile.go
+++ b/pkg/collector/textfile/textfile.go
@@ -30,6 +30,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus-community/windows_exporter/pkg/types"
+	"github.com/prometheus-community/windows_exporter/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -103,7 +104,7 @@ func (c *collector) GetPerfCounter() ([]string, error) {
 
 func (c *collector) Build() error {
 	c.directories = ""
-	if *c.textFileDirectory != "" || *c.textFileDirectories != "" {
+	if utils.HasValue(c.textFileDirectory) || utils.HasValue(c.textFileDirectories) {
 		c.directories = *c.textFileDirectory + "," + *c.textFileDirectories
 		c.directories = strings.Trim(c.directories, ",")
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -12,3 +12,11 @@ func BoolToFloat(b bool) float64 {
 	}
 	return 0.0
 }
+
+func HasValue(v *string) bool {
+	return !IsEmpty(v)
+}
+
+func IsEmpty(v *string) bool {
+	return v == nil || *v == ""
+}


### PR DESCRIPTION
When trying to remove the fork grafana agent uses ran into an issue with some strings being nil via the config. Kingpin never allows this so it hasnt been an issue yet.

Created two wrapper methods to make it easier, I could have went with one new func and ! the call  but I think its cleaner to have two. I checked for any *string and *bool.

Tested the windows_exporter and the Grafana Agent using this without problem.