### PR TITLE
Add collector for SMB

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Name     | Description | Enabled by default
 [remote_fx](docs/collector.remote_fx.md) | RemoteFX protocol (RDP) metrics |
 [scheduled_task](docs/collector.scheduled_task.md) | Scheduled Tasks metrics |
 [service](docs/collector.service.md) | Service state metrics | &#10003;
+[smb](docs/collector.smb.md) | SMB Server |
 [smtp](docs/collector.smtp.md) | IIS SMTP Server |
 [system](docs/collector.system.md) | System calls | &#10003;
 [tcp](docs/collector.tcp.md) | TCP connections |

--- a/docs/collector.smb.md
+++ b/docs/collector.smb.md
@@ -1,0 +1,35 @@
+# smb collector
+
+The smb collector collects metrics from MS Smb hosts through perflib
+=======
+
+
+|||
+-|-
+Metric name prefix  | `smb`
+Classes 			| [Win32_PerfRawData_SMB](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/)<br/> 
+Enabled by default? | No
+
+## Flags
+
+### `--collectors.smb.list`
+Lists the Perflib Objects that are queried for data along with the perlfib object id
+
+### `--collectors.smb.enabled`
+Comma-separated list of collectors to use, for example: `--collectors.smb.enabled=ServerShares`. Matching is case-sensitive. Depending on the smb installation not all performance counters are available. Use `--collectors.smb.list` to obtain a list of supported collectors.
+
+## Metrics
+Name          | Description
+--------------|---------------
+`windows_smb_server_shares_current_open_file_count` | Current total count open files on the SMB Server
+`windows_smb_server_shares_tree_connect_count` | Count of user connections to the SMB Server
+
+### Example metric
+_This collector does not yet have explained examples, we would appreciate your help adding them!_
+
+## Useful queries
+_This collector does not yet have any useful queries added, we would appreciate your help adding them!_
+
+## Alerting examples
+_This collector does not yet have alerting examples, we would appreciate your help adding them!_
+

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -127,6 +127,7 @@ func NewWithConfig(logger log.Logger, config Config) Collectors {
 	collectors[remote_fx.Name] = remote_fx.New(logger, &config.RemoteFx)
 	collectors[scheduled_task.Name] = scheduled_task.New(logger, &config.ScheduledTask)
 	collectors[service.Name] = service.New(logger, &config.Service)
+	collectors[smb.Name] = smb.New(logger, &config.Smb)
 	collectors[smtp.Name] = smtp.New(logger, &config.Smtp)
 	collectors[system.Name] = system.New(logger, &config.System)
 	collectors[teradici_pcoip.Name] = teradici_pcoip.New(logger, &config.TeradiciPcoip)
@@ -137,7 +138,6 @@ func NewWithConfig(logger log.Logger, config Config) Collectors {
 	collectors[time.Name] = time.New(logger, &config.Time)
 	collectors[vmware.Name] = vmware.New(logger, &config.Vmware)
 	collectors[vmware_blast.Name] = vmware_blast.New(logger, &config.VmwareBlast)
-	collectors[smb.Name] = smb.New(logger, &config.Smb)
 
 	return New(collectors)
 }

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -49,6 +49,7 @@ import (
 	"github.com/prometheus-community/windows_exporter/pkg/collector/remote_fx"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/scheduled_task"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/service"
+	"github.com/prometheus-community/windows_exporter/pkg/collector/smb"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/smtp"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/system"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/tcp"
@@ -136,6 +137,7 @@ func NewWithConfig(logger log.Logger, config Config) Collectors {
 	collectors[time.Name] = time.New(logger, &config.Time)
 	collectors[vmware.Name] = vmware.New(logger, &config.Vmware)
 	collectors[vmware_blast.Name] = vmware_blast.New(logger, &config.VmwareBlast)
+	collectors[smb.Name] = smb.New(logger, &config.Smb)
 
 	return New(collectors)
 }

--- a/pkg/collector/config.go
+++ b/pkg/collector/config.go
@@ -42,6 +42,7 @@ import (
 	"github.com/prometheus-community/windows_exporter/pkg/collector/remote_fx"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/scheduled_task"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/service"
+	"github.com/prometheus-community/windows_exporter/pkg/collector/smb"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/smtp"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/system"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/tcp"
@@ -107,6 +108,7 @@ type Config struct {
 	Time                           time.Config                            `yaml:"time"`
 	Vmware                         vmware.Config                          `yaml:"vmware"`
 	VmwareBlast                    vmware_blast.Config                    `yaml:"vmware_blast"`
+	Smb                            smb.Config                             `yaml:"smb"`
 }
 
 // ConfigDefaults Is an interface to be used by the external libraries. It holds all ConfigDefaults form all collectors
@@ -163,4 +165,5 @@ var ConfigDefaults = Config{
 	Time:                           time.ConfigDefaults,
 	Vmware:                         vmware.ConfigDefaults,
 	VmwareBlast:                    vmware_blast.ConfigDefaults,
+	Smb:                            smb.ConfigDefaults,
 }

--- a/pkg/collector/config.go
+++ b/pkg/collector/config.go
@@ -98,6 +98,7 @@ type Config struct {
 	RemoteFx                       remote_fx.Config                       `yaml:"remote_fx"`
 	ScheduledTask                  scheduled_task.Config                  `yaml:"scheduled_task"`
 	Service                        service.Config                         `yaml:"service"`
+	Smb                            smb.Config                             `yaml:"smb"`
 	Smtp                           smtp.Config                            `yaml:"smtp"`
 	System                         system.Config                          `yaml:"system"`
 	TeradiciPcoip                  teradici_pcoip.Config                  `yaml:"teradici_pcoip"`
@@ -108,7 +109,6 @@ type Config struct {
 	Time                           time.Config                            `yaml:"time"`
 	Vmware                         vmware.Config                          `yaml:"vmware"`
 	VmwareBlast                    vmware_blast.Config                    `yaml:"vmware_blast"`
-	Smb                            smb.Config                             `yaml:"smb"`
 }
 
 // ConfigDefaults Is an interface to be used by the external libraries. It holds all ConfigDefaults form all collectors
@@ -155,6 +155,7 @@ var ConfigDefaults = Config{
 	RemoteFx:                       remote_fx.ConfigDefaults,
 	ScheduledTask:                  scheduled_task.ConfigDefaults,
 	Service:                        service.ConfigDefaults,
+	Smb:                            smb.ConfigDefaults,
 	Smtp:                           smtp.ConfigDefaults,
 	System:                         system.ConfigDefaults,
 	TeradiciPcoip:                  teradici_pcoip.ConfigDefaults,
@@ -165,5 +166,4 @@ var ConfigDefaults = Config{
 	Time:                           time.ConfigDefaults,
 	Vmware:                         vmware.ConfigDefaults,
 	VmwareBlast:                    vmware_blast.ConfigDefaults,
-	Smb:                            smb.ConfigDefaults,
 }

--- a/pkg/collector/map.go
+++ b/pkg/collector/map.go
@@ -102,6 +102,7 @@ var Map = map[string]types.CollectorBuilderWithFlags{
 	remote_fx.Name:                       remote_fx.NewWithFlags,
 	scheduled_task.Name:                  scheduled_task.NewWithFlags,
 	service.Name:                         service.NewWithFlags,
+	smb.Name:                             smb.NewWithFlags,
 	smtp.Name:                            smtp.NewWithFlags,
 	system.Name:                          system.NewWithFlags,
 	teradici_pcoip.Name:                  teradici_pcoip.NewWithFlags,
@@ -112,7 +113,6 @@ var Map = map[string]types.CollectorBuilderWithFlags{
 	time.Name:                            time.NewWithFlags,
 	vmware.Name:                          vmware.NewWithFlags,
 	vmware_blast.Name:                    vmware_blast.NewWithFlags,
-	smb.Name:                             smb.NewWithFlags,
 }
 
 func Available() []string {

--- a/pkg/collector/map.go
+++ b/pkg/collector/map.go
@@ -43,6 +43,7 @@ import (
 	"github.com/prometheus-community/windows_exporter/pkg/collector/remote_fx"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/scheduled_task"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/service"
+	"github.com/prometheus-community/windows_exporter/pkg/collector/smb"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/smtp"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/system"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/tcp"
@@ -111,6 +112,7 @@ var Map = map[string]types.CollectorBuilderWithFlags{
 	time.Name:                            time.NewWithFlags,
 	vmware.Name:                          vmware.NewWithFlags,
 	vmware_blast.Name:                    vmware_blast.NewWithFlags,
+	smb.Name:                             smb.NewWithFlags,
 }
 
 func Available() []string {

--- a/pkg/collector/smb/smb.go
+++ b/pkg/collector/smb/smb.go
@@ -208,8 +208,3 @@ func (c *collector) toLabelName(name string) string {
 	s = strings.ReplaceAll(s, "__", "_")
 	return s
 }
-
-// msToSec converts from ms to seconds
-func (c *collector) msToSec(t float64) float64 {
-	return t / 1000
-}

--- a/pkg/collector/smb/smb.go
+++ b/pkg/collector/smb/smb.go
@@ -101,7 +101,7 @@ func (c *collector) Build() error {
 	}
 
 	c.CurrentOpenFileCount = desc("server_shares_current_open_file_count", "Current total count open files on the SMB Server")
-	c.TreeConnectCount = desc("server_shares_tree_connect_count", "Tree connect count to SMB Server")
+	c.TreeConnectCount = desc("server_shares_tree_connect_count", "Count of user connections to the SMB Server")
 
 	c.enabledCollectors = make([]string, 0, len(smbAllCollectorNames))
 

--- a/pkg/collector/smb/smb.go
+++ b/pkg/collector/smb/smb.go
@@ -1,0 +1,223 @@
+//go:build windows
+
+package smb
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus-community/windows_exporter/pkg/perflib"
+	"github.com/prometheus-community/windows_exporter/pkg/types"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	Name                     = "smb"
+	FlagSmbListAllCollectors = "collectors.smb.list"
+	FlagSmbCollectorsEnabled = "collectors.smb.enabled"
+)
+
+type Config struct {
+	CollectorsEnabled string `yaml:"collectors_enabled"`
+}
+
+var ConfigDefaults = Config{
+	CollectorsEnabled: "",
+}
+
+type collector struct {
+	logger log.Logger
+
+	smbListAllCollectors *bool
+	smbCollectorsEnabled *string
+
+	TreeConnectCount     *prometheus.Desc
+	CurrentOpenFileCount *prometheus.Desc
+
+	enabledCollectors []string
+}
+
+// All available collector functions
+var smbAllCollectorNames = []string{
+	"ServerShares",
+	"ServerSessions",
+}
+
+func New(logger log.Logger, config *Config) types.Collector {
+	if config == nil {
+		config = &ConfigDefaults
+	}
+
+	smbListAllCollectors := false
+	c := &collector{
+		smbCollectorsEnabled: &config.CollectorsEnabled,
+		smbListAllCollectors: &smbListAllCollectors,
+	}
+	c.SetLogger(logger)
+	return c
+}
+
+func NewWithFlags(app *kingpin.Application) types.Collector {
+	return &collector{
+		smbListAllCollectors: app.Flag(
+			FlagSmbListAllCollectors,
+			"List the collectors along with their perflib object name/ids",
+		).Bool(),
+
+		smbCollectorsEnabled: app.Flag(
+			FlagSmbCollectorsEnabled,
+			"Comma-separated list of collectors to use. Defaults to all, if not specified.",
+		).Default(ConfigDefaults.CollectorsEnabled).String(),
+	}
+}
+
+func (c *collector) GetName() string {
+	return Name
+}
+
+func (c *collector) SetLogger(logger log.Logger) {
+	c.logger = log.With(logger, "collector", Name)
+}
+
+func (c *collector) GetPerfCounter() ([]string, error) {
+	return []string{
+		"SMB Server Sessions",
+		"SMB Server Shares",
+	}, nil
+}
+
+func (c *collector) Build() error {
+	// desc creates a new prometheus description
+	desc := func(metricName string, description string, labels ...string) *prometheus.Desc {
+		return prometheus.NewDesc(
+			prometheus.BuildFQName(types.Namespace, "smb", metricName),
+			description,
+			labels,
+			nil,
+		)
+	}
+
+	c.CurrentOpenFileCount = desc("smb_server_shares_current_open_file_count", "Current count open files")
+	c.TreeConnectCount = desc("smb_server_session_tree_connect_count", "Current tree connect count")
+
+	c.enabledCollectors = make([]string, 0, len(smbAllCollectorNames))
+
+	collectorDesc := map[string]string{
+		"ServerShares":   "[] SMB Server Shares",
+		"ServerSessions": "[] SMB Server Sessions",
+	}
+
+	if *c.smbListAllCollectors {
+		fmt.Printf("%-32s %-32s\n", "Collector Name", "[PerfID] Perflib Object")
+		for _, cname := range smbAllCollectorNames {
+			fmt.Printf("%-32s %-32s\n", cname, collectorDesc[cname])
+		}
+		os.Exit(0)
+	}
+
+	if *c.smbCollectorsEnabled == "" {
+		for _, collectorName := range smbAllCollectorNames {
+			c.enabledCollectors = append(c.enabledCollectors, collectorName)
+		}
+	} else {
+		for _, collectorName := range strings.Split(*c.smbCollectorsEnabled, ",") {
+			if slices.Contains(smbAllCollectorNames, collectorName) {
+				c.enabledCollectors = append(c.enabledCollectors, collectorName)
+			} else {
+				return fmt.Errorf("unknown smb collector: %s", collectorName)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Collect collects smb metrics and sends them to prometheus
+func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
+	collectorFuncs := map[string]func(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error{
+		"ServerShares":   c.collectServerShares,
+		"ServerSessions": c.collectServerSessions,
+	}
+
+	for _, collectorName := range c.enabledCollectors {
+		if err := collectorFuncs[collectorName](ctx, ch); err != nil {
+			_ = level.Error(c.logger).Log("msg", "Error in "+collectorName, "err", err)
+			return err
+		}
+	}
+	return nil
+}
+
+// Perflib: [] SMB Server Shares
+type perflibServerShares struct {
+	Name string
+
+	CurrentOpenFileCount float64 `perflib:"Current Open File Count"`
+}
+
+func (c *collector) collectServerShares(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
+	var data []perflibServerShares
+	if err := perflib.UnmarshalObject(ctx.PerfObjects["SMB Server Shares"], &data, c.logger); err != nil {
+		return err
+	}
+	labelUseCount := make(map[string]int)
+	for _, proc := range data {
+		labelName := c.toLabelName(proc.Name)
+		if strings.HasSuffix(labelName, "_total") {
+			continue
+		}
+
+		// Since we're not including the PID suffix from the instance names in the label names, we get an occasional duplicate.
+		// This seems to affect about 4 instances only of this object.
+		labelUseCount[labelName]++
+		if labelUseCount[labelName] > 1 {
+			labelName = fmt.Sprintf("%s_%d", labelName, labelUseCount[labelName])
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.CurrentOpenFileCount,
+			prometheus.CounterValue,
+			c.msToSec(proc.CurrentOpenFileCount),
+			labelName,
+		)
+
+	}
+	return nil
+}
+
+// Perflib: [] SMB Server Sessions
+type perflibServerSession struct {
+	TreeConnectCount float64 `perflib:"Tree Connect Count"`
+}
+
+func (c *collector) collectServerSessions(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
+	var data []perflibServerSession
+	if err := perflib.UnmarshalObject(ctx.PerfObjects["SMB Server Sessions"], &data, c.logger); err != nil {
+		return err
+	}
+
+	for _, instance := range data {
+		ch <- prometheus.MustNewConstMetric(
+			c.TreeConnectCount,
+			prometheus.CounterValue,
+			instance.TreeConnectCount,
+		)
+	}
+	return nil
+}
+
+// toLabelName converts strings to lowercase and replaces all whitespaces and dots with underscores
+func (c *collector) toLabelName(name string) string {
+	s := strings.ReplaceAll(strings.Join(strings.Fields(strings.ToLower(name)), "_"), ".", "_")
+	s = strings.ReplaceAll(s, "__", "_")
+	return s
+}
+
+// msToSec converts from ms to seconds
+func (c *collector) msToSec(t float64) float64 {
+	return t / 1000
+}

--- a/pkg/collector/smb/smb.go
+++ b/pkg/collector/smb/smb.go
@@ -183,6 +183,7 @@ func (c *collector) collectServerShares(ctx *types.ScrapeContext, ch chan<- prom
 
 // Perflib: SMB Server Sessions
 type perflibServerSession struct {
+	Name             string
 	TreeConnectCount float64 `perflib:"Tree Connect Count"`
 }
 
@@ -193,6 +194,10 @@ func (c *collector) collectServerSessions(ctx *types.ScrapeContext, ch chan<- pr
 	}
 
 	for _, instance := range data {
+		labelName := c.toLabelName(instance.Name)
+		if !strings.HasSuffix(labelName, "_total") {
+			continue
+		}
 
 		ch <- prometheus.MustNewConstMetric(
 			c.TreeConnectCount,

--- a/pkg/collector/smb/smb.go
+++ b/pkg/collector/smb/smb.go
@@ -165,23 +165,15 @@ func (c *collector) collectServerShares(ctx *types.ScrapeContext, ch chan<- prom
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["SMB Server Shares"], &data, c.logger); err != nil {
 		return err
 	}
-	labelUseCount := make(map[string]int)
-	for _, proc := range data {
-		labelName := c.toLabelName(proc.Name)
+	for _, instance := range data {
+		labelName := c.toLabelName(instance.Name)
 		if strings.HasSuffix(labelName, "_total") {
 			continue
-		}
-
-		// Since we're not including the PID suffix from the instance names in the label names, we get an occasional duplicate.
-		// This seems to affect about 4 instances only of this object.
-		labelUseCount[labelName]++
-		if labelUseCount[labelName] > 1 {
-			labelName = fmt.Sprintf("%s_%d", labelName, labelUseCount[labelName])
 		}
 		ch <- prometheus.MustNewConstMetric(
 			c.CurrentOpenFileCount,
 			prometheus.CounterValue,
-			c.msToSec(proc.CurrentOpenFileCount),
+			instance.CurrentOpenFileCount,
 			labelName,
 		)
 

--- a/pkg/collector/smb/smb.go
+++ b/pkg/collector/smb/smb.go
@@ -102,18 +102,18 @@ func (c *collector) Build() error {
 		)
 	}
 
-	c.CurrentOpenFileCount = desc("server_shares_current_open_file_count", "Current total count open files")
-	c.TreeConnectCount = desc("server_session_tree_connect_count", "Current tree connect count")
+	c.CurrentOpenFileCount = desc("server_shares_current_open_file_count", "Current total count open files on the SMB Server")
+	c.TreeConnectCount = desc("server_session_tree_connect_count", "Tree connect count to SMB Server")
 
 	c.enabledCollectors = make([]string, 0, len(smbAllCollectorNames))
 
 	collectorDesc := map[string]string{
-		"ServerShares":   "[] SMB Server Shares",
-		"ServerSessions": "[] SMB Server Sessions",
+		"ServerShares":   "SMB Server Shares",
+		"ServerSessions": "SMB Server Sessions",
 	}
 
 	if *c.smbListAllCollectors {
-		fmt.Printf("%-32s %-32s\n", "Collector Name", "[PerfID] Perflib Object")
+		fmt.Printf("%-32s %-32s\n", "Collector Name", "Perflib Object")
 		for _, cname := range smbAllCollectorNames {
 			fmt.Printf("%-32s %-32s\n", cname, collectorDesc[cname])
 		}
@@ -153,7 +153,7 @@ func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metri
 	return nil
 }
 
-// Perflib: [] SMB Server Shares
+// Perflib: SMB Server Shares
 type perflibServerShares struct {
 	Name string
 
@@ -181,7 +181,7 @@ func (c *collector) collectServerShares(ctx *types.ScrapeContext, ch chan<- prom
 	return nil
 }
 
-// Perflib: [] SMB Server Sessions
+// Perflib: SMB Server Sessions
 type perflibServerSession struct {
 	TreeConnectCount float64 `perflib:"Tree Connect Count"`
 }

--- a/pkg/collector/smb/smb.go
+++ b/pkg/collector/smb/smb.go
@@ -102,8 +102,8 @@ func (c *collector) Build() error {
 		)
 	}
 
-	c.CurrentOpenFileCount = desc("smb_server_shares_current_open_file_count", "Current count open files")
-	c.TreeConnectCount = desc("smb_server_session_tree_connect_count", "Current tree connect count")
+	c.CurrentOpenFileCount = desc("server_shares_current_open_file_count", "Current total count open files")
+	c.TreeConnectCount = desc("server_session_tree_connect_count", "Current tree connect count")
 
 	c.enabledCollectors = make([]string, 0, len(smbAllCollectorNames))
 
@@ -167,14 +167,14 @@ func (c *collector) collectServerShares(ctx *types.ScrapeContext, ch chan<- prom
 	}
 	for _, instance := range data {
 		labelName := c.toLabelName(instance.Name)
-		if strings.HasSuffix(labelName, "_total") {
+		if !strings.HasSuffix(labelName, "_total") {
 			continue
 		}
+
 		ch <- prometheus.MustNewConstMetric(
 			c.CurrentOpenFileCount,
 			prometheus.CounterValue,
 			instance.CurrentOpenFileCount,
-			labelName,
 		)
 
 	}
@@ -193,6 +193,7 @@ func (c *collector) collectServerSessions(ctx *types.ScrapeContext, ch chan<- pr
 	}
 
 	for _, instance := range data {
+
 		ch <- prometheus.MustNewConstMetric(
 			c.TreeConnectCount,
 			prometheus.CounterValue,

--- a/pkg/collector/smb/smb_test.go
+++ b/pkg/collector/smb/smb_test.go
@@ -1,0 +1,12 @@
+package smb_test
+
+import (
+	"testing"
+
+	"github.com/prometheus-community/windows_exporter/pkg/collector/smb"
+	"github.com/prometheus-community/windows_exporter/pkg/testutils"
+)
+
+func BenchmarkCollector(b *testing.B) {
+	testutils.FuncBenchmarkCollector(b, smb.Name, smb.NewWithFlags)
+}


### PR DESCRIPTION
Added new collector for SMB Server
Collector collects 2 metrics:
- Current count of open files on the SMB Server(count of open files in shared folder)
- Current count of open session on the SMB Server(count of users connection to shared folder)

Thats metrics you can see on compmgmt.msc: Computer management -> Shared folders -> (Open files) and (Sessions)