### PR TITLE
CI: Add stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue has been marked as stale because it has been open for 90 days with no activity. This thread will be automatically closed in 30 days if no further activity occurs.'
+          exempt-issue-labels: 'lifecycle/frozen'
+          days-before-stale: 90
+          days-before-close: 30
+          enable-statistics: true


### PR DESCRIPTION
windows_exporter has a lot of opened issue with may not longer interest. I would like to cleanup some of the approx 300 issues and staled PRs.

This action uses https://github.com/actions/stale . After 90 days of inactivity, a post will be written from gh actions. After another 30 days of interactivity, the issue will be closed.