### PR TITLE
Add ARM64 MSI builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,14 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Install WiX
+        run: dotnet tool install --global wix
+
+      - name: Install WiX extensions
+        run: |
+          wix extension add -g WixToolset.Util.wixext
+          wix extension add -g WixToolset.Firewall.wixext
+
       - name: Install Build deps
         run: |
           dotnet tool install --global GitVersion.Tool --version 5.*
@@ -72,10 +80,10 @@ jobs:
           $TagName = $env:GITHUB_REF -replace 'refs/tags/', ''
           # The MSI version is not semver compliant, so just take the numerical parts
           $MSIVersion = $TagName -replace '^v?([0-9\.]+).*$','$1'
-          foreach($Arch in "amd64", "386") {
+          foreach($Arch in "amd64", "arm64", "386") {
             Write-Verbose "Building windows_exporter $MSIVersion msi for $Arch"
             .\installer\build.ps1 -PathToExecutable .\output\windows_exporter-$BuildVersion-$Arch.exe -Version $MSIVersion -Arch "$Arch"
-            Move-Item installer\Output\windows_exporter-$MSIVersion-$Arch.msi output\
+            Move-Item installer\windows_exporter-$MSIVersion-$Arch.msi output\
           }
 
           promu checksum output\

--- a/installer/build.ps1
+++ b/installer/build.ps1
@@ -5,7 +5,7 @@ Param (
     [Parameter(Mandatory = $true)]
     [String] $Version,
     [Parameter(Mandatory = $false)]
-    [ValidateSet("amd64", "386")]
+    [ValidateSet("amd64", "arm64", "386")]
     [String] $Arch = "amd64"
 )
 $ErrorActionPreference = "Stop"
@@ -23,7 +23,7 @@ mkdir -Force Work | Out-Null
 Copy-Item -Force $PathToExecutable Work/windows_exporter.exe
 
 Write-Verbose "Creating windows_exporter-${Version}-${Arch}.msi"
-$wixArch = @{"amd64" = "x64"; "386" = "x86"}[$Arch]
+$wixArch = @{"amd64" = "x64"; "arm64" = "arm64"; "386" = "x86"}[$Arch]
 $wixOpts = "-ext WixFirewallExtension -ext WixUtilExtension"
 Invoke-Expression "wix build -arch $wixArch -o .\windows_exporter-$($Version)-$($Arch).msi .\windows_exporter.wxs -d Version=$($Version) -ext WixToolset.Firewall.wixext -ext WixToolset.Util.wixext"
 

--- a/installer/build.ps1
+++ b/installer/build.ps1
@@ -19,42 +19,13 @@ Trap {
     Pop-Location
 }
 
-if ($PSVersionTable.PSVersion.Major -lt 5) {
-    Write-Error "Powershell version 5 required"
-    exit 1
-}
-
-$wc = New-Object System.Net.WebClient
-function Get-FileIfNotExists {
-    Param (
-        $Url,
-        $Destination
-    )
-    if (-not (Test-Path $Destination)) {
-        Write-Verbose "Downloading $Url"
-        $wc.DownloadFile($Url, $Destination)
-    }
-    else {
-        Write-Verbose "${Destination} already exists. Skipping."
-    }
-}
-
-$sourceDir = mkdir -Force Source
-mkdir -Force Work, Output | Out-Null
-
-Write-Verbose "Downloading WiX..."
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-Get-FileIfNotExists "https://github.com/wixtoolset/wix3/releases/download/wix311rtm/wix311-binaries.zip" "$sourceDir\wix-binaries.zip"
-mkdir -Force WiX | Out-Null
-Expand-Archive -Path "${sourceDir}\wix-binaries.zip" -DestinationPath WiX -Force
-
+mkdir -Force Work | Out-Null
 Copy-Item -Force $PathToExecutable Work/windows_exporter.exe
 
 Write-Verbose "Creating windows_exporter-${Version}-${Arch}.msi"
 $wixArch = @{"amd64" = "x64"; "386" = "x86"}[$Arch]
 $wixOpts = "-ext WixFirewallExtension -ext WixUtilExtension"
-Invoke-Expression "WiX\candle.exe -nologo -arch $wixArch $wixOpts -out Work\windows_exporter.wixobj -dVersion=`"$Version`" windows_exporter.wxs"
-Invoke-Expression "WiX\light.exe -nologo -spdb $wixOpts -out `"Output\windows_exporter-${Version}-${Arch}.msi`" Work\windows_exporter.wixobj"
+Invoke-Expression "wix build -arch $wixArch -o .\windows_exporter-$($Version)-$($Arch).msi .\windows_exporter.wxs -d Version=$($Version) -ext WixToolset.Firewall.wixext -ext WixToolset.Util.wixext"
 
 Write-Verbose "Done!"
 Pop-Location

--- a/installer/windows_exporter.wxs
+++ b/installer/windows_exporter.wxs
@@ -1,55 +1,42 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
-     xmlns:fw="http://schemas.microsoft.com/wix/FirewallExtension"
-     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:fw="http://wixtoolset.org/schemas/v4/wxs/firewall" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
   <?if $(sys.BUILDARCH)=x64 ?>
     <?define PlatformProgramFiles = "ProgramFiles64Folder" ?>
-  <?else ?>
+  <?else?>
     <?define PlatformProgramFiles = "ProgramFilesFolder" ?>
-  <?endif ?>
+  <?endif?>
 
-  <Product Id="*" UpgradeCode="66a6eb5b-1fc2-4b14-a362-5ceec6413308"
-           Name="windows_exporter" Version="$(var.Version)" Manufacturer="prometheus-community"
-           Language="1033" Codepage="1252">
-    <Package Id="*" Manufacturer="prometheus-community" InstallScope="perMachine" InstallerVersion="500"
-             Description="windows_exporter $(var.Version) installer" Compressed="yes" />
-    <Media Id="1" Cabinet="windows_exporter.cab" EmbedCab="yes"/>
+  <Package UpgradeCode="66a6eb5b-1fc2-4b14-a362-5ceec6413308" Name="windows_exporter" Version="$(var.Version)" Manufacturer="prometheus-community" Language="1033" Codepage="1252"><SummaryInformation Manufacturer="prometheus-community" Description="windows_exporter $(var.Version) installer" />
+    <Media Id="1" Cabinet="windows_exporter.cab" EmbedCab="yes" />
     <MajorUpgrade Schedule="afterInstallInitialize" DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />
 
-    <Property Id="ENABLED_COLLECTORS" Secure="yes"/>
-    <SetProperty Id="CollectorsFlag" After="InstallFiles" Sequence="execute" Value="--collectors.enabled [ENABLED_COLLECTORS]">ENABLED_COLLECTORS</SetProperty>
+    <Property Id="ENABLED_COLLECTORS" Secure="yes" />
+    <SetProperty Id="CollectorsFlag" After="InstallFiles" Sequence="execute" Value="--collectors.enabled [ENABLED_COLLECTORS]" Condition="ENABLED_COLLECTORS" />
 
-    <Property Id="EXTRA_FLAGS" Secure="yes"/>
-    <SetProperty Id="ExtraFlags" After="InstallFiles" Sequence="execute" Value="[EXTRA_FLAGS]">EXTRA_FLAGS</SetProperty>
+    <Property Id="EXTRA_FLAGS" Secure="yes" />
+    <SetProperty Id="ExtraFlags" After="InstallFiles" Sequence="execute" Value="[EXTRA_FLAGS]" Condition="EXTRA_FLAGS" />
 
     <Property Id="LISTEN_ADDR" Secure="yes" />
     <Property Id="LISTEN_PORT" Secure="yes" />
-    <SetProperty Id="ListenFlagBoth" After="InstallFiles" Sequence="execute" Value="--web.listen-address [LISTEN_ADDR]:[LISTEN_PORT]">LISTEN_ADDR AND LISTEN_PORT</SetProperty>
-    <SetProperty Id="ListenFlagAddr" After="InstallFiles" Sequence="execute" Value="--web.listen-address [LISTEN_ADDR]:9182">LISTEN_ADDR AND (NOT LISTEN_PORT)</SetProperty>
-    <SetProperty Id="ListenFlagPort" After="InstallFiles" Sequence="execute" Value="--web.listen-address 0.0.0.0:[LISTEN_PORT]">LISTEN_PORT AND (NOT LISTEN_ADDR)</SetProperty>
+    <SetProperty Id="ListenFlagBoth" After="InstallFiles" Sequence="execute" Value="--web.listen-address [LISTEN_ADDR]:[LISTEN_PORT]" Condition="LISTEN_ADDR AND LISTEN_PORT" />
+    <SetProperty Id="ListenFlagAddr" After="InstallFiles" Sequence="execute" Value="--web.listen-address [LISTEN_ADDR]:9182" Condition="LISTEN_ADDR AND (NOT LISTEN_PORT)" />
+    <SetProperty Id="ListenFlagPort" After="InstallFiles" Sequence="execute" Value="--web.listen-address 0.0.0.0:[LISTEN_PORT]" Condition="LISTEN_PORT AND (NOT LISTEN_ADDR)" />
 
-    <Property Id="METRICS_PATH" Secure="yes"/>
-    <SetProperty Id="MetricsPathFlag" After="InstallFiles" Sequence="execute" Value="--telemetry.path [METRICS_PATH]">METRICS_PATH</SetProperty>
+    <Property Id="METRICS_PATH" Secure="yes" />
+    <SetProperty Id="MetricsPathFlag" After="InstallFiles" Sequence="execute" Value="--telemetry.path [METRICS_PATH]" Condition="METRICS_PATH" />
 
     <Property Id="REMOTE_ADDR" Secure="yes" />
-    <SetProperty Id="RemoteAddressFlag" After="InstallFiles" Sequence="execute" Value="[REMOTE_ADDR]">REMOTE_ADDR</SetProperty>
+    <SetProperty Id="RemoteAddressFlag" After="InstallFiles" Sequence="execute" Value="[REMOTE_ADDR]" Condition="REMOTE_ADDR" />
 
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="$(var.PlatformProgramFiles)">
-        <Directory Id="APPLICATIONROOTDIRECTORY" Name="windows_exporter">
-          <Directory Id="textfile_inputs" Name="textfile_inputs" />
-        </Directory>
-      </Directory>
-    </Directory>
+    
 
-    <Property Id="TEXTFILE_DIR" Secure="yes"/>
-    <SetProperty Id="TextfileDirFlag" After="InstallFiles" Sequence="execute" Value="--collector.textfile.directory [TEXTFILE_DIR]">TEXTFILE_DIR</SetProperty>
+    <Property Id="TEXTFILE_DIR" Secure="yes" />
+    <SetProperty Id="TextfileDirFlag" After="InstallFiles" Sequence="execute" Value="--collector.textfile.directory [TEXTFILE_DIR]" Condition="TEXTFILE_DIR" />
 
     <ComponentGroup Id="Files">
       <Component Directory="APPLICATIONROOTDIRECTORY">
         <File Id="windows_exporter.exe" Name="windows_exporter.exe" Source="Work\windows_exporter.exe" KeyPath="yes">
           <fw:FirewallException Id="MetricsEndpoint" Name="windows_exporter (HTTP [LISTEN_PORT])" Description="windows_exporter HTTP endpoint" Port="[LISTEN_PORT]" Protocol="tcp" IgnoreFailure="yes">
-            <fw:RemoteAddress>[REMOTE_ADDR]</fw:RemoteAddress>
+            <fw:RemoteAddress Value="[REMOTE_ADDR]" />
           </fw:FirewallException>
         </File>
         <ServiceInstall Id="InstallExporterService" Name="windows_exporter" DisplayName="windows_exporter" Description="Exports Prometheus metrics about the system" ErrorControl="normal" Start="auto" Type="ownProcess" Arguments="--log.file eventlog [CollectorsFlag] [ListenFlagBoth] [ListenFlagAddr] [ListenFlagPort] [MetricsPathFlag] [TextfileDirFlag] [ExtraFlags]">
@@ -67,5 +54,11 @@
     <Feature Id="DefaultFeature" Level="1">
       <ComponentGroupRef Id="Files" />
     </Feature>
-  </Product>
+  
+      <Directory Id="$(var.PlatformProgramFiles)">
+        <Directory Id="APPLICATIONROOTDIRECTORY" Name="windows_exporter">
+          <Directory Id="textfile_inputs" Name="textfile_inputs" />
+        </Directory>
+      </Directory>
+    </Package>
 </Wix>

--- a/installer/windows_exporter.wxs
+++ b/installer/windows_exporter.wxs
@@ -15,11 +15,8 @@
     <Property Id="EXTRA_FLAGS" Secure="yes" />
     <SetProperty Id="ExtraFlags" After="InstallFiles" Sequence="execute" Value="[EXTRA_FLAGS]" Condition="EXTRA_FLAGS" />
 
-    <Property Id="LISTEN_ADDR" Secure="yes" />
-    <Property Id="LISTEN_PORT" Secure="yes" />
-    <SetProperty Id="ListenFlagBoth" After="InstallFiles" Sequence="execute" Value="--web.listen-address [LISTEN_ADDR]:[LISTEN_PORT]" Condition="LISTEN_ADDR AND LISTEN_PORT" />
-    <SetProperty Id="ListenFlagAddr" After="InstallFiles" Sequence="execute" Value="--web.listen-address [LISTEN_ADDR]:9182" Condition="LISTEN_ADDR AND (NOT LISTEN_PORT)" />
-    <SetProperty Id="ListenFlagPort" After="InstallFiles" Sequence="execute" Value="--web.listen-address 0.0.0.0:[LISTEN_PORT]" Condition="LISTEN_PORT AND (NOT LISTEN_ADDR)" />
+    <Property Id="LISTEN_ADDR" Secure="yes" Value="0.0.0.0" />
+    <Property Id="LISTEN_PORT" Secure="yes" Value="9182" />
 
     <Property Id="METRICS_PATH" Secure="yes" />
     <SetProperty Id="MetricsPathFlag" After="InstallFiles" Sequence="execute" Value="--telemetry.path [METRICS_PATH]" Condition="METRICS_PATH" />
@@ -39,7 +36,7 @@
             <fw:RemoteAddress Value="[REMOTE_ADDR]" />
           </fw:FirewallException>
         </File>
-        <ServiceInstall Id="InstallExporterService" Name="windows_exporter" DisplayName="windows_exporter" Description="Exports Prometheus metrics about the system" ErrorControl="normal" Start="auto" Type="ownProcess" Arguments="--log.file eventlog [CollectorsFlag] [ListenFlagBoth] [ListenFlagAddr] [ListenFlagPort] [MetricsPathFlag] [TextfileDirFlag] [ExtraFlags]">
+        <ServiceInstall Id="InstallExporterService" Name="windows_exporter" DisplayName="windows_exporter" Description="Exports Prometheus metrics about the system" ErrorControl="normal" Start="auto" Type="ownProcess" Arguments="--log.file eventlog [CollectorsFlag] --web.listen-address [LISTEN_ADDR]:[LISTEN_PORT] [MetricsPathFlag] [TextfileDirFlag] [ExtraFlags]">
           <util:ServiceConfig FirstFailureActionType="restart" SecondFailureActionType="restart" ThirdFailureActionType="restart" RestartServiceDelayInSeconds="60" />
           <ServiceDependency Id="wmiApSrv" />
         </ServiceInstall>


### PR DESCRIPTION
As WiX v3 did not support ARM64 builds, I've upgraded it to v4 in the Github release action and build script. The bulk of the work was done with `wix convert`.

I've run the release action in my own fork to confirm the MSIs are built correctly, see https://github.com/breed808/windows_exporter/releases/tag/v0.24.1 for the artifacts. I've successfully tested the `amd64` MSI with some variables (`ENABLED_COLLECTORS`, `LISTEN_PORT` and `METRICS_PATH`); unfortunately I'm not in a position to test the `386` or `arm64` MSI packages.

Resolves #1293 