### PR TITLE
CI: Provide binary builds from GH actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,6 +77,15 @@ jobs:
       - name: Promtool
         run: make promtool
 
+      - name: Upload windows_exporter.exe
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: windows_exporter.amd64.exe
+          path: 'windows_exporter.exe'
+          retention-days: 7
+          if-no-files-found: error
+
   lint:
     runs-on: windows-2022
     steps:


### PR DESCRIPTION
This PR uploads the windows_exporter.exe file from job lint as job artifact.

It give us the opportunity the ask different users, if PR like #1376 solves issues. Before this, users have build own exporter binaries which could be a blocker for inexperienced users.