### PR TITLE
Remove i386 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           (Get-Content -Path VERSION) -replace '\+', '_' | Set-Content -Path VERSION
           make build-all
           # GH requires all files to have different names, so add version/arch to differentiate
-          foreach($Arch in "amd64", "arm64","386") {
+          foreach($Arch in "amd64", "arm64") {
             Move-Item output\$Arch\windows_exporter.exe output\windows_exporter-$Version-$Arch.exe
           }
 
@@ -80,7 +80,7 @@ jobs:
           $TagName = $env:GITHUB_REF -replace 'refs/tags/', ''
           # The MSI version is not semver compliant, so just take the numerical parts
           $MSIVersion = $TagName -replace '^v?([0-9\.]+).*$','$1'
-          foreach($Arch in "amd64", "arm64", "386") {
+          foreach($Arch in "amd64", "arm64") {
             Write-Verbose "Building windows_exporter $MSIVersion msi for $Arch"
             .\installer\build.ps1 -PathToExecutable .\output\windows_exporter-$BuildVersion-$Arch.exe -Version $MSIVersion -Arch "$Arch"
             Move-Item installer\windows_exporter-$MSIVersion-$Arch.msi output\

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ crossbuild:
 	# on Windows, so for now, we'll just build twice
 	GOARCH=amd64 promu build --prefix=output/amd64
 	GOARCH=arm64 promu build --prefix=output/arm64
-	GOARCH=386   promu build --prefix=output/386
 
 build-image: crossbuild
 	$(DOCKER) build --build-arg=BASE=$(BASE_IMAGE):$(OS) -f Dockerfile -t $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(VERSION)-$(OS) .

--- a/installer/build.ps1
+++ b/installer/build.ps1
@@ -5,7 +5,7 @@ Param (
     [Parameter(Mandatory = $true)]
     [String] $Version,
     [Parameter(Mandatory = $false)]
-    [ValidateSet("amd64", "arm64", "386")]
+    [ValidateSet("amd64", "arm64")]
     [String] $Arch = "amd64"
 )
 $ErrorActionPreference = "Stop"
@@ -23,7 +23,7 @@ mkdir -Force Work | Out-Null
 Copy-Item -Force $PathToExecutable Work/windows_exporter.exe
 
 Write-Verbose "Creating windows_exporter-${Version}-${Arch}.msi"
-$wixArch = @{"amd64" = "x64"; "arm64" = "arm64"; "386" = "x86"}[$Arch]
+$wixArch = @{"amd64" = "x64"; "arm64" = "arm64"}[$Arch]
 $wixOpts = "-ext WixFirewallExtension -ext WixUtilExtension"
 Invoke-Expression "wix build -arch $wixArch -o .\windows_exporter-$($Version)-$($Arch).msi .\windows_exporter.wxs -d Version=$($Version) -ext WixToolset.Firewall.wixext -ext WixToolset.Util.wixext"
 


### PR DESCRIPTION
This PR removes x86 binary builds.

The x86 binary builds are broken, because Windows provides only int32 values for PerfCounter which leads into user error, if the value is higher than 32-bit integer.

I would like to remove build to reduce the maintenance efforts. 