### PR TITLE
fix(#1352): moving the stop signal after svc.Run()

### DIFF
--- a/pkg/initiate/initiate.go
+++ b/pkg/initiate/initiate.go
@@ -64,9 +64,7 @@ func init() {
 			if err != nil {
 				_ = logger.Error(102, fmt.Sprintf("Failed to start service: %v", err))
 			}
-			defer func() {
-				StopCh <- true
-			}()
+			StopCh <- true
 		}()
 	}
 }

--- a/pkg/initiate/initiate.go
+++ b/pkg/initiate/initiate.go
@@ -13,9 +13,7 @@ const (
 	serviceName = "windows_exporter"
 )
 
-type windowsExporterService struct {
-	stopCh chan<- bool
-}
+type windowsExporterService struct{}
 
 var logger *eventlog.Log
 
@@ -39,7 +37,6 @@ loop:
 			}
 		}
 	}
-	s.stopCh <- true
 	return
 }
 
@@ -63,10 +60,13 @@ func init() {
 		}
 		_ = logger.Info(100, "Attempting to start exporter service")
 		go func() {
-			err = svc.Run(serviceName, &windowsExporterService{stopCh: StopCh})
+			err = svc.Run(serviceName, &windowsExporterService{})
 			if err != nil {
 				_ = logger.Error(102, fmt.Sprintf("Failed to start service: %v", err))
 			}
+			defer func() {
+				StopCh <- true
+			}()
 		}()
 	}
 }


### PR DESCRIPTION
As explained in the closed PR #1372 this would be the shorthand fix for #1352.

Just to mention that @jkroepke suggested the it would be better to split the windows service stuff from the exporter itself and create two binaries. Like it is done in the https://github.com/grafana/agent/issues/3243 I also agree with that but this would be a bigger change and take more time to implement which I don't have at the moment.

So in the meantime this PR could fix the stop error and since there is only e little change in when the stop signal is sent, it should not re interduce some old behavior/issues like #1047 or #551.

I have tested this PR with default collectors enabled and windows 11 and windows server 2016 (I don't have more options just yet)



 