### PR TITLE
fix: Apply query filter to metrics

### DIFF
--- a/pkg/collector/handler.go
+++ b/pkg/collector/handler.go
@@ -32,7 +32,14 @@ func (c *Collectors) BuildServeHTTP(disableExporterMetrics bool, timeoutMargin f
 			}
 			filteredCollectors[name] = col
 		}
-		return nil, NewPrometheus(timeout, c, c.logger)
+
+		filtered := Collectors{
+			logger:           c.logger,
+			collectors:       filteredCollectors,
+			perfCounterQuery: c.perfCounterQuery,
+		}
+
+		return nil, NewPrometheus(timeout, &filtered, c.logger)
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Refactor in 0711268d3c3025b5b6ed49b3862264b7e7600bec introduced #1389, where the `collect[]=` parameter is being ignored, preventing users from filtering metrics.

This change ensures the collector filter is applied.