### PR TITLE
docs!: Remove support for EOL Windows versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ See detailed steps to install on Windows Kubernetes [here](./kubernetes/kubernet
 
 `windows_exporter` supports Windows Server versions 2016 and later, and desktop Windows version 10 and 11 (21H2 or later).
 
+Windows Server 2012 and 2012R2 are supported as best-effort only, but not guaranteed to work.
+
 ## Usage
 
     go get -u github.com/prometheus/promu

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ See detailed steps to install on Windows Kubernetes [here](./kubernetes/kubernet
 
 ## Supported versions
 
-windows_exporter supports Windows Server versions 2008R2 and later, and desktop Windows version 7 and later.
+`windows_exporter` supports Windows Server versions 2016 and later, and desktop Windows version 10 and 11 (21H2 or later).
 
 ## Usage
 


### PR DESCRIPTION
Microsoft currently support Windows Server 2016 or newer, and Windows 10 and Windows 11 (21HR or later). Dropping support for end-of-life Windows Server versions will reduce maintenance overhead for project maintainers.

This removal of support is intended for the next major exporter release (v0.26.0).