### PR TITLE
Fix collector.process.iis flag

### DIFF
--- a/pkg/collector/process/process.go
+++ b/pkg/collector/process/process.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	Name               = "process"
-	FlagProcessExclude = "collector.process.exclude"
-	FlagProcessInclude = "collector.process.include"
+	Name                    = "process"
+	FlagProcessExclude      = "collector.process.exclude"
+	FlagProcessInclude      = "collector.process.include"
+	FlagEnableWorkerProcess = "collector.process.iis"
 )
 
 type Config struct {
@@ -91,7 +92,7 @@ func NewWithFlags(app *kingpin.Application) types.Collector {
 		).Default(ConfigDefaults.ProcessExclude).String(),
 
 		enableWorkerProcess: app.Flag(
-			"collector.process.iis",
+			FlagEnableWorkerProcess,
 			"Enable IIS worker process name queries. May cause the collector to leak memory.",
 		).Default("false").Bool(),
 	}


### PR DESCRIPTION
Process Collector Enable Worker Process Query Broken
Relating PR: [1062](https://github.com/prometheus-community/windows_exporter/pull/1062)
Error running:
.\windows_exporter.exe --web.listen-address "0.0.0.0:9183" --collectors.enabled "process" --collector.process.iis

Fixed the error:
windows_exporter.exe: error: unknown long flag '--collector.process.iis', try --help

Tested fix and working on the commandline and using a config file.
