### PR TITLE
installer: Disable Windows Firewall Exception by default. Can be re-enabled with ADD_FIREWALL_EXCEPTION=yes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.wxs]
+
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ output/
 .vscode
 .idea
 *.syso
+installer/*.msi
+installer/*.wixpdb

--- a/README.md
+++ b/README.md
@@ -121,10 +121,18 @@ Example service collector with a custom query.
 msiexec /i <path-to-msi-file> ENABLED_COLLECTORS=os,service --% EXTRA_FLAGS="--collector.service.services-where ""Name LIKE 'sql%'"""
 ```
 
-On some older versions of Windows you may need to surround parameter values with double quotes to get the install command parsing properly:
+On some older versions of Windows,
+you may need to surround parameter values with double quotes to get the installation command parsing properly:
 ```powershell
 msiexec /i C:\Users\Administrator\Downloads\windows_exporter.msi ENABLED_COLLECTORS="ad,iis,logon,memory,process,tcp,textfile,thermalzone" TEXTFILE_DIRS="C:\custom_metrics\"
 ```
+
+To install the exporter with creating a firewall exception, use the following command:
+
+```powershell
+msiexec /i <path-to-msi-file> ADD_FIREWALL_EXCEPTION=yes
+```
+
 
 Powershell versions 7.3 and above require [PSNativeCommandArgumentPassing](https://learn.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.3) to be set to `Legacy` when using `--% EXTRA_FLAGS`:
 
@@ -132,7 +140,6 @@ Powershell versions 7.3 and above require [PSNativeCommandArgumentPassing](https
 $PSNativeCommandArgumentPassing = 'Legacy'
 msiexec /i <path-to-msi-file> ENABLED_COLLECTORS=os,service --% EXTRA_FLAGS="--collector.service.services-where ""Name LIKE 'sql%'"""
 ```
-
 
 ## Kubernetes Implementation
 

--- a/installer/build.ps1
+++ b/installer/build.ps1
@@ -24,7 +24,7 @@ Copy-Item -Force $PathToExecutable Work/windows_exporter.exe
 
 Write-Verbose "Creating windows_exporter-${Version}-${Arch}.msi"
 $wixArch = @{"amd64" = "x64"; "arm64" = "arm64"}[$Arch]
-$wixOpts = "-ext WixFirewallExtension -ext WixUtilExtension"
+
 Invoke-Expression "wix build -arch $wixArch -o .\windows_exporter-$($Version)-$($Arch).msi .\windows_exporter.wxs -d Version=$($Version) -ext WixToolset.Firewall.wixext -ext WixToolset.Util.wixext"
 
 Write-Verbose "Done!"

--- a/installer/windows_exporter.wxs
+++ b/installer/windows_exporter.wxs
@@ -15,6 +15,9 @@
     <Property Id="EXTRA_FLAGS" Secure="yes" />
     <SetProperty Id="ExtraFlags" After="InstallFiles" Sequence="execute" Value="[EXTRA_FLAGS]" Condition="EXTRA_FLAGS" />
 
+    <Property Id="ADD_FIREWALL_EXCEPTION" Secure="yes" />
+    <SetProperty Id="FirewallException" After="InstallFiles" Sequence="execute" Value="[ADD_FIREWALL_EXCEPTION]" Condition="ADD_FIREWALL_EXCEPTION" />
+
     <Property Id="LISTEN_ADDR" Secure="yes" Value="0.0.0.0" />
     <Property Id="LISTEN_PORT" Secure="yes" Value="9182" />
 
@@ -49,11 +52,7 @@
 
     <ComponentGroup Id="Files">
       <Component Directory="APPLICATIONROOTDIRECTORY">
-        <File Id="windows_exporter.exe" Name="windows_exporter.exe" Source="Work\windows_exporter.exe" KeyPath="yes">
-          <fw:FirewallException Id="MetricsEndpoint" Name="windows_exporter (HTTP [LISTEN_PORT])" Description="windows_exporter HTTP endpoint" Port="[LISTEN_PORT]" Protocol="tcp" IgnoreFailure="yes">
-            <fw:RemoteAddress Value="[REMOTE_ADDR]" />
-          </fw:FirewallException>
-        </File>
+        <File Id="windows_exporter.exe" Name="windows_exporter.exe" Source="Work\windows_exporter.exe" KeyPath="yes" />
         <ServiceInstall Id="InstallExporterService" Name="windows_exporter" DisplayName="windows_exporter" Description="Exports Prometheus metrics about the system" ErrorControl="normal" Start="auto" Type="ownProcess" Arguments="--log.file eventlog [CollectorsFlag] --web.listen-address [LISTEN_ADDR]:[LISTEN_PORT] [MetricsPathFlag] [TextfileDirsFlag] [ExtraFlags]">
           <util:ServiceConfig FirstFailureActionType="restart" SecondFailureActionType="restart" ThirdFailureActionType="restart" RestartServiceDelayInSeconds="60" />
           <ServiceDependency Id="wmiApSrv" />
@@ -64,15 +63,26 @@
         <CreateFolder />
       </Component>
     </ComponentGroup>
+    <ComponentGroup Id="CG_FirewallException">
+      <Component Condition="ADD_FIREWALL_EXCEPTION=&quot;yes&quot;" Directory="APPLICATIONROOTDIRECTORY" Id="C_FirewallException" Guid="9f522655-ac0e-42d2-a512-a7b19ebec7f7">
+        <fw:FirewallException Id="MetricsEndpoint" Name="windows_exporter (HTTP [LISTEN_PORT])" Description="windows_exporter HTTP endpoint" Port="[LISTEN_PORT]" Protocol="tcp" IgnoreFailure="yes">
+          <fw:RemoteAddress Value="[REMOTE_ADDR]" />
+        </fw:FirewallException>
+      </Component>
+    </ComponentGroup>
 
     <Feature Id="DefaultFeature" Level="1">
       <ComponentGroupRef Id="Files" />
     </Feature>
 
-    <Directory Id="$(var.PlatformProgramFiles)">
+    <Feature Id="FirewallException" Level="1">
+      <ComponentGroupRef Id="CG_FirewallException" />
+    </Feature>
+
+    <StandardDirectory Id="ProgramFiles64Folder">
       <Directory Id="APPLICATIONROOTDIRECTORY" Name="windows_exporter">
         <Directory Id="textfile_inputs" Name="textfile_inputs" />
       </Directory>
-    </Directory>
+    </StandardDirectory>
   </Package>
 </Wix>


### PR DESCRIPTION
Fixes #513 

Signed-off-by: Jan-Otto Kröpke <mail@jkroepke.de>