### PR TITLE
Add: push docker images to dockerhub and quay.io

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,6 @@ jobs:
           Expand-Archive -Path promu-$($Env:PROMU_VER).windows-amd64.zip -DestinationPath .
           Copy-Item -Path promu-$($Env:PROMU_VER).windows-amd64\promu.exe -Destination "$(go env GOPATH)\bin"
 
-          go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.2.0
           # GOPATH\bin dir must be appended to PATH else the `promu` command won't be found
           echo "$(go env GOPATH)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
@@ -69,8 +68,6 @@ jobs:
           Expand-Archive -Path promu-$($Env:PROMU_VER).windows-amd64.zip -DestinationPath .
           Copy-Item -Path promu-$($Env:PROMU_VER).windows-amd64\promu.exe -Destination "$(go env GOPATH)\bin"
 
-          # No binaries available so build from source
-          go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.2.0
           # GOPATH\bin dir must be appended to PATH else the `promu` command won't be found
           echo "$(go env GOPATH)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,15 @@ jobs:
           promu checksum output\
 
       - name: Build Docker Artifacts
-        run: |
-          $Env:VERSION = '${{ startsWith(github.ref, 'refs/tags/') && 'latest' || github.ref_name }}'
-          make build-all
+        run: make build-all
+        env:
+          VERSION: >-
+            ${{
+              startsWith(github.ref, 'refs/tags/') && 'latest' || 
+              (
+                github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || github.ref_name
+              )
+            }}
 
       - name: Login to Docker Hub
         if: ${{ github.event_name != 'pull_request' }}
@@ -118,8 +124,8 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ startsWith(github.ref, 'refs/tags/') && 'latest' || github.ref_name }}
         run: |
-          $Env:VERSION = '${{ startsWith(github.ref, 'refs/tags/') && 'latest' || github.ref_name }}'
           make push-all
 
       - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,17 +45,9 @@ jobs:
           Invoke-WebRequest -Uri https://github.com/prometheus/promu/releases/download/v$($Env:PROMU_VER)/promu-$($Env:PROMU_VER).windows-amd64.zip -OutFile promu-$($Env:PROMU_VER).windows-amd64.zip
           Expand-Archive -Path promu-$($Env:PROMU_VER).windows-amd64.zip -DestinationPath .
           Copy-Item -Path promu-$($Env:PROMU_VER).windows-amd64\promu.exe -Destination "$(go env GOPATH)\bin"
-          
-          Invoke-WebRequest -Uri https://github.com/moby/buildkit/releases/download/v0.13.2/buildkit-v0.13.2.windows-amd64.tar.gz -OutFile buildkit.tar.gz
-          tar xvf buildkit.tar.gz
-          Copy-Item -Path bin\buildctl.exe -Destination "$(go env GOPATH)\bin"
 
           # GOPATH\bin dir must be added to PATH else the `promu` commands won't be found
           echo "$(go env GOPATH)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Start buildkit
-        run: |
-          bin\buildkitd.exe
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Install WiX
         run: dotnet tool install --global wix
 
@@ -48,6 +45,10 @@ jobs:
           Invoke-WebRequest -Uri https://github.com/prometheus/promu/releases/download/v$($Env:PROMU_VER)/promu-$($Env:PROMU_VER).windows-amd64.zip -OutFile promu-$($Env:PROMU_VER).windows-amd64.zip
           Expand-Archive -Path promu-$($Env:PROMU_VER).windows-amd64.zip -DestinationPath .
           Copy-Item -Path promu-$($Env:PROMU_VER).windows-amd64\promu.exe -Destination "$(go env GOPATH)\bin"
+          
+          Invoke-WebRequest -Uri https://github.com/moby/buildkit/releases/download/v0.13.2/buildkit-v0.13.2.windows-amd64.tar.gz -OutFile buildkit.tar.gz
+          tar xvf buildkit.tar.gz
+          Copy-Item -Path bin\buildctl.exe -Destination "$(go env GOPATH)\bin"
 
           # GOPATH\bin dir must be added to PATH else the `promu` commands won't be found
           echo "$(go env GOPATH)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,10 @@ jobs:
           # GOPATH\bin dir must be added to PATH else the `promu` commands won't be found
           echo "$(go env GOPATH)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Start buildkit
+        run: |
+          bin\buildkitd.exe
+
       - name: Build
         run: |
           $ErrorActionPreference = "Stop"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,9 @@ jobs:
 
           promu checksum output\
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build Docker Artifacts
         run: |
           $Env:VERSION = '${{ startsWith(github.ref, 'refs/tags/') && 'latest' || github.ref_name }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: Releases
 
 # Trigger on releases.
 on:
+  push:
+    branches:
+      - master
+  pull_request:
   release:
     types:
       - published
@@ -68,7 +72,7 @@ jobs:
           path: output\windows_exporter-*.exe
 
       - name: Build Release Artifacts
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           $ErrorActionPreference = "Stop"
           $BuildVersion = Get-Content VERSION
@@ -83,6 +87,25 @@ jobs:
 
           promu checksum output\
 
+      - name: Build Docker Artifacts
+        run: |
+          $Env:VERSION = '${{ startsWith(github.ref, 'refs/tags/') && 'latest' || github.ref_name }}'
+          make build-all
+
+      - name: Login to Docker Hub
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_LOGIN }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Login to Docker Hub
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          username: '$token'
+          password: ${{ secrets.QUAY_IO_API_TOKEN }}
+
       - name: Login to GitHub container registry
         if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
@@ -96,7 +119,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $Env:VERSION = 'latest'
+          $Env:VERSION = '${{ startsWith(github.ref, 'refs/tags/') && 'latest' || github.ref_name }}'
           make push-all
 
       - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Install WiX
         run: dotnet tool install --global wix
 
@@ -86,9 +89,6 @@ jobs:
           }
 
           promu checksum output\
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Build Docker Artifacts
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Note this image doesn't really matter for hostprocess but it is good to build per OS version
 # the files in the image are copied to $env:CONTAINER_SANDBOX_MOUNT_POINT on the host
 # but the file system is the Host NOT the container
-ARG BASE="mcr.microsoft.com/windows/nanoserver:1809"
+ARG BASE="mcr.microsoft.com/windows/nanoserver:ltsc2022"
 FROM $BASE
 
 ENV PATH="C:\Windows\system32;C:\Windows;"

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build-image: crossbuild
 # Hostprocess images requires buildkit to build
 # https://github.com/microsoft/windows-host-process-containers-base-image#build-with-buildkit
 build-hostprocess-image: crossbuild
-	$(DOCKER) buildx build --load --build-arg=BASE=$(BASE_HOST_PROCESS_IMAGE) -f Dockerfile -t local/$(DOCKER_IMAGE_NAME):$(VERSION)-hostprocess .
+	$(DOCKER) buildx build --build-arg=BASE=$(BASE_HOST_PROCESS_IMAGE) -f Dockerfile -t local/$(DOCKER_IMAGE_NAME):$(VERSION)-hostprocess .
 
 sub-build-%:
 	$(MAKE) OS=$* build-image

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 export GOOS=windows
 export DOCKER_IMAGE_NAME ?= windows-exporter
-DOCKER_REPO:= ghcr.io/prometheus-community docker.io/prometheuscommunity quay.io/prometheuscommunity
+
+# DOCKER_REPO is the official image repository name at docker.io, quay.io.
+DOCKER_REPO:= prometheuscommunity
+
+# DOCKER_PUSH_REPOS is the list of repositories to push the image to. ghcr.io requires that org name be the same as the image repo name.
+DOCKER_PUSH_REPOS:=docker.io/$(DOCKER_REPO) quay.io/$(DOCKER_REPO) ghcr.io/prometheus-community
 
 VERSION?=$(shell cat VERSION)
 DOCKER?=docker
@@ -76,3 +81,8 @@ push:
 	done
 
 push-all: build-all push
+
+# Mandatory target for container description sync action
+.PHONY: docker-repo-name
+docker-repo-name:
+	@echo "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)"

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build-all: $(addprefix sub-build-,$(ALL_OS)) build-hostprocess-image
 
 push:
 	set -x; \
-	for repo in ${DOCKER_REPO}; do \
+	for repo in ${DOCKER_PUSH_REPOS}; do \
 		for osversion in ${ALL_OS}; do \
 			$(DOCKER) tag local/$(DOCKER_IMAGE_NAME):$(VERSION)-$${osversion} $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(VERSION)-$${osversion}; \
 			$(DOCKER) push $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(VERSION)-$${osversion}; \

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,9 @@ build-image: crossbuild
 
 # Hostprocess images requires buildkit to build
 # https://github.com/microsoft/windows-host-process-containers-base-image#build-with-buildkit
+# docker buildx is not supported on Windows
 build-hostprocess-image: crossbuild
-	$(DOCKER) buildx build --build-arg=BASE=$(BASE_HOST_PROCESS_IMAGE) -f Dockerfile -t local/$(DOCKER_IMAGE_NAME):$(VERSION)-hostprocess .
+	buildctl.exe build --frontend=dockerfile.v0 --local context=. --local dockerfile=. --output type=docker,name=local/$(DOCKER_IMAGE_NAME):$(VERSION)-hostprocess
 
 sub-build-%:
 	$(MAKE) OS=$* build-image

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,10 @@ crossbuild: generate
 build-image: crossbuild
 	$(DOCKER) build --build-arg=BASE=$(BASE_IMAGE):$(OS) -f Dockerfile -t local/$(DOCKER_IMAGE_NAME):$(VERSION)-$(OS) .
 
+# Hostprocess images requires buildkit to build
+# https://github.com/microsoft/windows-host-process-containers-base-image#build-with-buildkit
 build-hostprocess-image: crossbuild
-	$(DOCKER) build --build-arg=BASE=$(BASE_HOST_PROCESS_IMAGE) -f Dockerfile -t local/$(DOCKER_IMAGE_NAME):$(VERSION)-hostprocess .
+	$(DOCKER) buildx build --load --build-arg=BASE=$(BASE_HOST_PROCESS_IMAGE) -f Dockerfile -t local/$(DOCKER_IMAGE_NAME):$(VERSION)-hostprocess .
 
 sub-build-%:
 	$(MAKE) OS=$* build-image

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 A Prometheus exporter for Windows machines.
 
-
 ## Collectors
 
 Name     | Description | Enabled by default
@@ -81,17 +80,17 @@ This can be useful for having different Prometheus servers collect specific metr
 
 windows_exporter accepts flags to configure certain behaviours. The ones configuring the global behaviour of the exporter are listed below, while collector-specific ones are documented in the respective collector documentation above.
 
-Flag     | Description | Default value
----------|-------------|--------------------
-`--web.listen-address` | host:port for exporter. | `:9182`
-`--telemetry.path` | URL path for surfacing collected metrics. | `/metrics`
-`--telemetry.max-requests` | Maximum number of concurrent requests. 0 to disable. | `5`
-`--collectors.enabled` | Comma-separated list of collectors to use. Use `[defaults]` as a placeholder which gets expanded containing all the collectors enabled by default." | `[defaults]`
-`--collectors.print` | If true, print available collectors and exit. |
-`--scrape.timeout-margin` | Seconds to subtract from the timeout allowed by the client. Tune to allow for overhead or high loads. | `0.5`
-`--web.config.file` | A [web config][web_config] for setting up TLS and Auth | None
-`--config.file` | [Using a config file](#using-a-configuration-file) from path or URL | None
-`--config.file.insecure-skip-verify` | Skip TLS when loading config file from URL | false
+| Flag                                 | Description                                                                                                                                         | Default value |
+|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `--web.listen-address`               | host:port for exporter.                                                                                                                             | `:9182`       |
+| `--telemetry.path`                   | URL path for surfacing collected metrics.                                                                                                           | `/metrics`    |
+| `--telemetry.max-requests`           | Maximum number of concurrent requests. 0 to disable.                                                                                                | `5`           |
+| `--collectors.enabled`               | Comma-separated list of collectors to use. Use `[defaults]` as a placeholder which gets expanded containing all the collectors enabled by default." | `[defaults]`  |
+| `--collectors.print`                 | If true, print available collectors and exit.                                                                                                       |               |
+| `--scrape.timeout-margin`            | Seconds to subtract from the timeout allowed by the client. Tune to allow for overhead or high loads.                                               | `0.5`         |
+| `--web.config.file`                  | A [web config][web_config] for setting up TLS and Auth                                                                                              | None          |
+| `--config.file`                      | [Using a config file](#using-a-configuration-file) from path or URL                                                                                 | None          |
+| `--config.file.insecure-skip-verify` | Skip TLS when loading config file from URL                                                                                                          | false         |
 
 ## Installation
 The latest release can be downloaded from the [releases page](https://github.com/prometheus-community/windows_exporter/releases).
@@ -100,15 +99,15 @@ Each release provides a .msi installer. The installer will setup the windows_exp
 
 If the installer is run without any parameters, the exporter will run with default settings for enabled collectors, ports, etc. The following parameters are available:
 
-Name | Description
------|------------
-`ENABLED_COLLECTORS` | As the `--collectors.enabled` flag, provide a comma-separated list of enabled collectors
-`LISTEN_ADDR` | The IP address to bind to. Defaults to 0.0.0.0
-`LISTEN_PORT` | The port to bind to. Defaults to 9182.
-`METRICS_PATH` | The path at which to serve metrics. Defaults to `/metrics`
-`TEXTFILE_DIRS` | As the `--collector.textfile.directories` flag, provide a directory to read text files with metrics from
-`REMOTE_ADDR` | Allows setting comma separated remote IP addresses for the Windows Firewall exception (allow list). Defaults to an empty string (any remote address).
-`EXTRA_FLAGS` | Allows passing full CLI flags. Defaults to an empty string.
+| Name                 | Description                                                                                                                                           |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ENABLED_COLLECTORS` | As the `--collectors.enabled` flag, provide a comma-separated list of enabled collectors                                                              |
+| `LISTEN_ADDR`        | The IP address to bind to. Defaults to 0.0.0.0                                                                                                        |
+| `LISTEN_PORT`        | The port to bind to. Defaults to 9182.                                                                                                                |
+| `METRICS_PATH`       | The path at which to serve metrics. Defaults to `/metrics`                                                                                            |
+| `TEXTFILE_DIRS`      | As the `--collector.textfile.directories` flag, provide a directory to read text files with metrics from                                              |
+| `REMOTE_ADDR`        | Allows setting comma separated remote IP addresses for the Windows Firewall exception (allow list). Defaults to an empty string (any remote address). |
+| `EXTRA_FLAGS`        | Allows passing full CLI flags. Defaults to an empty string.                                                                                           |
 
 Parameters are sent to the installer via `msiexec`. Example invocations:
 
@@ -140,6 +139,15 @@ Powershell versions 7.3 and above require [PSNativeCommandArgumentPassing](https
 $PSNativeCommandArgumentPassing = 'Legacy'
 msiexec /i <path-to-msi-file> ENABLED_COLLECTORS=os,service --% EXTRA_FLAGS="--collector.service.services-where ""Name LIKE 'sql%'"""
 ```
+
+## Docker Implementation
+
+The windows_exporter can be run as a Docker container. The Docker image is available on 
+
+* [Docker Hub](https://hub.docker.com/r/prometheuscommunity/windows-exporter): `ghcr.io/prometheus-community/windows-exporter`
+* [GitHub Container Registry](https://github.com/prometheus-community/windows_exporter/pkgs/container/windows-exporter): `docker.io/prometheuscommunity/windows-exporter`
+* [quay.io Registry](https://quay.io/repository/prometheuscommunity/windows-exporter): `quay.io/prometheuscommunity/windows-exporter`
+
 
 ## Kubernetes Implementation
 


### PR DESCRIPTION
Fixes #1476 

This PR introduce the image push to dockerhub and quay.io. 

~~There is a new image flavor (hostprocess image) which is designed for hostprocesses. It works on any OS.~~ - It's only possible to build that image with buildkit which is not available under Windows

Additionally, the release pipelines now includes pushes from master branch. The release process will now continuously tested and we are able to gain faster feedback from the community.

I'm expected some push error after merge, since I'm not a makefile pro.