### PR TITLE
Remove unused `*prometheus.Desc` return value from collectors `collect()` function

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,14 +1,12 @@
 linters:
   disable-all: true
   enable:
-  - deadcode
   - errcheck
   - revive
   - govet
   - gofmt
   - ineffassign
   - unconvert
-  - varcheck
   - nilnil
   - nilerr
   - unparam

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,10 @@ linters:
   - ineffassign
   - unconvert
   - varcheck
+  - nilnil
+  - nilerr
+  - unparam
+  - loggercheck
 
 issues:
   exclude:

--- a/exporter.go
+++ b/exporter.go
@@ -184,7 +184,7 @@ func main() {
 		w.Header().Set("Content-Type", "application/json")
 		_, err := fmt.Fprintln(w, `{"status":"ok"}`)
 		if err != nil {
-			_ = level.Debug(logger).Log("Failed to write to stream", "err", err)
+			_ = level.Debug(logger).Log("msg", "Failed to write to stream", "err", err)
 		}
 	})
 	mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/collector/ad/ad.go
+++ b/pkg/collector/ad/ad.go
@@ -490,8 +490,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting ad metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting ad metrics", "err", err)
 		return err
 	}
 	return nil
@@ -649,14 +649,14 @@ type Win32_PerfRawData_DirectoryServices_DirectoryServices struct {
 	TransitivesuboperationsPersec                                    uint32
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_DirectoryServices_DirectoryServices
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) == 0 {
-		return nil, errors.New("WMI query returned empty result set")
+		return errors.New("WMI query returned empty result set")
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -1350,5 +1350,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		float64(dst[0].TombstonesVisitedPersec),
 	)
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/adcs/adcs.go
+++ b/pkg/collector/adcs/adcs.go
@@ -145,8 +145,8 @@ func (c *collector) Build() error {
 }
 
 func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collectADCSCounters(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting ADCS metrics", "desc", desc, "err", err)
+	if err := c.collectADCSCounters(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting ADCS metrics", "err", err)
 		return err
 	}
 	return nil
@@ -169,17 +169,17 @@ type perflibADCS struct {
 	SignedCertificateTimestampListProcessingTime float64 `perflib:"Signed Certificate Timestamp List processing time (ms)"`
 }
 
-func (c *collector) collectADCSCounters(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectADCSCounters(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	dst := make([]perflibADCS, 0)
 	if _, ok := ctx.PerfObjects["Certification Authority"]; !ok {
-		return nil, errors.New("perflib did not contain an entry for Certification Authority")
+		return errors.New("perflib did not contain an entry for Certification Authority")
 	}
 	err := perflib.UnmarshalObject(ctx.PerfObjects["Certification Authority"], &dst, c.logger)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) == 0 {
-		return nil, errors.New("perflib query for Certification Authority (ADCS) returned empty result set")
+		return errors.New("perflib query for Certification Authority (ADCS) returned empty result set")
 	}
 
 	for _, d := range dst {
@@ -267,5 +267,5 @@ func (c *collector) collectADCSCounters(ctx *types.ScrapeContext, ch chan<- prom
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/cache/cache.go
+++ b/pkg/collector/cache/cache.go
@@ -254,8 +254,8 @@ func (c *collector) Build() error {
 
 // Collect implements the Collector interface
 func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting cache metrics", "desc", desc, "err", err)
+	if err := c.collect(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting cache metrics", "err", err)
 		return err
 	}
 	return nil
@@ -295,10 +295,10 @@ type perflibCache struct {
 	SyncPinReadsTotal           float64 `perflib:"Sync Pin Reads/sec"`
 }
 
-func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var dst []perflibCache // Single-instance class, array is required but will have single entry.
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["Cache"], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -475,5 +475,5 @@ func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metri
 		dst[0].SyncPinReadsTotal,
 	)
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/cs/cs.go
+++ b/pkg/collector/cs/cs.go
@@ -77,21 +77,21 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting cs metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting cs metrics", "err", err)
 		return err
 	}
 	return nil
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	// Get systeminfo for number of processors
 	systemInfo := sysinfoapi.GetSystemInfo()
 
 	// Get memory status for physical memory
 	mem, err := sysinfoapi.GlobalMemoryStatusEx()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -108,15 +108,15 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 
 	hostname, err := sysinfoapi.GetComputerName(sysinfoapi.ComputerNameDNSHostname)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	domain, err := sysinfoapi.GetComputerName(sysinfoapi.ComputerNameDNSDomain)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	fqdn, err := sysinfoapi.GetComputerName(sysinfoapi.ComputerNameDNSFullyQualified)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -128,5 +128,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		fqdn,
 	)
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/diskdrive/diskdrive.go
+++ b/pkg/collector/diskdrive/diskdrive.go
@@ -150,21 +150,21 @@ var (
 
 // Collect sends the metric values for each metric to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting disk_drive_info metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting disk_drive_info metrics", "err", err)
 		return err
 	}
 	return nil
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_DiskDrive
 
 	if err := wmi.Query(win32DiskQuery, &dst); err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) == 0 {
-		return nil, errors.New("WMI query returned empty result set")
+		return errors.New("WMI query returned empty result set")
 	}
 
 	for _, disk := range dst {
@@ -222,5 +222,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		}
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/fsrmquota/fsrmquota.go
+++ b/pkg/collector/fsrmquota/fsrmquota.go
@@ -118,8 +118,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting fsrmquota metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting fsrmquota metrics", "err", err)
 		return err
 	}
 	return nil
@@ -142,14 +142,14 @@ type MSFT_FSRMQuota struct {
 	SoftLimit       bool
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []MSFT_FSRMQuota
 	q := wmi.QueryAll(&dst, c.logger)
 
 	var count int
 
 	if err := wmi.QueryNamespace(q, &dst, "root/microsoft/windows/fsrm"); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, quota := range dst {
@@ -214,5 +214,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		prometheus.GaugeValue,
 		float64(count),
 	)
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/hyperv/hyperv.go
+++ b/pkg/collector/hyperv/hyperv.go
@@ -743,63 +743,63 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collectVmHealth(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV health status metrics", "desc", desc, "err", err)
+	if err := c.collectVmHealth(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV health status metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectVmVid(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV pages metrics", "desc", desc, "err", err)
+	if err := c.collectVmVid(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV pages metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectVmHv(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV hv status metrics", "desc", desc, "err", err)
+	if err := c.collectVmHv(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV hv status metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectVmProcessor(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV processor metrics", "desc", desc, "err", err)
+	if err := c.collectVmProcessor(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV processor metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectHostLPUsage(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV host logical processors metrics", "desc", desc, "err", err)
+	if err := c.collectHostLPUsage(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV host logical processors metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectHostCpuUsage(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV host CPU metrics", "desc", desc, "err", err)
+	if err := c.collectHostCpuUsage(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV host CPU metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectVmCpuUsage(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV VM CPU metrics", "desc", desc, "err", err)
+	if err := c.collectVmCpuUsage(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV VM CPU metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectVmSwitch(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV switch metrics", "desc", desc, "err", err)
+	if err := c.collectVmSwitch(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV switch metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectVmEthernet(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV ethernet metrics", "desc", desc, "err", err)
+	if err := c.collectVmEthernet(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV ethernet metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectVmStorage(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV virtual storage metrics", "desc", desc, "err", err)
+	if err := c.collectVmStorage(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV virtual storage metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectVmNetwork(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV virtual network metrics", "desc", desc, "err", err)
+	if err := c.collectVmNetwork(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV virtual network metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectVmMemory(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV virtual memory metrics", "desc", desc, "err", err)
+	if err := c.collectVmMemory(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting hyperV virtual memory metrics", "err", err)
 		return err
 	}
 
@@ -812,11 +812,11 @@ type Win32_PerfRawData_VmmsVirtualMachineStats_HyperVVirtualMachineHealthSummary
 	HealthOk       uint32
 }
 
-func (c *collector) collectVmHealth(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectVmHealth(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_VmmsVirtualMachineStats_HyperVVirtualMachineHealthSummary
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, health := range dst {
@@ -834,7 +834,7 @@ func (c *collector) collectVmHealth(ch chan<- prometheus.Metric) (*prometheus.De
 
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_VidPerfProvider_HyperVVMVidPartition ..,
@@ -845,11 +845,11 @@ type Win32_PerfRawData_VidPerfProvider_HyperVVMVidPartition struct {
 	RemotePhysicalPages    uint64
 }
 
-func (c *collector) collectVmVid(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectVmVid(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_VidPerfProvider_HyperVVMVidPartition
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, page := range dst {
@@ -880,7 +880,7 @@ func (c *collector) collectVmVid(ch chan<- prometheus.Metric) (*prometheus.Desc,
 
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_HvStats_HyperVHypervisorRootPartition ...
@@ -909,11 +909,11 @@ type Win32_PerfRawData_HvStats_HyperVHypervisorRootPartition struct {
 	VirtualTLBPages               uint64
 }
 
-func (c *collector) collectVmHv(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectVmHv(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_HvStats_HyperVHypervisorRootPartition
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, obj := range dst {
@@ -1038,7 +1038,7 @@ func (c *collector) collectVmHv(ch chan<- prometheus.Metric) (*prometheus.Desc, 
 
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_HvStats_HyperVHypervisor ...
@@ -1047,11 +1047,11 @@ type Win32_PerfRawData_HvStats_HyperVHypervisor struct {
 	VirtualProcessors uint64
 }
 
-func (c *collector) collectVmProcessor(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectVmProcessor(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_HvStats_HyperVHypervisor
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, obj := range dst {
@@ -1070,7 +1070,7 @@ func (c *collector) collectVmProcessor(ch chan<- prometheus.Metric) (*prometheus
 
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_HvStats_HyperVHypervisorLogicalProcessor ...
@@ -1081,11 +1081,11 @@ type Win32_PerfRawData_HvStats_HyperVHypervisorLogicalProcessor struct {
 	PercentTotalRunTime      uint
 }
 
-func (c *collector) collectHostLPUsage(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectHostLPUsage(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_HvStats_HyperVHypervisorLogicalProcessor
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, obj := range dst {
@@ -1123,7 +1123,7 @@ func (c *collector) collectHostLPUsage(ch chan<- prometheus.Metric) (*prometheus
 
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_HvStats_HyperVHypervisorRootVirtualProcessor ...
@@ -1136,11 +1136,11 @@ type Win32_PerfRawData_HvStats_HyperVHypervisorRootVirtualProcessor struct {
 	CPUWaitTimePerDispatch   uint64
 }
 
-func (c *collector) collectHostCpuUsage(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectHostCpuUsage(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_HvStats_HyperVHypervisorRootVirtualProcessor
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, obj := range dst {
@@ -1191,7 +1191,7 @@ func (c *collector) collectHostCpuUsage(ch chan<- prometheus.Metric) (*prometheu
 		)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_HvStats_HyperVHypervisorVirtualProcessor ...
@@ -1204,11 +1204,11 @@ type Win32_PerfRawData_HvStats_HyperVHypervisorVirtualProcessor struct {
 	CPUWaitTimePerDispatch   uint64
 }
 
-func (c *collector) collectVmCpuUsage(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectVmCpuUsage(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_HvStats_HyperVHypervisorVirtualProcessor
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, obj := range dst {
@@ -1266,7 +1266,7 @@ func (c *collector) collectVmCpuUsage(ch chan<- prometheus.Metric) (*prometheus.
 
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_NvspSwitchStats_HyperVVirtualSwitch ...
@@ -1298,11 +1298,11 @@ type Win32_PerfRawData_NvspSwitchStats_HyperVVirtualSwitch struct {
 	PurgedMacAddressesPersec               uint64
 }
 
-func (c *collector) collectVmSwitch(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectVmSwitch(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_NvspSwitchStats_HyperVVirtualSwitch
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, obj := range dst {
@@ -1449,7 +1449,7 @@ func (c *collector) collectVmSwitch(ch chan<- prometheus.Metric) (*prometheus.De
 		)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_EthernetPerfProvider_HyperVLegacyNetworkAdapter ...
@@ -1463,11 +1463,11 @@ type Win32_PerfRawData_EthernetPerfProvider_HyperVLegacyNetworkAdapter struct {
 	FramesSentPersec     uint64
 }
 
-func (c *collector) collectVmEthernet(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectVmEthernet(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_EthernetPerfProvider_HyperVLegacyNetworkAdapter
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, obj := range dst {
@@ -1519,7 +1519,7 @@ func (c *collector) collectVmEthernet(ch chan<- prometheus.Metric) (*prometheus.
 
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_Counters_HyperVVirtualStorageDevice ...
@@ -1533,11 +1533,11 @@ type Win32_PerfRawData_Counters_HyperVVirtualStorageDevice struct {
 	WriteOperationsPerSec uint64
 }
 
-func (c *collector) collectVmStorage(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectVmStorage(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_Counters_HyperVVirtualStorageDevice
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, obj := range dst {
@@ -1588,7 +1588,7 @@ func (c *collector) collectVmStorage(ch chan<- prometheus.Metric) (*prometheus.D
 		)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_NvspNicStats_HyperVVirtualNetworkAdapter ...
@@ -1602,11 +1602,11 @@ type Win32_PerfRawData_NvspNicStats_HyperVVirtualNetworkAdapter struct {
 	PacketsSentPersec            uint64
 }
 
-func (c *collector) collectVmNetwork(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectVmNetwork(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_NvspNicStats_HyperVVirtualNetworkAdapter
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, obj := range dst {
@@ -1657,7 +1657,7 @@ func (c *collector) collectVmNetwork(ch chan<- prometheus.Metric) (*prometheus.D
 		)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_BalancerStats_HyperVDynamicMemoryVM ...
@@ -1675,11 +1675,11 @@ type Win32_PerfRawData_BalancerStats_HyperVDynamicMemoryVM struct {
 	RemovedMemory              uint64
 }
 
-func (c *collector) collectVmMemory(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectVmMemory(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_BalancerStats_HyperVDynamicMemoryVM
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, obj := range dst {
@@ -1758,5 +1758,5 @@ func (c *collector) collectVmMemory(ch chan<- prometheus.Metric) (*prometheus.De
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/iis/iis.go
+++ b/pkg/collector/iis/iis.go
@@ -926,23 +926,23 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collectWebService(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting iis metrics", "desc", desc, "err", err)
+	if err := c.collectWebService(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting iis metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectAPP_POOL_WAS(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting iis metrics", "desc", desc, "err", err)
+	if err := c.collectAPP_POOL_WAS(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting iis metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectW3SVC_W3WP(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting iis metrics", "desc", desc, "err", err)
+	if err := c.collectW3SVC_W3WP(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting iis metrics", "err", err)
 		return err
 	}
 
-	if desc, err := c.collectWebServiceCache(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", "failed collecting iis metrics", "desc", desc, "err", err)
+	if err := c.collectWebServiceCache(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting iis metrics", "err", err)
 		return err
 	}
 
@@ -1039,10 +1039,10 @@ func dedupIISNames[V hasGetIISName](services []V) map[string]V {
 	return webServiceDeDuplicated
 }
 
-func (c *collector) collectWebService(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectWebService(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var webService []perflibWebService
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["Web Service"], &webService, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -1298,7 +1298,7 @@ func (c *collector) collectWebService(ctx *types.ScrapeContext, ch chan<- promet
 		)
 	}
 
-	return nil, nil
+	return nil
 }
 
 type perflibAPP_POOL_WAS struct {
@@ -1331,10 +1331,10 @@ var applicationStates = map[uint32]string{
 	7: "Delete Pending",
 }
 
-func (c *collector) collectAPP_POOL_WAS(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectAPP_POOL_WAS(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var APP_POOL_WAS []perflibAPP_POOL_WAS
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["APP_POOL_WAS"], &APP_POOL_WAS, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	appPoolDeDuplicated := dedupIISNames(APP_POOL_WAS)
@@ -1434,7 +1434,7 @@ func (c *collector) collectAPP_POOL_WAS(ctx *types.ScrapeContext, ch chan<- prom
 		)
 	}
 
-	return nil, nil
+	return nil
 }
 
 var workerProcessNameExtractor = regexp.MustCompile(`^(\d+)_(.+)$`)
@@ -1508,10 +1508,10 @@ type perflibW3SVC_W3WP_IIS8 struct {
 	WebSocketConnectionsRejected float64 `perflib:"WebSocket Connections Rejected / Sec"`
 }
 
-func (c *collector) collectW3SVC_W3WP(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectW3SVC_W3WP(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var W3SVC_W3WP []perflibW3SVC_W3WP
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["W3SVC_W3WP"], &W3SVC_W3WP, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	w3svcW3WPDeduplicated := dedupIISNames(W3SVC_W3WP)
@@ -1770,7 +1770,7 @@ func (c *collector) collectW3SVC_W3WP(ctx *types.ScrapeContext, ch chan<- promet
 	if c.iis_version.major >= 8 {
 		var W3SVC_W3WP_IIS8 []perflibW3SVC_W3WP_IIS8
 		if err := perflib.UnmarshalObject(ctx.PerfObjects["W3SVC_W3WP"], &W3SVC_W3WP_IIS8, c.logger); err != nil {
-			return nil, err
+			return err
 		}
 
 		w3svcW3WPIIS8Deduplicated := dedupIISNames(W3SVC_W3WP_IIS8)
@@ -1856,7 +1856,7 @@ func (c *collector) collectW3SVC_W3WP(ctx *types.ScrapeContext, ch chan<- promet
 		}
 	}
 
-	return nil, nil
+	return nil
 }
 
 type perflibWebServiceCache struct {
@@ -1906,10 +1906,10 @@ type perflibWebServiceCache struct {
 	ServiceCache_OutputCacheQueriesTotal       float64
 }
 
-func (c *collector) collectWebServiceCache(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectWebServiceCache(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var WebServiceCache []perflibWebServiceCache
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["Web Service Cache"], &WebServiceCache, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, app := range WebServiceCache {
@@ -2097,5 +2097,5 @@ func (c *collector) collectWebServiceCache(ctx *types.ScrapeContext, ch chan<- p
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/logon/logon.go
+++ b/pkg/collector/logon/logon.go
@@ -62,8 +62,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting user metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting user metrics", "err", err)
 		return err
 	}
 	return nil
@@ -75,14 +75,14 @@ type Win32_LogonSession struct {
 	LogonType uint32
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_LogonSession
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) == 0 {
-		return nil, errors.New("WMI query returned empty result set")
+		return errors.New("WMI query returned empty result set")
 	}
 
 	// Init counters
@@ -221,5 +221,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		float64(cachedunlock),
 		"cached_unlock",
 	)
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/memory/memory.go
+++ b/pkg/collector/memory/memory.go
@@ -291,8 +291,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting memory metrics", "desc", desc, "err", err)
+	if err := c.collect(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting memory metrics", "err", err)
 		return err
 	}
 	return nil
@@ -335,10 +335,10 @@ type memory struct {
 	WriteCopiesPersec               float64 `perflib:"Write Copies/sec"`
 }
 
-func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var dst []memory
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["Memory"], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -533,5 +533,5 @@ func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metri
 		dst[0].WriteCopiesPersec,
 	)
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/msmq/msmq.go
+++ b/pkg/collector/msmq/msmq.go
@@ -106,8 +106,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting msmq metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting msmq metrics", "err", err)
 		return err
 	}
 	return nil
@@ -122,11 +122,11 @@ type Win32_PerfRawData_MSMQ_MSMQQueue struct {
 	MessagesinQueue        uint64
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_MSMQ_MSMQQueue
 	q := wmi.QueryAllWhere(&dst, *c.queryWhereClause, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, msmq := range dst {
@@ -158,5 +158,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 			strings.ToLower(msmq.Name),
 		)
 	}
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/mssql/mssql.go
+++ b/pkg/collector/mssql/mssql.go
@@ -1932,7 +1932,7 @@ func (c *collector) Build() error {
 	return nil
 }
 
-type mssqlCollectorFunc func(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error)
+type mssqlCollectorFunc func(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error
 
 func (c *collector) execute(ctx *types.ScrapeContext, name string, fn mssqlCollectorFunc, ch chan<- prometheus.Metric, sqlInstance string, wg *sync.WaitGroup) {
 	// Reset failure counter on each scrape
@@ -1940,7 +1940,7 @@ func (c *collector) execute(ctx *types.ScrapeContext, name string, fn mssqlColle
 	defer wg.Done()
 
 	begin := time.Now()
-	_, err := fn(ctx, ch, sqlInstance)
+	err := fn(ctx, ch, sqlInstance)
 	duration := time.Since(begin)
 	var success float64
 
@@ -2038,12 +2038,12 @@ type mssqlAccessMethods struct {
 	WorktablesFromCacheRatio_Base float64 `perflib:"Worktables From Cache Base_Base"`
 }
 
-func (c *collector) collectAccessMethods(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
+func (c *collector) collectAccessMethods(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error {
 	var dst []mssqlAccessMethods
 	_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("mssql_accessmethods collector iterating sql instance %s.", sqlInstance))
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects[mssqlGetPerfObjectName(sqlInstance, "accessmethods")], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, v := range dst {
@@ -2355,7 +2355,7 @@ func (c *collector) collectAccessMethods(ctx *types.ScrapeContext, ch chan<- pro
 			sqlInstance,
 		)
 	}
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_MSSQLSERVER_SQLServerAvailabilityReplica docs:
@@ -2373,12 +2373,12 @@ type mssqlAvailabilityReplica struct {
 	SendstoTransportPersec         float64 `perflib:"Sends to Transport/sec"`
 }
 
-func (c *collector) collectAvailabilityReplica(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
+func (c *collector) collectAvailabilityReplica(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error {
 	var dst []mssqlAvailabilityReplica
 	_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("mssql_availreplica collector iterating sql instance %s.", sqlInstance))
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects[mssqlGetPerfObjectName(sqlInstance, "availreplica")], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, v := range dst {
@@ -2450,7 +2450,7 @@ func (c *collector) collectAvailabilityReplica(ctx *types.ScrapeContext, ch chan
 			sqlInstance, replicaName,
 		)
 	}
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_MSSQLSERVER_SQLServerBufferManager docs:
@@ -2481,12 +2481,12 @@ type mssqlBufferManager struct {
 	Targetpages                   float64 `perflib:"Target pages"`
 }
 
-func (c *collector) collectBufferManager(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
+func (c *collector) collectBufferManager(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error {
 	var dst []mssqlBufferManager
 	_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("mssql_bufman collector iterating sql instance %s.", sqlInstance))
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects[mssqlGetPerfObjectName(sqlInstance, "bufman")], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, v := range dst {
@@ -2652,7 +2652,7 @@ func (c *collector) collectBufferManager(ctx *types.ScrapeContext, ch chan<- pro
 		)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_MSSQLSERVER_SQLServerDatabaseReplica docs:
@@ -2685,12 +2685,12 @@ type mssqlDatabaseReplica struct {
 	TransactionDelay                float64 `perflib:"Transaction Delay"`
 }
 
-func (c *collector) collectDatabaseReplica(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
+func (c *collector) collectDatabaseReplica(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error {
 	var dst []mssqlDatabaseReplica
 	_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("mssql_dbreplica collector iterating sql instance %s.", sqlInstance))
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects[mssqlGetPerfObjectName(sqlInstance, "dbreplica")], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, v := range dst {
@@ -2867,7 +2867,7 @@ func (c *collector) collectDatabaseReplica(ctx *types.ScrapeContext, ch chan<- p
 			sqlInstance, replicaName,
 		)
 	}
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_MSSQLSERVER_SQLServerDatabases docs:
@@ -2924,12 +2924,12 @@ type mssqlDatabases struct {
 	XTPMemoryUsedKB                  float64 `perflib:"XTP Memory Used (KB)"`
 }
 
-func (c *collector) collectDatabases(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
+func (c *collector) collectDatabases(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error {
 	var dst []mssqlDatabases
 	_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("mssql_databases collector iterating sql instance %s.", sqlInstance))
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects[mssqlGetPerfObjectName(sqlInstance, "databases")], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, v := range dst {
@@ -3274,7 +3274,7 @@ func (c *collector) collectDatabases(ctx *types.ScrapeContext, ch chan<- prometh
 			sqlInstance, dbName,
 		)
 	}
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_MSSQLSERVER_SQLServerGeneralStatistics docs:
@@ -3306,12 +3306,12 @@ type mssqlGeneralStatistics struct {
 	UserConnections               float64 `perflib:"User Connections"`
 }
 
-func (c *collector) collectGeneralStatistics(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
+func (c *collector) collectGeneralStatistics(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error {
 	var dst []mssqlGeneralStatistics
 	_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("mssql_genstats collector iterating sql instance %s.", sqlInstance))
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects[mssqlGetPerfObjectName(sqlInstance, "genstats")], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, v := range dst {
@@ -3484,7 +3484,7 @@ func (c *collector) collectGeneralStatistics(ctx *types.ScrapeContext, ch chan<-
 		)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_MSSQLSERVER_SQLServerLocks docs:
@@ -3501,12 +3501,12 @@ type mssqlLocks struct {
 	NumberofDeadlocksPersec    float64 `perflib:"Number of Deadlocks/sec"`
 }
 
-func (c *collector) collectLocks(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
+func (c *collector) collectLocks(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error {
 	var dst []mssqlLocks
 	_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("mssql_locks collector iterating sql instance %s.", sqlInstance))
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects[mssqlGetPerfObjectName(sqlInstance, "locks")], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, v := range dst {
@@ -3571,7 +3571,7 @@ func (c *collector) collectLocks(ctx *types.ScrapeContext, ch chan<- prometheus.
 			sqlInstance, lockResourceName,
 		)
 	}
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_MSSQLSERVER_SQLServerMemoryManager docs:
@@ -3599,12 +3599,12 @@ type mssqlMemoryManager struct {
 	TotalServerMemoryKB      float64 `perflib:"Total Server Memory (KB)"`
 }
 
-func (c *collector) collectMemoryManager(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
+func (c *collector) collectMemoryManager(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error {
 	var dst []mssqlMemoryManager
 	_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("mssql_memmgr collector iterating sql instance %s.", sqlInstance))
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects[mssqlGetPerfObjectName(sqlInstance, "memmgr")], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, v := range dst {
@@ -3749,7 +3749,7 @@ func (c *collector) collectMemoryManager(ctx *types.ScrapeContext, ch chan<- pro
 		)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_MSSQLSERVER_SQLServerSQLStatistics docs:
@@ -3768,12 +3768,12 @@ type mssqlSQLStatistics struct {
 	UnsafeAutoParamsPersec        float64 `perflib:"Unsafe Auto-Params/sec"`
 }
 
-func (c *collector) collectSQLStats(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
+func (c *collector) collectSQLStats(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error {
 	var dst []mssqlSQLStatistics
 	_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("mssql_sqlstats collector iterating sql instance %s.", sqlInstance))
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects[mssqlGetPerfObjectName(sqlInstance, "sqlstats")], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, v := range dst {
@@ -3855,7 +3855,7 @@ func (c *collector) collectSQLStats(ctx *types.ScrapeContext, ch chan<- promethe
 		)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Win32_PerfRawData_MSSQLSERVER_SQLServerWaitStatistics docs:
@@ -3876,12 +3876,12 @@ type mssqlWaitStatistics struct {
 	WaitStatsTransactionOwnershipWaits     float64 `perflib:"Transaction ownership waits"`
 }
 
-func (c *collector) collectWaitStats(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
+func (c *collector) collectWaitStats(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error {
 	var dst []mssqlWaitStatistics
 	_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("mssql_waitstats collector iterating sql instance %s.", sqlInstance))
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects[mssqlGetPerfObjectName(sqlInstance, "waitstats")], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, v := range dst {
@@ -3972,7 +3972,7 @@ func (c *collector) collectWaitStats(ctx *types.ScrapeContext, ch chan<- prometh
 		)
 	}
 
-	return nil, nil
+	return nil
 }
 
 type mssqlSQLErrors struct {
@@ -3982,12 +3982,12 @@ type mssqlSQLErrors struct {
 
 // Win32_PerfRawData_MSSQLSERVER_SQLServerErrors docs:
 // - https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-sql-errors-object
-func (c *collector) collectSQLErrors(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
+func (c *collector) collectSQLErrors(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error {
 	var dst []mssqlSQLErrors
 	_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("mssql_sqlerrors collector iterating sql instance %s.", sqlInstance))
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects[mssqlGetPerfObjectName(sqlInstance, "sqlerrors")], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, v := range dst {
@@ -4004,7 +4004,7 @@ func (c *collector) collectSQLErrors(ctx *types.ScrapeContext, ch chan<- prometh
 		)
 	}
 
-	return nil, nil
+	return nil
 }
 
 type mssqlTransactions struct {
@@ -4025,12 +4025,12 @@ type mssqlTransactions struct {
 
 // Win32_PerfRawData_MSSQLSERVER_Transactions docs:
 // - https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-transactions-object
-func (c *collector) collectTransactions(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
+func (c *collector) collectTransactions(ctx *types.ScrapeContext, ch chan<- prometheus.Metric, sqlInstance string) error {
 	var dst []mssqlTransactions
 	_ = level.Debug(c.logger).Log("msg", fmt.Sprintf("mssql_transactions collector iterating sql instance %s.", sqlInstance))
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects[mssqlGetPerfObjectName(sqlInstance, "transactions")], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, v := range dst {
@@ -4126,5 +4126,5 @@ func (c *collector) collectTransactions(ctx *types.ScrapeContext, ch chan<- prom
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/net/net.go
+++ b/pkg/collector/net/net.go
@@ -196,8 +196,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting net metrics", "desc", desc, "err", err)
+	if err := c.collect(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting net metrics", "err", err)
 		return err
 	}
 	return nil
@@ -228,11 +228,11 @@ type networkInterface struct {
 	CurrentBandwidth         float64 `perflib:"Current Bandwidth"`
 }
 
-func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var dst []networkInterface
 
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["Network Interface"], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, nic := range dst {
@@ -326,5 +326,5 @@ func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metri
 			name,
 		)
 	}
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/netframework_clrexceptions/netframework_clrexceptions.go
+++ b/pkg/collector/netframework_clrexceptions/netframework_clrexceptions.go
@@ -81,8 +81,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting win32_perfrawdata_netframework_netclrexceptions metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting win32_perfrawdata_netframework_netclrexceptions metrics", "err", err)
 		return err
 	}
 	return nil
@@ -98,11 +98,11 @@ type Win32_PerfRawData_NETFramework_NETCLRExceptions struct {
 	ThrowToCatchDepthPersec    uint32
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRExceptions
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, process := range dst {
@@ -140,5 +140,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/netframework_clrinterop/netframework_clrinterop.go
+++ b/pkg/collector/netframework_clrinterop/netframework_clrinterop.go
@@ -74,8 +74,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting win32_perfrawdata_netframework_netclrinterop metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting win32_perfrawdata_netframework_netclrinterop metrics", "err", err)
 		return err
 	}
 	return nil
@@ -91,11 +91,11 @@ type Win32_PerfRawData_NETFramework_NETCLRInterop struct {
 	NumberofTLBimportsPersec uint32
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRInterop
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, process := range dst {
@@ -126,5 +126,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/netframework_clrjit/netframework_clrjit.go
+++ b/pkg/collector/netframework_clrjit/netframework_clrjit.go
@@ -80,8 +80,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting win32_perfrawdata_netframework_netclrjit metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting win32_perfrawdata_netframework_netclrjit metrics", "err", err)
 		return err
 	}
 	return nil
@@ -99,11 +99,11 @@ type Win32_PerfRawData_NETFramework_NETCLRJit struct {
 	TotalNumberofILBytesJitted uint32
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRJit
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, process := range dst {
@@ -141,5 +141,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/netframework_clrloading/netframework_clrloading.go
+++ b/pkg/collector/netframework_clrloading/netframework_clrloading.go
@@ -115,8 +115,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting win32_perfrawdata_netframework_netclrloading metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting win32_perfrawdata_netframework_netclrloading metrics", "err", err)
 		return err
 	}
 	return nil
@@ -143,11 +143,11 @@ type Win32_PerfRawData_NETFramework_NETCLRLoading struct {
 	TotalNumberofLoadFailures uint32
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRLoading
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, process := range dst {
@@ -220,5 +220,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/netframework_clrlocksandthreads/netframework_clrlocksandthreads.go
+++ b/pkg/collector/netframework_clrlocksandthreads/netframework_clrlocksandthreads.go
@@ -101,8 +101,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting win32_perfrawdata_netframework_netclrlocksandthreads metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting win32_perfrawdata_netframework_netclrlocksandthreads metrics", "err", err)
 		return err
 	}
 	return nil
@@ -123,11 +123,11 @@ type Win32_PerfRawData_NETFramework_NETCLRLocksAndThreads struct {
 	TotalNumberofContentions         uint32
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRLocksAndThreads
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, process := range dst {
@@ -186,5 +186,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/netframework_clrmemory/netframework_clrmemory.go
+++ b/pkg/collector/netframework_clrmemory/netframework_clrmemory.go
@@ -139,8 +139,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting win32_perfrawdata_netframework_netclrmemory metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting win32_perfrawdata_netframework_netclrmemory metrics", "err", err)
 		return err
 	}
 	return nil
@@ -180,11 +180,11 @@ type Win32_PerfRawData_NETFramework_NETCLRMemory struct {
 	PromotedMemoryfromGen1             uint64
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRMemory
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, process := range dst {
@@ -329,5 +329,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/netframework_clrremoting/netframework_clrremoting.go
+++ b/pkg/collector/netframework_clrremoting/netframework_clrremoting.go
@@ -94,8 +94,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting win32_perfrawdata_netframework_netclrremoting metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting win32_perfrawdata_netframework_netclrremoting metrics", "err", err)
 		return err
 	}
 	return nil
@@ -113,11 +113,11 @@ type Win32_PerfRawData_NETFramework_NETCLRRemoting struct {
 	TotalRemoteCalls               uint32
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRRemoting
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, process := range dst {
@@ -169,5 +169,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/netframework_clrsecurity/netframework_clrsecurity.go
+++ b/pkg/collector/netframework_clrsecurity/netframework_clrsecurity.go
@@ -80,8 +80,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting win32_perfrawdata_netframework_netclrsecurity metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting win32_perfrawdata_netframework_netclrsecurity metrics", "err", err)
 		return err
 	}
 	return nil
@@ -98,11 +98,11 @@ type Win32_PerfRawData_NETFramework_NETCLRSecurity struct {
 	TotalRuntimeChecks           uint32
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRSecurity
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, process := range dst {
@@ -140,5 +140,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/nps/nps.go
+++ b/pkg/collector/nps/nps.go
@@ -229,12 +229,12 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.CollectAccept(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", fmt.Sprintf("failed collecting NPS accept data: %s %v", desc, err))
+	if err := c.CollectAccept(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", fmt.Sprintf("failed collecting NPS accept data: %s", err))
 		return err
 	}
-	if desc, err := c.CollectAccounting(ch); err != nil {
-		_ = level.Error(c.logger).Log("msg", fmt.Sprintf("failed collecting NPS accounting data: %s %v", desc, err))
+	if err := c.CollectAccounting(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", fmt.Sprintf("failed collecting NPS accounting data: %s", err))
 		return err
 	}
 	return nil
@@ -279,11 +279,11 @@ type Win32_PerfRawData_IAS_NPSAccountingServer struct {
 
 // CollectAccept sends the metric values for each metric
 // to the provided prometheus Metric channel.
-func (c *collector) CollectAccept(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) CollectAccept(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_IAS_NPSAuthenticationServer
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -364,14 +364,14 @@ func (c *collector) CollectAccept(ch chan<- prometheus.Metric) (*prometheus.Desc
 		float64(dst[0].AccessUnknownType),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) CollectAccounting(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) CollectAccounting(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_IAS_NPSAccountingServer
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -446,5 +446,5 @@ func (c *collector) CollectAccounting(ch chan<- prometheus.Metric) (*prometheus.
 		float64(dst[0].AccountingUnknownType),
 	)
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/physical_disk/physical_disk.go
+++ b/pkg/collector/physical_disk/physical_disk.go
@@ -206,8 +206,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting physical_disk metrics", "desc", desc, "err", err)
+	if err := c.collect(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting physical_disk metrics", "err", err)
 		return err
 	}
 	return nil
@@ -232,10 +232,10 @@ type PhysicalDisk struct {
 	AvgDiskSecPerTransfer  float64 `perflib:"Avg. Disk sec/Transfer"`
 }
 
-func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var dst []PhysicalDisk
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["PhysicalDisk"], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, disk := range dst {
@@ -334,5 +334,5 @@ func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metri
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/process/process.go
+++ b/pkg/collector/process/process.go
@@ -270,7 +270,7 @@ func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metri
 	if *c.enableWorkerProcess {
 		q_wp := wmi.QueryAll(&dst_wp, c.logger)
 		if err := wmi.QueryNamespace(q_wp, &dst_wp, "root\\WebAdministration"); err != nil {
-			_ = level.Debug(c.logger).Log(fmt.Sprintf("Could not query WebAdministration namespace for IIS worker processes: %v. Skipping\n", err))
+			_ = level.Debug(c.logger).Log("msg", "Could not query WebAdministration namespace for IIS worker processes", "err", err)
 		}
 	}
 

--- a/pkg/collector/remote_fx/remote_fx.go
+++ b/pkg/collector/remote_fx/remote_fx.go
@@ -184,12 +184,12 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collectRemoteFXNetworkCount(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting terminal services session count metrics", "desc", desc, "err", err)
+	if err := c.collectRemoteFXNetworkCount(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting terminal services session count metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectRemoteFXGraphicsCounters(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting terminal services session count metrics", "desc", desc, "err", err)
+	if err := c.collectRemoteFXGraphicsCounters(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting terminal services session count metrics", "err", err)
 		return err
 	}
 	return nil
@@ -209,11 +209,11 @@ type perflibRemoteFxNetwork struct {
 	UDPPacketsSentPersec     float64 `perflib:"UDP Packets Sent/sec"`
 }
 
-func (c *collector) collectRemoteFXNetworkCount(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectRemoteFXNetworkCount(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	dst := make([]perflibRemoteFxNetwork, 0)
 	err := perflib.UnmarshalObject(ctx.PerfObjects["RemoteFX Network"], &dst, c.logger)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, d := range dst {
@@ -283,7 +283,7 @@ func (c *collector) collectRemoteFXNetworkCount(ctx *types.ScrapeContext, ch cha
 			d.Name,
 		)
 	}
-	return nil, nil
+	return nil
 }
 
 type perflibRemoteFxGraphics struct {
@@ -299,11 +299,11 @@ type perflibRemoteFxGraphics struct {
 	SourceFramesPerSecond                              float64 `perflib:"Source Frames/Second"`
 }
 
-func (c *collector) collectRemoteFXGraphicsCounters(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectRemoteFXGraphicsCounters(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	dst := make([]perflibRemoteFxGraphics, 0)
 	err := perflib.UnmarshalObject(ctx.PerfObjects["RemoteFX Graphics"], &dst, c.logger)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, d := range dst {
@@ -371,5 +371,5 @@ func (c *collector) collectRemoteFXGraphicsCounters(ctx *types.ScrapeContext, ch
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/scheduled_task/scheduled_task.go
+++ b/pkg/collector/scheduled_task/scheduled_task.go
@@ -164,8 +164,8 @@ func (c *collector) Build() error {
 }
 
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting user metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting user metrics", "err", err)
 		return err
 	}
 
@@ -174,10 +174,10 @@ func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric)
 
 var TASK_STATES = []string{"disabled", "queued", "ready", "running", "unknown"}
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	scheduledTasks, err := getScheduledTasks()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, task := range scheduledTasks {
@@ -222,7 +222,7 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		}
 	}
 
-	return nil, nil
+	return nil
 }
 
 const SCHEDULED_TASK_PROGRAM_ID = "Schedule.Service.1"

--- a/pkg/collector/smtp/smtp.go
+++ b/pkg/collector/smtp/smtp.go
@@ -399,8 +399,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting smtp metrics", "desc", desc, "err", err)
+	if err := c.collect(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting smtp metrics", "err", err)
 		return err
 	}
 	return nil
@@ -454,10 +454,10 @@ type PerflibSMTPServer struct {
 	RoutingTableLookupsTotal                float64 `perflib:"Routing Table Lookups Total"`
 }
 
-func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var dst []PerflibSMTPServer
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["SMTP Server"], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, server := range dst {
@@ -755,5 +755,5 @@ func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metri
 		)
 
 	}
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/system/system.go
+++ b/pkg/collector/system/system.go
@@ -94,8 +94,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting system metrics", "desc", desc, "err", err)
+	if err := c.collect(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting system metrics", "err", err)
 		return err
 	}
 	return nil
@@ -112,10 +112,10 @@ type system struct {
 	Threads                   float64 `perflib:"Threads"`
 }
 
-func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var dst []system
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["System"], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -148,5 +148,5 @@ func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metri
 		prometheus.GaugeValue,
 		dst[0].Threads,
 	)
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/tcp/tcp.go
+++ b/pkg/collector/tcp/tcp.go
@@ -115,8 +115,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting tcp metrics", "desc", desc, "err", err)
+	if err := c.collect(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting tcp metrics", "err", err)
 		return err
 	}
 	return nil
@@ -194,12 +194,12 @@ func writeTCPCounters(metrics tcp, labels []string, c *collector, ch chan<- prom
 	)
 }
 
-func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var dst []tcp
 
 	// TCPv4 counters
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["TCPv4"], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) != 0 {
 		writeTCPCounters(dst[0], []string{"ipv4"}, c, ch)
@@ -207,11 +207,11 @@ func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metri
 
 	// TCPv6 counters
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["TCPv6"], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) != 0 {
 		writeTCPCounters(dst[0], []string{"ipv6"}, c, ch)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/teradici_pcoip/teradici_pcoip.go
+++ b/pkg/collector/teradici_pcoip/teradici_pcoip.go
@@ -326,24 +326,24 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collectAudio(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting teradici session audio metrics", "desc", desc, "err", err)
+	if err := c.collectAudio(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting teradici session audio metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectGeneral(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting teradici session general metrics", "desc", desc, "err", err)
+	if err := c.collectGeneral(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting teradici session general metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectImaging(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting teradici session imaging metrics", "desc", desc, "err", err)
+	if err := c.collectImaging(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting teradici session imaging metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectNetwork(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting teradici session network metrics", "desc", desc, "err", err)
+	if err := c.collectNetwork(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting teradici session network metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectUsb(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting teradici session USB metrics", "desc", desc, "err", err)
+	if err := c.collectUsb(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting teradici session USB metrics", "err", err)
 		return err
 	}
 	return nil
@@ -401,14 +401,14 @@ type win32_PerfRawData_TeradiciPerf_PCoIPSessionUsbStatistics struct {
 	USBTXBWkbitPersec uint64
 }
 
-func (c *collector) collectAudio(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectAudio(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_TeradiciPerf_PCoIPSessionAudioStatistics
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) == 0 {
-		return nil, errors.New("WMI query returned empty result set")
+		return errors.New("WMI query returned empty result set")
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -441,17 +441,17 @@ func (c *collector) collectAudio(ch chan<- prometheus.Metric) (*prometheus.Desc,
 		float64(dst[0].AudioTXBWLimitkbitPersec),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectGeneral(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectGeneral(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_TeradiciPerf_PCoIPSessionGeneralStatistics
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) == 0 {
-		return nil, errors.New("WMI query returned empty result set")
+		return errors.New("WMI query returned empty result set")
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -496,17 +496,17 @@ func (c *collector) collectGeneral(ch chan<- prometheus.Metric) (*prometheus.Des
 		float64(dst[0].TXPacketsLost),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectImaging(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectImaging(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_TeradiciPerf_PCoIPSessionImagingStatistics
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) == 0 {
-		return nil, errors.New("WMI query returned empty result set")
+		return errors.New("WMI query returned empty result set")
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -575,17 +575,17 @@ func (c *collector) collectImaging(ch chan<- prometheus.Metric) (*prometheus.Des
 		float64(dst[0].ImagingTXBWkbitPersec),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectNetwork(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectNetwork(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_TeradiciPerf_PCoIPSessionNetworkStatistics
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) == 0 {
-		return nil, errors.New("WMI query returned empty result set")
+		return errors.New("WMI query returned empty result set")
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -648,17 +648,17 @@ func (c *collector) collectNetwork(ch chan<- prometheus.Metric) (*prometheus.Des
 		float64(dst[0].TXPacketLossPercent_Base),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectUsb(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectUsb(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_TeradiciPerf_PCoIPSessionUsbStatistics
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) == 0 {
-		return nil, errors.New("WMI query returned empty result set")
+		return errors.New("WMI query returned empty result set")
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -685,5 +685,5 @@ func (c *collector) collectUsb(ch chan<- prometheus.Metric) (*prometheus.Desc, e
 		float64(dst[0].USBTXBWkbitPersec),
 	)
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/terminal_services/terminal_services.go
+++ b/pkg/collector/terminal_services/terminal_services.go
@@ -208,19 +208,19 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collectTSSessionCount(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting terminal services session count metrics", "desc", desc, "err", err)
+	if err := c.collectTSSessionCount(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting terminal services session count metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectTSSessionCounters(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting terminal services session count metrics", "desc", desc, "err", err)
+	if err := c.collectTSSessionCounters(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting terminal services session count metrics", "err", err)
 		return err
 	}
 
 	// only collect CollectionBrokerPerformance if host is a Connection Broker
 	if c.connectionBrokerEnabled {
-		if desc, err := c.collectCollectionBrokerPerformanceCounter(ctx, ch); err != nil {
-			_ = level.Error(c.logger).Log("failed collecting Connection Broker performance metrics", "desc", desc, "err", err)
+		if err := c.collectCollectionBrokerPerformanceCounter(ctx, ch); err != nil {
+			_ = level.Error(c.logger).Log("msg", "failed collecting Connection Broker performance metrics", "err", err)
 			return err
 		}
 	}
@@ -233,14 +233,14 @@ type perflibTerminalServices struct {
 	TotalSessions    float64 `perflib:"Total Sessions"`
 }
 
-func (c *collector) collectTSSessionCount(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectTSSessionCount(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	dst := make([]perflibTerminalServices, 0)
 	err := perflib.UnmarshalObject(ctx.PerfObjects["Terminal Services"], &dst, c.logger)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) == 0 {
-		return nil, errors.New("WMI query returned empty result set")
+		return errors.New("WMI query returned empty result set")
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -264,7 +264,7 @@ func (c *collector) collectTSSessionCount(ctx *types.ScrapeContext, ch chan<- pr
 		"total",
 	)
 
-	return nil, nil
+	return nil
 }
 
 type perflibTerminalServicesSession struct {
@@ -286,11 +286,11 @@ type perflibTerminalServicesSession struct {
 	WorkingSetPeak        float64 `perflib:"Working Set Peak"`
 }
 
-func (c *collector) collectTSSessionCounters(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectTSSessionCounters(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	dst := make([]perflibTerminalServicesSession, 0)
 	err := perflib.UnmarshalObject(ctx.PerfObjects["Terminal Services Session"], &dst, c.logger)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	names := make(map[string]bool)
 
@@ -397,7 +397,7 @@ func (c *collector) collectTSSessionCounters(ctx *types.ScrapeContext, ch chan<-
 			d.Name,
 		)
 	}
-	return nil, nil
+	return nil
 }
 
 type perflibRemoteDesktopConnectionBrokerCounterset struct {
@@ -406,14 +406,14 @@ type perflibRemoteDesktopConnectionBrokerCounterset struct {
 	FailedConnections     float64 `perflib:"Failed Connections"`
 }
 
-func (c *collector) collectCollectionBrokerPerformanceCounter(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectCollectionBrokerPerformanceCounter(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	dst := make([]perflibRemoteDesktopConnectionBrokerCounterset, 0)
 	err := perflib.UnmarshalObject(ctx.PerfObjects["Remote Desktop Connection Broker Counterset"], &dst, c.logger)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if len(dst) == 0 {
-		return nil, errors.New("WMI query returned empty result set")
+		return errors.New("WMI query returned empty result set")
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -437,5 +437,5 @@ func (c *collector) collectCollectionBrokerPerformanceCounter(ctx *types.ScrapeC
 		"Failed",
 	)
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/thermalzone/thermalzone.go
+++ b/pkg/collector/thermalzone/thermalzone.go
@@ -81,8 +81,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting thermalzone metrics", "desc", desc, "err", err)
+	if err := c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting thermalzone metrics", "err", err)
 		return err
 	}
 	return nil
@@ -98,16 +98,16 @@ type Win32_PerfRawData_Counters_ThermalZoneInformation struct {
 	ThrottleReasons          uint32
 }
 
-func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ch chan<- prometheus.Metric) error {
 	var dst []Win32_PerfRawData_Counters_ThermalZoneInformation
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	// ThermalZone collector has been known to 'successfully' return an empty result.
 	if len(dst) == 0 {
-		return nil, errors.New("Empty results set for collector")
+		return errors.New("Empty results set for collector")
 	}
 
 	for _, info := range dst {
@@ -134,5 +134,5 @@ func (c *collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, erro
 		)
 	}
 
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/time/time.go
+++ b/pkg/collector/time/time.go
@@ -101,8 +101,8 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ctx, ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting time metrics", "desc", desc, "err", err)
+	if err := c.collect(ctx, ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting time metrics", "err", err)
 		return err
 	}
 	return nil
@@ -118,10 +118,10 @@ type windowsTime struct {
 	NTPServerOutgoingResponsesTotal  float64 `perflib:"NTP Server Outgoing Responses"`
 }
 
-func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var dst []windowsTime // Single-instance class, array is required but will have single entry.
 	if err := perflib.UnmarshalObject(ctx.PerfObjects["Windows Time Service"], &dst, c.logger); err != nil {
-		return nil, err
+		return err
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -154,5 +154,5 @@ func (c *collector) collect(ctx *types.ScrapeContext, ch chan<- prometheus.Metri
 		prometheus.CounterValue,
 		dst[0].NTPServerOutgoingResponsesTotal,
 	)
-	return nil, nil
+	return nil
 }

--- a/pkg/collector/vmware_blast/vmware_blast.go
+++ b/pkg/collector/vmware_blast/vmware_blast.go
@@ -570,52 +570,52 @@ func (c *collector) Build() error {
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
 func (c *collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
-	if desc, err := c.collectAudio(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting vmware blast audio metrics", "desc", desc, "err", err)
+	if err := c.collectAudio(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting vmware blast audio metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectCdr(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting vmware blast CDR metrics", "desc", desc, "err", err)
+	if err := c.collectCdr(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting vmware blast CDR metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectClipboard(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting vmware blast clipboard metrics", "desc", desc, "err", err)
+	if err := c.collectClipboard(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting vmware blast clipboard metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectHtml5Mmr(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting vmware blast HTML5 MMR metrics", "desc", desc, "err", err)
+	if err := c.collectHtml5Mmr(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting vmware blast HTML5 MMR metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectImaging(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting vmware blast imaging metrics", "desc", desc, "err", err)
+	if err := c.collectImaging(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting vmware blast imaging metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectRtav(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting vmware blast RTAV metrics", "desc", desc, "err", err)
+	if err := c.collectRtav(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting vmware blast RTAV metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectSerialPortandScanner(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting vmware blast serial port and scanner metrics", "desc", desc, "err", err)
+	if err := c.collectSerialPortandScanner(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting vmware blast serial port and scanner metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectSession(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting vmware blast metrics", "desc", desc, "err", err)
+	if err := c.collectSession(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting vmware blast metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectSkypeforBusinessControl(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting vmware blast skype for business control metrics", "desc", desc, "err", err)
+	if err := c.collectSkypeforBusinessControl(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting vmware blast skype for business control metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectThinPrint(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting vmware blast thin print metrics", "desc", desc, "err", err)
+	if err := c.collectThinPrint(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting vmware blast thin print metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectUsb(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting vmware blast USB metrics", "desc", desc, "err", err)
+	if err := c.collectUsb(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting vmware blast USB metrics", "err", err)
 		return err
 	}
-	if desc, err := c.collectWindowsMediaMmr(ch); err != nil {
-		_ = level.Error(c.logger).Log("failed collecting vmware blast windows media MMR metrics", "desc", desc, "err", err)
+	if err := c.collectWindowsMediaMmr(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting vmware blast windows media MMR metrics", "err", err)
 		return err
 	}
 	return nil
@@ -726,16 +726,16 @@ type win32_PerfRawData_Counters_VMwareBlastWindowsMediaMMRCounters struct {
 	TransmittedPackets uint32
 }
 
-func (c *collector) collectAudio(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectAudio(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_Counters_VMwareBlastAudioCounters
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(dst) == 0 {
 		// It's possible for these classes to legitimately return null when queried
-		return nil, nil
+		return nil
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -762,19 +762,19 @@ func (c *collector) collectAudio(ch chan<- prometheus.Metric) (*prometheus.Desc,
 		float64(dst[0].TransmittedPackets),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectCdr(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectCdr(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_Counters_VMwareBlastCDRCounters
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(dst) == 0 {
 		// It's possible for these classes to legitimately return null when queried
-		return nil, nil
+		return nil
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -801,19 +801,19 @@ func (c *collector) collectCdr(ch chan<- prometheus.Metric) (*prometheus.Desc, e
 		float64(dst[0].TransmittedPackets),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectClipboard(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectClipboard(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_Counters_VMwareBlastClipboardCounters
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(dst) == 0 {
 		// It's possible for these classes to legitimately return null when queried
-		return nil, nil
+		return nil
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -840,19 +840,19 @@ func (c *collector) collectClipboard(ch chan<- prometheus.Metric) (*prometheus.D
 		float64(dst[0].TransmittedPackets),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectHtml5Mmr(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectHtml5Mmr(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_Counters_VMwareBlastHTML5MMRcounters
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(dst) == 0 {
 		// It's possible for these classes to legitimately return null when queried
-		return nil, nil
+		return nil
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -879,19 +879,19 @@ func (c *collector) collectHtml5Mmr(ch chan<- prometheus.Metric) (*prometheus.De
 		float64(dst[0].TransmittedPackets),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectImaging(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectImaging(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_Counters_VMwareBlastImagingCounters
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(dst) == 0 {
 		// It's possible for these classes to legitimately return null when queried
-		return nil, nil
+		return nil
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -966,19 +966,19 @@ func (c *collector) collectImaging(ch chan<- prometheus.Metric) (*prometheus.Des
 		float64(dst[0].TransmittedPackets),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectRtav(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectRtav(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_Counters_VMwareBlastRTAVCounters
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(dst) == 0 {
 		// It's possible for these classes to legitimately return null when queried
-		return nil, nil
+		return nil
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -1005,19 +1005,19 @@ func (c *collector) collectRtav(ch chan<- prometheus.Metric) (*prometheus.Desc, 
 		float64(dst[0].TransmittedPackets),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectSerialPortandScanner(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectSerialPortandScanner(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_Counters_VMwareBlastSerialPortandScannerCounters
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(dst) == 0 {
 		// It's possible for these classes to legitimately return null when queried
-		return nil, nil
+		return nil
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -1044,19 +1044,19 @@ func (c *collector) collectSerialPortandScanner(ch chan<- prometheus.Metric) (*p
 		float64(dst[0].TransmittedPackets),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectSession(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectSession(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_Counters_VMwareBlastSessionCounters
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(dst) == 0 {
 		// It's possible for these classes to legitimately return null when queried
-		return nil, nil
+		return nil
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -1161,19 +1161,19 @@ func (c *collector) collectSession(ch chan<- prometheus.Metric) (*prometheus.Des
 		float64(dst[0].TransmittedPackets),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectSkypeforBusinessControl(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectSkypeforBusinessControl(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_Counters_VMwareBlastSkypeforBusinessControlCounters
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(dst) == 0 {
 		// It's possible for these classes to legitimately return null when queried
-		return nil, nil
+		return nil
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -1200,19 +1200,19 @@ func (c *collector) collectSkypeforBusinessControl(ch chan<- prometheus.Metric) 
 		float64(dst[0].TransmittedPackets),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectThinPrint(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectThinPrint(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_Counters_VMwareBlastThinPrintCounters
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(dst) == 0 {
 		// It's possible for these classes to legitimately return null when queried
-		return nil, nil
+		return nil
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -1239,19 +1239,19 @@ func (c *collector) collectThinPrint(ch chan<- prometheus.Metric) (*prometheus.D
 		float64(dst[0].TransmittedPackets),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectUsb(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectUsb(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_Counters_VMwareBlastUSBCounters
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(dst) == 0 {
 		// It's possible for these classes to legitimately return null when queried
-		return nil, nil
+		return nil
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -1278,19 +1278,19 @@ func (c *collector) collectUsb(ch chan<- prometheus.Metric) (*prometheus.Desc, e
 		float64(dst[0].TransmittedPackets),
 	)
 
-	return nil, nil
+	return nil
 }
 
-func (c *collector) collectWindowsMediaMmr(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+func (c *collector) collectWindowsMediaMmr(ch chan<- prometheus.Metric) error {
 	var dst []win32_PerfRawData_Counters_VMwareBlastWindowsMediaMMRCounters
 	q := wmi.QueryAll(&dst, c.logger)
 	if err := wmi.Query(q, &dst); err != nil {
-		return nil, err
+		return err
 	}
 
 	if len(dst) == 0 {
 		// It's possible for these classes to legitimately return null when queried
-		return nil, nil
+		return nil
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -1317,5 +1317,5 @@ func (c *collector) collectWindowsMediaMmr(ch chan<- prometheus.Metric) (*promet
 		float64(dst[0].TransmittedPackets),
 	)
 
-	return nil, nil
+	return nil
 }


### PR DESCRIPTION
Added relevant CI checks to prevent this from being accidentally re-introduced.

Uneven logging pairs have also been fixed.