### PR TITLE
Enable process V1 performance counters by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,6 @@ jobs:
           $ErrorActionPreference = "Stop"
           $BuildVersion = Get-Content VERSION
           $TagName = $env:GITHUB_REF -replace 'refs/tags/', ''
-          # The MSI version is not semver compliant, so just take the numerical parts
-          $MSIVersion = $TagName -replace '^v?([0-9\.]+).*$','$1'
           foreach($Arch in "amd64", "arm64") {
             Write-Verbose "Building windows_exporter $MSIVersion msi for $Arch"
             .\installer\build.ps1 -PathToExecutable .\output\windows_exporter-$BuildVersion-$Arch.exe -Version $MSIVersion -Arch "$Arch"

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ crossbuild: generate
 	GOARCH=amd64 promu build --prefix=output/amd64
 	GOARCH=arm64 promu build --prefix=output/arm64
 
+.PHONY: package
+package: crossbuild
+	powershell -NonInteractive -ExecutionPolicy Bypass -File .\installer\build.ps1 -PathToExecutable .\output\amd64\windows_exporter.exe -Version $(shell git describe --tags --abbrev=0)
+
 build-image: crossbuild
 	$(DOCKER) build --build-arg=BASE=$(BASE_IMAGE):$(OS) -f Dockerfile -t $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(VERSION)-$(OS) .
 

--- a/README.md
+++ b/README.md
@@ -100,15 +100,17 @@ Each release provides a .msi installer. The installer will setup the windows_exp
 
 If the installer is run without any parameters, the exporter will run with default settings for enabled collectors, ports, etc. The following parameters are available:
 
-Name | Description
------|------------
-`ENABLED_COLLECTORS` | As the `--collectors.enabled` flag, provide a comma-separated list of enabled collectors
-`LISTEN_ADDR` | The IP address to bind to. Defaults to 0.0.0.0
-`LISTEN_PORT` | The port to bind to. Defaults to 9182.
-`METRICS_PATH` | The path at which to serve metrics. Defaults to `/metrics`
-`TEXTFILE_DIRS` | As the `--collector.textfile.directories` flag, provide a directory to read text files with metrics from
-`REMOTE_ADDR` | Allows setting comma separated remote IP addresses for the Windows Firewall exception (allow list). Defaults to an empty string (any remote address).
-`EXTRA_FLAGS` | Allows passing full CLI flags. Defaults to an empty string.
+| Name                             | Description                                                                                                                                           |
+|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ENABLED_COLLECTORS`             | As the `--collectors.enabled` flag, provide a comma-separated list of enabled collectors                                                              |
+| `LISTEN_ADDR`                    | The IP address to bind to. Defaults to an empty string. (any local address)                                                                           |
+| `LISTEN_PORT`                    | The port to bind to. Defaults to `9182`.                                                                                                              |
+| `METRICS_PATH`                   | The path at which to serve metrics. Defaults to `/metrics`                                                                                            |
+| `TEXTFILE_DIRS`                  | As the `--collector.textfile.directories` flag, provide a directory to read text files with metrics from                                              |
+| `REMOTE_ADDR`                    | Allows setting comma separated remote IP addresses for the Windows Firewall exception (allow list). Defaults to an empty string (any remote address). |
+| `EXTRA_FLAGS`                    | Allows passing full CLI flags. Defaults to an empty string.                                                                                           |
+| `ADD_FIREWALL_EXCEPTION`         | Setup an firewall exception for windows_exporter. Defaults to `yes`.                                                                                  |
+| `ENABLE_V1_PERFORMANCE_COUNTERS` | Enables V1 performance counter on modern systems. Defaults to `yes`.                                                                                  |
 
 Parameters are sent to the installer via `msiexec`. Example invocations:
 
@@ -131,6 +133,12 @@ To install the exporter with creating a firewall exception, use the following co
 
 ```powershell
 msiexec /i <path-to-msi-file> ADD_FIREWALL_EXCEPTION=yes
+```
+
+To repair an installation, e.g force re-creating Windows service:
+
+```powershell
+msiexec /fa <path-to-msi-file>
 ```
 
 

--- a/installer/build.ps1
+++ b/installer/build.ps1
@@ -10,6 +10,9 @@ Param (
 )
 $ErrorActionPreference = "Stop"
 
+# The MSI version is not semver compliant, so just take the numerical parts
+$Version = $Version -replace '^v?([0-9\.]+).*$','$1'
+
 # Get absolute path to executable before switching directories
 $PathToExecutable = Resolve-Path $PathToExecutable
 # Set working dir to this directory, reset previous on exit

--- a/installer/windows_exporter.wxs
+++ b/installer/windows_exporter.wxs
@@ -18,10 +18,8 @@
     <SetProperty Id="ExtraFlags" After="InstallFiles" Sequence="execute" Value="[EXTRA_FLAGS]" Condition="EXTRA_FLAGS" />
 
     <Property Id="ADD_FIREWALL_EXCEPTION" Secure="yes" />
-    <SetProperty Id="FirewallException" After="InstallFiles" Sequence="execute" Value="[ADD_FIREWALL_EXCEPTION]" Condition="ADD_FIREWALL_EXCEPTION" />
 
-    <Property Id="ENABLE_V1_PERFORMANCE_COUNTERS" Secure="yes" />
-    <SetProperty Id="EnableV1PerformanceCounters" After="InstallFiles" Sequence="execute" Value="[ADD_FIREWALL_EXCEPTION]" Condition="ENABLE_V1_PERFORMANCE_COUNTERS" />
+    <Property Id="ENABLE_V1_PERFORMANCE_COUNTERS" Secure="yes" Value="yes"/>
 
     <Property Id="LISTEN_PORT" Secure="yes" Value="9182" />
     <SetProperty Id="ListenFlag" After="InstallFiles" Sequence="execute" Value="--web.listen-address [LISTEN_ADDR]:[LISTEN_PORT]" Condition="LISTEN_ADDR&lt;&gt;&quot;&quot; OR LISTEN_PORT&lt;&gt;9182" />
@@ -52,8 +50,23 @@
       <Custom Action="RemoveEventSource" After="InstallInitialize" />
     </InstallExecuteSequence>
 
+    <SetProperty
+            Id="EnableV1PerformanceCounters"
+            Value="&quot;[%ComSpec]&quot; /c lodctr.exe /E:Lsa &amp; lodctr.exe /E:PerfProc &amp; lodctr.exe /R"
+            Before="EnableV1PerformanceCounters"
+            Sequence="execute"
+    />
+    <CustomAction
+            Id="EnableV1PerformanceCounters"
+            BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)"
+            DllEntry="WixSilentExec"
+            Execute="deferred"
+            Impersonate="no"
+            Return="check"
+    />
+
     <InstallExecuteSequence>
-      <Custom Action="EnableV1PerformanceCounters" After="InstallInitialize">ENABLE_V1_PERFORMANCE_COUNTERS="yes"</Custom>
+      <Custom Action="EnableV1PerformanceCounters" Before="InstallFinalize" Condition="ENABLE_V1_PERFORMANCE_COUNTERS=&quot;yes&quot;"/>
     </InstallExecuteSequence>
 
     <Property Id="TEXTFILE_DIRS" Secure="yes" />
@@ -79,21 +92,6 @@
         </fw:FirewallException>
       </Component>
     </ComponentGroup>
-
-    <SetProperty
-      Id="WixQuietExecCmdLine"
-      Value="&quot;[%ComSpec]&quot; /c lodctr.exe /E:Lsa &amp; lodctr.exe /E:PerfProc &amp; lodctr.exe /R"
-      Before="EnableV1PerformanceCounters"
-      Sequence="execute"
-    />
-    <CustomAction
-      Id="EnableV1PerformanceCounters"
-      BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)"
-      DllEntry="WixSilentExec"
-      Execute="deferred"
-      Impersonate="no"
-      Return="ignore"
-    />
 
     <Feature Id="DefaultFeature" Level="1">
       <ComponentGroupRef Id="Files" />

--- a/installer/windows_exporter.wxs
+++ b/installer/windows_exporter.wxs
@@ -5,7 +5,9 @@
     <?define PlatformProgramFiles = "ProgramFilesFolder" ?>
   <?endif?>
 
-  <Package UpgradeCode="66a6eb5b-1fc2-4b14-a362-5ceec6413308" Name="windows_exporter" Version="$(var.Version)" Manufacturer="prometheus-community" Language="1033" Codepage="1252"><SummaryInformation Manufacturer="prometheus-community" Description="windows_exporter $(var.Version) installer" />
+  <Package UpgradeCode="66a6eb5b-1fc2-4b14-a362-5ceec6413308" Name="windows_exporter" Version="$(var.Version)" Manufacturer="prometheus-community" Language="1033" Codepage="1252">
+    <SummaryInformation Manufacturer="prometheus-community" Description="windows_exporter $(var.Version) installer" />
+
     <Media Id="1" Cabinet="windows_exporter.cab" EmbedCab="yes" />
     <MajorUpgrade Schedule="afterInstallInitialize" DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />
 
@@ -17,6 +19,9 @@
 
     <Property Id="ADD_FIREWALL_EXCEPTION" Secure="yes" />
     <SetProperty Id="FirewallException" After="InstallFiles" Sequence="execute" Value="[ADD_FIREWALL_EXCEPTION]" Condition="ADD_FIREWALL_EXCEPTION" />
+
+    <Property Id="ENABLE_V1_PERFORMANCE_COUNTERS" Secure="yes" />
+    <SetProperty Id="EnableV1PerformanceCounters" After="InstallFiles" Sequence="execute" Value="[ADD_FIREWALL_EXCEPTION]" Condition="ENABLE_V1_PERFORMANCE_COUNTERS" />
 
     <Property Id="LISTEN_PORT" Secure="yes" Value="9182" />
     <SetProperty Id="ListenFlag" After="InstallFiles" Sequence="execute" Value="--web.listen-address [LISTEN_ADDR]:[LISTEN_PORT]" Condition="LISTEN_ADDR&lt;&gt;&quot;&quot; OR LISTEN_PORT&lt;&gt;9182" />
@@ -71,12 +76,38 @@
       </Component>
     </ComponentGroup>
 
+    <SetProperty
+      Id="WixQuietExecCmdLine"
+      Value="&quot;[%ComSpec]&quot; /c lodctr.exe /E:Lsa &amp; lodctr.exe /E:PerfProc &amp; lodctr.exe /R"
+      Before="EnableV1PerformanceCounters"
+      Sequence="execute"
+    />
+    <CustomAction
+      Id="EnableV1PerformanceCounters"
+      BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)"
+      DllEntry="WixSilentExec"
+      Execute="deferred"
+      Impersonate="no"
+      Return="ignore"
+    />
+    <ComponentGroup Id="CG_EnableV1PerformanceCounters">
+      <Component Condition="ENABLE_V1_PERFORMANCE_COUNTERS=&quot;yes&quot;" Directory="APPLICATIONROOTDIRECTORY" Id="CG_EnableV1PerformanceCollectors" Guid="9f522655-ac0e-42d2-a512-a7b19ebec7f8">
+        <InstallExecuteSequence>
+          <Custom Action="EnableV1PerformanceCounters" After="InstallInitialize" />
+        </InstallExecuteSequence>
+      </Component>
+    </ComponentGroup>
+
     <Feature Id="DefaultFeature" Level="1">
       <ComponentGroupRef Id="Files" />
     </Feature>
 
     <Feature Id="FirewallException" Level="1">
       <ComponentGroupRef Id="CG_FirewallException" />
+    </Feature>
+
+    <Feature Id="EnableV1PerformanceCounters" Level="1">
+      <ComponentGroupRef Id="CG_EnableV1PerformanceCounters" />
     </Feature>
 
     <StandardDirectory Id="ProgramFiles64Folder">

--- a/installer/windows_exporter.wxs
+++ b/installer/windows_exporter.wxs
@@ -52,6 +52,10 @@
       <Custom Action="RemoveEventSource" After="InstallInitialize" />
     </InstallExecuteSequence>
 
+    <InstallExecuteSequence>
+      <Custom Action="EnableV1PerformanceCounters" After="InstallInitialize">ENABLE_V1_PERFORMANCE_COUNTERS="yes"</Custom>
+    </InstallExecuteSequence>
+
     <Property Id="TEXTFILE_DIRS" Secure="yes" />
     <SetProperty Id="TextfileDirsFlag" After="InstallFiles" Sequence="execute" Value="--collector.textfile.directories [TEXTFILE_DIRS]" Condition="TEXTFILE_DIRS" />
 
@@ -90,13 +94,6 @@
       Impersonate="no"
       Return="ignore"
     />
-    <ComponentGroup Id="CG_EnableV1PerformanceCounters">
-      <Component Condition="ENABLE_V1_PERFORMANCE_COUNTERS=&quot;yes&quot;" Directory="APPLICATIONROOTDIRECTORY" Id="CG_EnableV1PerformanceCollectors" Guid="9f522655-ac0e-42d2-a512-a7b19ebec7f8">
-        <InstallExecuteSequence>
-          <Custom Action="EnableV1PerformanceCounters" After="InstallInitialize" />
-        </InstallExecuteSequence>
-      </Component>
-    </ComponentGroup>
 
     <Feature Id="DefaultFeature" Level="1">
       <ComponentGroupRef Id="Files" />
@@ -104,10 +101,6 @@
 
     <Feature Id="FirewallException" Level="1">
       <ComponentGroupRef Id="CG_FirewallException" />
-    </Feature>
-
-    <Feature Id="EnableV1PerformanceCounters" Level="1">
-      <ComponentGroupRef Id="CG_EnableV1PerformanceCounters" />
     </Feature>
 
     <StandardDirectory Id="ProgramFiles64Folder">


### PR DESCRIPTION
Fixes #1313 

Thats a workaround until process collector uses PDH calls to gather the data. Tested on a Windows Server 2022