### PR TITLE
Add new RemoteFX network metrics

### DIFF
--- a/docs/collector.remote_fx.md
+++ b/docs/collector.remote_fx.md
@@ -24,10 +24,15 @@ Name | Description | Type | Labels
 `windows_remote_fx_net_current_tcp_rtt_seconds` | Average TCP round-trip time (RTT) detected in seconds. | gauge | `session_name`
 `windows_remote_fx_net_current_udp_bandwidth` | UDP Bandwidth detected in bytes per second. | gauge | `session_name`
 `windows_remote_fx_net_current_udp_rtt_seconds` | Average UDP round-trip time (RTT) detected in seconds. | gauge | `session_name`
-`windows_remote_fx_net_received_bytes_total` | _Not yet documented_ | counter | `session_name`
-`windows_remote_fx_net_sent_bytes_total` | _Not yet documented_ | counter | `session_name`
+`windows_remote_fx_net_received_bytes_total` | Total bytes received over the network session. | counter | `session_name`
+`windows_remote_fx_net_sent_bytes_total` | Total bytes sent over the network session. | counter | `session_name`
 `windows_remote_fx_net_udp_packets_received_total` | Rate in packets per second at which packets are received over UDP. | counter | `session_name`
 `windows_remote_fx_net_udp_packets_sent_total` | Rate in packets per second at which packets are sent over UDP. | counter | `session_name`
+`windows_remote_fx_net_loss_rate` | Network packet loss rate detected over the RemoteFX session, expressed as a percentage. | counter | `session_name`
+`windows_remote_fx_net_fec_rate` | Forward Error Correction (FEC) rate applied to packets sent over the RemoteFX session, expressed as a percentage. | counter | `session_name`
+`windows_remote_fx_net_retransmission_rate` Rate of packets retransmitted over the RemoteFX session, expressed as a percentage. | counter | `session_name`
+
+
 
 ## Metrics (Graphics)
 

--- a/pkg/collector/remote_fx/remote_fx.go
+++ b/pkg/collector/remote_fx/remote_fx.go
@@ -39,6 +39,9 @@ type collector struct {
 	TotalSentBytes           *prometheus.Desc
 	UDPPacketsReceivedPersec *prometheus.Desc
 	UDPPacketsSentPersec     *prometheus.Desc
+	FECRate                  *prometheus.Desc
+	LossRate                 *prometheus.Desc
+	RetransmissionRate       *prometheus.Desc
 
 	// gfx
 	AverageEncodingTime                         *prometheus.Desc
@@ -134,6 +137,24 @@ func (c *collector) Build() error {
 		[]string{"session_name"},
 		nil,
 	)
+	c.FECRate = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, Name, "net_fec_rate"),
+		"Forward Error Correction (FEC) percentage",
+		[]string{"session_name"},
+		nil,
+	)
+	c.LossRate = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, Name, "net_loss_rate"),
+		"Loss percentage",
+		[]string{"session_name"},
+		nil,
+	)
+	c.RetransmissionRate = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, Name, "net_retransmission_rate"),
+		"Percentage of packets that have been retransmitted",
+		[]string{"session_name"},
+		nil,
+	)
 
 	// gfx
 	c.AverageEncodingTime = prometheus.NewDesc(
@@ -207,6 +228,9 @@ type perflibRemoteFxNetwork struct {
 	TotalSentBytes           float64 `perflib:"Total Sent Bytes"`
 	UDPPacketsReceivedPersec float64 `perflib:"UDP Packets Received/sec"`
 	UDPPacketsSentPersec     float64 `perflib:"UDP Packets Sent/sec"`
+	FECRate                  float64 `perflib:"Forward Error Correction (FEC) percentage"`
+	LossRate                 float64 `perflib:"Loss percentage"`
+	RetransmissionRate       float64 `perflib:"Percentage of packets that have been retransmitted"`
 }
 
 func (c *collector) collectRemoteFXNetworkCount(ctx *types.ScrapeContext, ch chan<- prometheus.Metric) error {
@@ -280,6 +304,26 @@ func (c *collector) collectRemoteFXNetworkCount(ctx *types.ScrapeContext, ch cha
 			c.UDPPacketsSentPersec,
 			prometheus.CounterValue,
 			d.UDPPacketsSentPersec,
+			d.Name,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.FECRate,
+			prometheus.GaugeValue,
+			d.FECRate,
+			d.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.LossRate,
+			prometheus.GaugeValue,
+			d.LossRate,
+			d.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.RetransmissionRate,
+			prometheus.GaugeValue,
+			d.RetransmissionRate,
 			d.Name,
 		)
 	}


### PR DESCRIPTION
I've added FECRate, LossRate, and RetransmissionRate metric to remote_fx_net.   These metrics help determine connection health and should be included.   