### PR TITLE
Remove push to quay.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,13 +106,13 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_LOGIN }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
-      - name: Login to Docker Hub
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: 'robot'
-          password: ${{ secrets.QUAY_IO_API_TOKEN }}
+      #- name: Login to quay.io
+      #  if: ${{ github.event_name != 'pull_request' }}
+      #  uses: docker/login-action@v3
+      #  with:
+      #    registry: quay.io
+      #    username: 'robot'
+      #    password: ${{ secrets.QUAY_IO_API_TOKEN }}
 
       - name: Login to GitHub container registry
         if: ${{ github.event_name != 'pull_request' }}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DOCKER_REPO       ?= prometheuscommunity
 DOCKER_IMAGE_NAME ?= windows-exporter
 
 # ALL_DOCKER_REPOS is the list of repositories to push the image to. ghcr.io requires that org name be the same as the image repo name.
-ALL_DOCKER_REPOS  ?= docker.io/$(DOCKER_REPO) quay.io/$(DOCKER_REPO) ghcr.io/prometheus-community
+ALL_DOCKER_REPOS  ?= docker.io/$(DOCKER_REPO) ghcr.io/prometheus-community # quay.io/$(DOCKER_REPO) 
 
 # Image Variables for host process Container
 # Windows image build is heavily influenced by https://github.com/kubernetes/kubernetes/blob/master/cluster/images/etcd/Makefile

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The windows_exporter can be run as a Docker container. The Docker image is avail
 
 * [Docker Hub](https://hub.docker.com/r/prometheuscommunity/windows-exporter): `ghcr.io/prometheus-community/windows-exporter`
 * [GitHub Container Registry](https://github.com/prometheus-community/windows_exporter/pkgs/container/windows-exporter): `docker.io/prometheuscommunity/windows-exporter`
-* [quay.io Registry](https://quay.io/repository/prometheuscommunity/windows-exporter): `quay.io/prometheuscommunity/windows-exporter`
+<!-- * [quay.io Registry](https://quay.io/repository/prometheuscommunity/windows-exporter): `quay.io/prometheuscommunity/windows-exporter` -->
 
 
 ## Kubernetes Implementation


### PR DESCRIPTION
We don't know the robots account name if quay,io.

I asked in Slack https://cloud-native.slack.com/archives/C01AUBA4PFE/p1715422584716549 but this block us to publish and release a new RC.