### PR TITLE
service: Breaking split service collector into two separate collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Name     | Description | Enabled by default
 [remote_fx](docs/collector.remote_fx.md) | RemoteFX protocol (RDP) metrics |
 [scheduled_task](docs/collector.scheduled_task.md) | Scheduled Tasks metrics |
 [service](docs/collector.service.md) | Service state metrics | &#10003;
+[service_info](docs/collector.service_info.md) | Service info metrics | &#10003;
 [smb](docs/collector.smb.md) | SMB Server |
 [smbclient](docs/collector.smbclient.md) | SMB Client |
 [smtp](docs/collector.smtp.md) | IIS SMTP Server |

--- a/docs/collector.service.md
+++ b/docs/collector.service.md
@@ -2,121 +2,22 @@
 
 The service collector exposes metrics about Windows Services
 
-The collector exists in 2 different version. Version 1 is using WMI to query all services and is able to provide additional
-information. Version 2 is a more efficient solution by directly connecting to the service manager, but is not able to
-provide additional information like `run_as` or start configuration
-
-## Flags
-
-### `--collector.service.services-where`
-
-A WMI filter on which services to include. Recommended to keep down number of returned metrics.
-
-Example: `--collector.service.services-where="Name='windows_exporter'"`
-
-Example config win_exporter.yml for multiple services: `services-where: Name='SQLServer' OR Name='Couchbase' OR Name='Spooler' OR Name='ActiveMQ'`
-
-### `--collector.service.use-api`
-
-Uses API calls instead of WMI for performance optimization. **Note** the previous flag (`--collector.service.services-where`) won't have any effect on this mode.
-
-### `--collector.service.v2`
-
-Version 2 of the service collector. Is using API calls for performance optimization. **Note** the previous flag (`--collector.service.services-where`) won't have any effect on this mode.
-For additional performance reasons, it doesn't provide any additional information like `run_as` or start configuration.
-
-# collector V1
-
-|||
--|-
-Metric name prefix  | `service`
-Classes             | [`Win32_Service`](https://msdn.microsoft.com/en-us/library/aa394418(v=vs.85).aspx)
-Enabled by default? | Yes
-
-## Metrics
-
-Name | Description | Type | Labels
------|-------------|------|-------
-`windows_service_info` | Contains service information in labels, constant 1 | gauge | name, display_name, process_id, run_as
-`windows_service_state` | The state of the service, 1 if the current state, 0 otherwise | gauge | name, state
-`windows_service_start_mode` | The start mode of the service, 1 if the current start mode, 0 otherwise | gauge | name, start_mode
-`windows_service_status` | The status of the service, 1 if the current status, 0 otherwise | gauge | name, status
-
-For the values of the `state`, `start_mode`, `status` and `run_as` labels, see below.
-
-### States
-
-A service can be in the following states:
-- `stopped`
-- `start pending`
-- `stop pending`
-- `running`
-- `continue pending`
-- `pause pending`
-- `paused`
-- `unknown`
-
-### Start modes
-
-A service can have the following start modes:
-- `boot`
-- `system`
-- `auto`
-- `manual`
-- `disabled`
-
-### Status (not available in API mode)
-
-A service can have any of the following statuses:
-- `ok`
-- `error`
-- `degraded`
-- `unknown`
-- `pred fail`
-- `starting`
-- `stopping`
-- `service`
-- `stressed`
-- `nonrecover`
-- `no contact`
-- `lost comm`
-
-Note that there is some overlap with service state.
-
-### Run As
-
-Account name under which a service runs. Depending on the service type, the account name may be in the form of "DomainName\Username" or UPN format ("Username@DomainName").
-
-It corresponds to the `StartName` attribute of the `Win32_Service` class.
-`StartName` attribute can be NULL and in such case the label is reported as an empty string. Notice that if the attribute is NULL the service is logged on as the `LocalSystem` account or, for kernel or system-level drive, it runs with a default object name created by the I/O system based on the service name, for example, DWDOM\Admin.
-
-### Example metric
-Lists the services that have a 'disabled' start mode.
-```
-windows_service_start_mode{exported_name=~"(mssqlserver|sqlserveragent)",start_mode="disabled"}
-```
-
-## Useful queries
-Counts the number of Microsoft SQL Server/Agent Processes
-```
-count(windows_service_state{exported_name=~"(sqlserveragent|mssqlserver)",state="running"})
-```
-
-# collector V2
-
-
 |||
 -|-
 Metric name prefix  | `service`
 Classes             | none
 Enabled by default? | No
 
+## Flags
+
+None
 
 ## Metrics
 
-Name | Description | Type | Labels
------|-------------|------|-------
-`windows_service_state` | The state of the service, 1 if the current state, 0 otherwise | gauge | name, display_name, state
+| Name                         | Description                                                          | Type  | Labels                    |
+|------------------------------|----------------------------------------------------------------------|-------|---------------------------|
+| `windows_service_state`      | The state of the service, 1 if the current state, 0 otherwise        | gauge | name, display_name, state |
+| `windows_service_process_id` | Contains the process_id of the service process in labels, constant 1 | gauge | name, process_id          |
 
 ### States
 

--- a/docs/collector.service_info.md
+++ b/docs/collector.service_info.md
@@ -1,14 +1,12 @@
-# service collector
+# service_info collector
 
 The service collector exposes information as metrics about Windows Services
 
-|||
--|-
-Metric name prefix  | `service_info`
-Classes             | -
-Enabled by default? | Yes
-
-
+|                     |                |
+|---------------------|----------------|
+| Metric name prefix  | `service_info` |
+| Classes             | -              |
+| Enabled by default? | Yes            |
 
 ## Flags
 
@@ -16,10 +14,10 @@ None
 
 ## Metrics
 
-| Name                              | Description                                                             | Type  | Labels           |
-|-----------------------------------|-------------------------------------------------------------------------|-------|------------------|
-| `windows_service_info_run_as`     | Contains service information run as user in labels, constant 1          | gauge | name, run_as     |
-| `windows_service_info_start_mode` | The start mode of the service, 1 if the current start mode, 0 otherwise | gauge | name, start_mode |
+| Name                              | Description                                                             | Type  | Labels                  |
+|-----------------------------------|-------------------------------------------------------------------------|-------|-------------------------|
+| `windows_service_info`            | Contains service information run as user in labels, constant 1          | gauge | name, path_name, run_as |
+| `windows_service_info_start_mode` | The start mode of the service, 1 if the current start mode, 0 otherwise | gauge | name, start_mode        |
 
 For the values of the `start_mode`, `status` and `run_as` labels, see below.
 
@@ -43,11 +41,10 @@ Account name under which a service runs. Depending on the service type, the acco
 ### Example metric
 
 ```
-# HELP windows_service_info_run_as The start mode of the service (StartMode)
-# TYPE windows_service_info_run_as gauge
-windows_service_info_run_as{name="AGSService",run_as="LocalSystem"} 1
-windows_service_info_run_as{name="AJRouter",run_as="NT AUTHORITY\\LocalService"} 1
-windows_service_info_run_as{name="ALG",run_as="NT AUTHORITY\\LocalService"} 1
+# HELP windows_service_info A metric with a constant '1' value labeled with service information
+# TYPE windows_service_info gauge
+windows_service_info{name="AJRouter",path_name="C:\\WINDOWS\\system32\\svchost.exe -k LocalServiceNetworkRestricted -p",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info{name="ALG",path_name="C:\\WINDOWS\\System32\\alg.exe",run_as="NT AUTHORITY\\LocalService"} 1
 # HELP windows_service_info_start_mode The start mode of the service (StartMode)
 # TYPE windows_service_info_start_mode gauge
 windows_service_info_start_mode{name="AGSService",start_mode="auto"} 0
@@ -64,5 +61,5 @@ windows_service_info_start_mode{name="ALG",start_mode="auto"} 0
 windows_service_info_start_mode{name="ALG",start_mode="boot"} 0
 windows_service_info_start_mode{name="ALG",start_mode="disabled"} 0
 windows_service_info_start_mode{name="ALG",start_mode="manual"} 1
-windows_service_info_start_mode{name="ALG",start_mode="system"} 0   
+windows_service_info_start_mode{name="ALG",start_mode="system"} 0
 ```

--- a/docs/collector.service_info.md
+++ b/docs/collector.service_info.md
@@ -1,0 +1,68 @@
+# service collector
+
+The service collector exposes information as metrics about Windows Services
+
+|||
+-|-
+Metric name prefix  | `service_info`
+Classes             | -
+Enabled by default? | Yes
+
+
+
+## Flags
+
+None
+
+## Metrics
+
+| Name                              | Description                                                             | Type  | Labels           |
+|-----------------------------------|-------------------------------------------------------------------------|-------|------------------|
+| `windows_service_info_run_as`     | Contains service information run as user in labels, constant 1          | gauge | name, run_as     |
+| `windows_service_info_start_mode` | The start mode of the service, 1 if the current start mode, 0 otherwise | gauge | name, start_mode |
+
+For the values of the `start_mode`, `status` and `run_as` labels, see below.
+
+
+### Start modes
+
+A service can have the following start modes:
+- `boot`
+- `system`
+- `auto`
+- `manual`
+- `disabled`
+
+Note that there is some overlap with service state.
+
+### Run As
+
+Account name under which a service runs. Depending on the service type, the account name may be in the form of "DomainName\Username" or UPN format ("Username@DomainName").
+
+
+### Example metric
+
+```
+# HELP windows_service_info_run_as The start mode of the service (StartMode)
+# TYPE windows_service_info_run_as gauge
+windows_service_info_run_as{name="AGSService",run_as="LocalSystem"} 1
+windows_service_info_run_as{name="AJRouter",run_as="NT AUTHORITY\\LocalService"} 1
+windows_service_info_run_as{name="ALG",run_as="NT AUTHORITY\\LocalService"} 1
+# HELP windows_service_info_start_mode The start mode of the service (StartMode)
+# TYPE windows_service_info_start_mode gauge
+windows_service_info_start_mode{name="AGSService",start_mode="auto"} 0
+windows_service_info_start_mode{name="AGSService",start_mode="boot"} 0
+windows_service_info_start_mode{name="AGSService",start_mode="disabled"} 1
+windows_service_info_start_mode{name="AGSService",start_mode="manual"} 0
+windows_service_info_start_mode{name="AGSService",start_mode="system"} 0
+windows_service_info_start_mode{name="AJRouter",start_mode="auto"} 0
+windows_service_info_start_mode{name="AJRouter",start_mode="boot"} 0
+windows_service_info_start_mode{name="AJRouter",start_mode="disabled"} 0
+windows_service_info_start_mode{name="AJRouter",start_mode="manual"} 1
+windows_service_info_start_mode{name="AJRouter",start_mode="system"} 0
+windows_service_info_start_mode{name="ALG",start_mode="auto"} 0
+windows_service_info_start_mode{name="ALG",start_mode="boot"} 0
+windows_service_info_start_mode{name="ALG",start_mode="disabled"} 0
+windows_service_info_start_mode{name="ALG",start_mode="manual"} 1
+windows_service_info_start_mode{name="ALG",start_mode="system"} 0   
+```

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -53,6 +53,7 @@ import (
 	"github.com/prometheus-community/windows_exporter/pkg/collector/remote_fx"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/scheduled_task"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/service"
+	"github.com/prometheus-community/windows_exporter/pkg/collector/service_info"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/smb"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/smbclient"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/smtp"
@@ -135,6 +136,7 @@ func NewWithConfig(logger log.Logger, config Config) Collectors {
 	collectors[remote_fx.Name] = remote_fx.New(logger, &config.RemoteFx)
 	collectors[scheduled_task.Name] = scheduled_task.New(logger, &config.ScheduledTask)
 	collectors[service.Name] = service.New(logger, &config.Service)
+	collectors[service_info.Name] = service_info.New(logger, &config.ServiceInfo)
 	collectors[smb.Name] = smb.New(logger, &config.SMB)
 	collectors[smbclient.Name] = smbclient.New(logger, &config.SMBClient)
 	collectors[smtp.Name] = smtp.New(logger, &config.SMTP)

--- a/pkg/collector/config.go
+++ b/pkg/collector/config.go
@@ -45,6 +45,7 @@ import (
 	"github.com/prometheus-community/windows_exporter/pkg/collector/remote_fx"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/scheduled_task"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/service"
+	"github.com/prometheus-community/windows_exporter/pkg/collector/service_info"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/smb"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/smbclient"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/smtp"
@@ -104,6 +105,7 @@ type Config struct {
 	RemoteFx                       remote_fx.Config                       `yaml:"remote_fx"`
 	ScheduledTask                  scheduled_task.Config                  `yaml:"scheduled_task"`
 	Service                        service.Config                         `yaml:"service"`
+	ServiceInfo                    service_info.Config                    `yaml:"service_info"`
 	SMB                            smb.Config                             `yaml:"smb"`
 	SMBClient                      smbclient.Config                       `yaml:"smbclient"` //nolint:tagliatelle
 	SMTP                           smtp.Config                            `yaml:"smtp"`
@@ -166,6 +168,7 @@ var ConfigDefaults = Config{
 	RemoteFx:                       remote_fx.ConfigDefaults,
 	ScheduledTask:                  scheduled_task.ConfigDefaults,
 	Service:                        service.ConfigDefaults,
+	ServiceInfo:                    service_info.ConfigDefaults,
 	SMB:                            smb.ConfigDefaults,
 	SMBClient:                      smbclient.ConfigDefaults,
 	SMTP:                           smtp.ConfigDefaults,

--- a/pkg/collector/map.go
+++ b/pkg/collector/map.go
@@ -45,6 +45,7 @@ import (
 	"github.com/prometheus-community/windows_exporter/pkg/collector/remote_fx"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/scheduled_task"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/service"
+	"github.com/prometheus-community/windows_exporter/pkg/collector/service_info"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/smb"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/smbclient"
 	"github.com/prometheus-community/windows_exporter/pkg/collector/smtp"
@@ -105,6 +106,7 @@ var BuildersWithFlags = map[string]BuilderWithFlags[Collector]{
 	remote_fx.Name:                       NewBuilderWithFlags(remote_fx.NewWithFlags),
 	scheduled_task.Name:                  NewBuilderWithFlags(scheduled_task.NewWithFlags),
 	service.Name:                         NewBuilderWithFlags(service.NewWithFlags),
+	service_info.Name:                    NewBuilderWithFlags(service_info.NewWithFlags),
 	smb.Name:                             NewBuilderWithFlags(smb.NewWithFlags),
 	smbclient.Name:                       NewBuilderWithFlags(smbclient.NewWithFlags),
 	smtp.Name:                            NewBuilderWithFlags(smtp.NewWithFlags),

--- a/pkg/collector/mssql/mssql.go
+++ b/pkg/collector/mssql/mssql.go
@@ -437,7 +437,6 @@ func NewWithFlags(app *kingpin.Application) *Collector {
 	c := &Collector{
 		config: ConfigDefaults,
 	}
-	c.config.CollectorsEnabled = make([]string, 0)
 
 	var listAllCollectors bool
 
@@ -449,7 +448,7 @@ func NewWithFlags(app *kingpin.Application) *Collector {
 	app.Flag(
 		"collectors.mssql.classes-enabled",
 		"Comma-separated list of mssql WMI classes to use.",
-	).Default(strings.Join(ConfigDefaults.CollectorsEnabled, ",")).StringsVar(&c.config.CollectorsEnabled)
+	).Default(c.config.CollectorsEnabled...).StringsVar(&c.config.CollectorsEnabled)
 
 	app.PreAction(func(*kingpin.ParseContext) error {
 		if listAllCollectors {

--- a/pkg/collector/prometheus.go
+++ b/pkg/collector/prometheus.go
@@ -184,8 +184,11 @@ func (coll *Prometheus) execute(name string, c Collector, ctx *types.ScrapeConte
 
 	if err != nil {
 		_ = level.Error(coll.logger).Log("msg", fmt.Sprintf("collector %s failed after %fs", name, duration), "err", err)
+
 		return failed
 	}
+
 	_ = level.Debug(coll.logger).Log("msg", fmt.Sprintf("collector %s succeeded after %fs.", name, duration))
+
 	return success
 }

--- a/pkg/collector/service/service.go
+++ b/pkg/collector/service/service.go
@@ -19,8 +19,7 @@ import (
 
 const Name = "service"
 
-type Config struct {
-}
+type Config struct{}
 
 var ConfigDefaults = Config{}
 
@@ -34,7 +33,7 @@ var apiStateValues = map[uint32]string{
 	windows.SERVICE_STOPPED:          "stopped",
 }
 
-// A Collector is a Prometheus Collector for WMI Win32_Service metrics.
+// A Collector is a Prometheus Collector for service metrics.
 type Collector struct {
 	config Config
 	logger log.Logger

--- a/pkg/collector/service/service.go
+++ b/pkg/collector/service/service.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"syscall"
 	"unsafe"
 
@@ -14,8 +13,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus-community/windows_exporter/pkg/types"
-	"github.com/prometheus-community/windows_exporter/pkg/utils"
-	"github.com/prometheus-community/windows_exporter/pkg/wmi"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc/mgr"
@@ -24,30 +21,28 @@ import (
 const Name = "service"
 
 type Config struct {
-	ServiceWhereClause string `yaml:"service_where_clause"`
-	UseAPI             bool   `yaml:"use_api"`
-	V2                 bool   `yaml:"v2"`
 }
 
-var ConfigDefaults = Config{
-	ServiceWhereClause: "",
-	UseAPI:             false,
-	V2:                 false,
+var ConfigDefaults = Config{}
+
+var apiStateValues = map[uint32]string{
+	windows.SERVICE_CONTINUE_PENDING: "continue pending",
+	windows.SERVICE_PAUSE_PENDING:    "pause pending",
+	windows.SERVICE_PAUSED:           "paused",
+	windows.SERVICE_RUNNING:          "running",
+	windows.SERVICE_START_PENDING:    "start pending",
+	windows.SERVICE_STOP_PENDING:     "stop pending",
+	windows.SERVICE_STOPPED:          "stopped",
 }
 
 // A Collector is a Prometheus Collector for WMI Win32_Service metrics.
 type Collector struct {
 	logger log.Logger
 
-	serviceWhereClause *string
-	useAPI             *bool
-	v2                 *bool
+	state     *prometheus.Desc
+	processID *prometheus.Desc
 
-	Information *prometheus.Desc
-	State       *prometheus.Desc
-	StartMode   *prometheus.Desc
-	Status      *prometheus.Desc
-	StateV2     *prometheus.Desc
+	serviceManagerHandle *mgr.Mgr
 }
 
 func New(logger log.Logger, config *Config) *Collector {
@@ -55,30 +50,14 @@ func New(logger log.Logger, config *Config) *Collector {
 		config = &ConfigDefaults
 	}
 
-	c := &Collector{
-		serviceWhereClause: &config.ServiceWhereClause,
-		useAPI:             &config.UseAPI,
-	}
+	c := &Collector{}
 	c.SetLogger(logger)
 
 	return c
 }
 
-func NewWithFlags(app *kingpin.Application) *Collector {
-	return &Collector{
-		serviceWhereClause: app.Flag(
-			"collector.service.services-where",
-			"WQL 'where' clause to use in WMI metrics query. Limits the response to the services you specify and reduces the size of the response.",
-		).Default(ConfigDefaults.ServiceWhereClause).String(),
-		useAPI: app.Flag(
-			"collector.service.use-api",
-			"Use API calls to collect service data instead of WMI. Flag 'collector.service.services-where' won't be effective.",
-		).Default(strconv.FormatBool(ConfigDefaults.UseAPI)).Bool(),
-		v2: app.Flag(
-			"collector.service.v2",
-			"Enable V2 service collector. This collector can services state much more efficiently, can't provide general service information.",
-		).Default(strconv.FormatBool(ConfigDefaults.V2)).Bool(),
-	}
+func NewWithFlags(_ *kingpin.Application) *Collector {
+	return &Collector{}
 }
 
 func (c *Collector) GetName() string {
@@ -93,48 +72,35 @@ func (c *Collector) GetPerfCounter() ([]string, error) {
 	return []string{}, nil
 }
 
-func (c *Collector) Close() error {
-	return nil
-}
-
 func (c *Collector) Build() error {
-	if utils.IsEmpty(c.serviceWhereClause) {
-		_ = level.Warn(c.logger).Log("msg", "No where-clause specified for service collector. This will generate a very large number of metrics!")
-	}
-	if *c.useAPI {
-		_ = level.Warn(c.logger).Log("msg", "API collection is enabled.")
-	}
-
-	c.Information = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "info"),
-		"A metric with a constant '1' value labeled with service information",
-		[]string{"name", "display_name", "process_id", "run_as"},
-		nil,
-	)
-	c.State = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "state"),
-		"The state of the service (State)",
-		[]string{"name", "state"},
-		nil,
-	)
-	c.StartMode = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "start_mode"),
-		"The start mode of the service (StartMode)",
-		[]string{"name", "start_mode"},
-		nil,
-	)
-	c.Status = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "status"),
-		"The status of the service (Status)",
-		[]string{"name", "status"},
-		nil,
-	)
-	c.StateV2 = prometheus.NewDesc(
+	c.state = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, Name, "state"),
 		"The state of the service (State)",
 		[]string{"name", "display_name", "status"},
 		nil,
 	)
+	c.processID = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, Name, "process_id"),
+		"Process ID of started service",
+		[]string{"name", "process_id"},
+		nil,
+	)
+
+	// EnumServiceStatusEx requires only SC_MANAGER_ENUM_SERVICE.
+	handle, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_ENUMERATE_SERVICE)
+	if err != nil {
+		return fmt.Errorf("failed to open scm: %w", err)
+	}
+
+	c.serviceManagerHandle = &mgr.Mgr{Handle: handle}
+
+	return nil
+}
+
+func (c *Collector) Close() error {
+	if err := c.serviceManagerHandle.Disconnect(); err != nil {
+		_ = level.Warn(c.logger).Log("msg", "Failed to disconnect from scm", "err", err)
+	}
 
 	return nil
 }
@@ -144,248 +110,15 @@ func (c *Collector) Build() error {
 func (c *Collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
 	var err error
 
-	switch {
-	case *c.useAPI:
-		if err = c.collectAPI(ch); err != nil {
-			_ = level.Error(c.logger).Log("msg", "failed collecting API service metrics:", "err", err)
-		}
-	case *c.v2:
-		if err = c.collectAPIV2(ch); err != nil {
-			_ = level.Error(c.logger).Log("msg", "failed collecting API service metrics:", "err", err)
-		}
-	default:
-		if err = c.collectWMI(ch); err != nil {
-			_ = level.Error(c.logger).Log("msg", "failed collecting WMI service metrics:", "err", err)
-		}
+	if err = c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting API service metrics:", "err", err)
 	}
 
 	return err
 }
 
-// Win32_Service docs:
-// - https://msdn.microsoft.com/en-us/library/aa394418(v=vs.85).aspx
-type Win32_Service struct {
-	DisplayName string
-	Name        string
-	ProcessId   uint32
-	State       string
-	Status      string
-	StartMode   string
-	StartName   *string
-}
-
-var (
-	allStates = []string{
-		"stopped",
-		"start pending",
-		"stop pending",
-		"running",
-		"continue pending",
-		"pause pending",
-		"paused",
-		"unknown",
-	}
-	apiStateValues = map[uint32]string{
-		windows.SERVICE_CONTINUE_PENDING: "continue pending",
-		windows.SERVICE_PAUSE_PENDING:    "pause pending",
-		windows.SERVICE_PAUSED:           "paused",
-		windows.SERVICE_RUNNING:          "running",
-		windows.SERVICE_START_PENDING:    "start pending",
-		windows.SERVICE_STOP_PENDING:     "stop pending",
-		windows.SERVICE_STOPPED:          "stopped",
-	}
-	allStartModes = []string{
-		"boot",
-		"system",
-		"auto",
-		"manual",
-		"disabled",
-	}
-	apiStartModeValues = map[uint32]string{
-		windows.SERVICE_AUTO_START:   "auto",
-		windows.SERVICE_BOOT_START:   "boot",
-		windows.SERVICE_DEMAND_START: "manual",
-		windows.SERVICE_DISABLED:     "disabled",
-		windows.SERVICE_SYSTEM_START: "system",
-	}
-	allStatuses = []string{
-		"ok",
-		"error",
-		"degraded",
-		"unknown",
-		"pred fail",
-		"starting",
-		"stopping",
-		"service",
-		"stressed",
-		"nonrecover",
-		"no contact",
-		"lost comm",
-	}
-)
-
-func (c *Collector) collectWMI(ch chan<- prometheus.Metric) error {
-	var dst []Win32_Service
-	q := wmi.QueryAllWhere(&dst, *c.serviceWhereClause, c.logger) //nolint:staticcheck
-	if err := wmi.Query(q, &dst); err != nil {
-		return err
-	}
-	for _, service := range dst {
-		pid := strconv.FormatUint(uint64(service.ProcessId), 10)
-
-		runAs := ""
-		if service.StartName != nil {
-			runAs = *service.StartName
-		}
-		ch <- prometheus.MustNewConstMetric(
-			c.Information,
-			prometheus.GaugeValue,
-			1.0,
-			strings.ToLower(service.Name),
-			service.DisplayName,
-			pid,
-			runAs,
-		)
-
-		for _, state := range allStates {
-			isCurrentState := 0.0
-			if state == strings.ToLower(service.State) {
-				isCurrentState = 1.0
-			}
-			ch <- prometheus.MustNewConstMetric(
-				c.State,
-				prometheus.GaugeValue,
-				isCurrentState,
-				strings.ToLower(service.Name),
-				state,
-			)
-		}
-
-		for _, startMode := range allStartModes {
-			isCurrentStartMode := 0.0
-			if startMode == strings.ToLower(service.StartMode) {
-				isCurrentStartMode = 1.0
-			}
-			ch <- prometheus.MustNewConstMetric(
-				c.StartMode,
-				prometheus.GaugeValue,
-				isCurrentStartMode,
-				strings.ToLower(service.Name),
-				startMode,
-			)
-		}
-
-		for _, status := range allStatuses {
-			isCurrentStatus := 0.0
-			if status == strings.ToLower(service.Status) {
-				isCurrentStatus = 1.0
-			}
-			ch <- prometheus.MustNewConstMetric(
-				c.Status,
-				prometheus.GaugeValue,
-				isCurrentStatus,
-				strings.ToLower(service.Name),
-				status,
-			)
-		}
-	}
-	return nil
-}
-
-func (c *Collector) collectAPI(ch chan<- prometheus.Metric) error {
-	svcmgrConnection, err := mgr.Connect()
-	if err != nil {
-		return err
-	}
-	defer svcmgrConnection.Disconnect() //nolint:errcheck
-
-	// List All Services from the Services Manager.
-	serviceList, err := svcmgrConnection.ListServices()
-	if err != nil {
-		return err
-	}
-
-	// Iterate through the Services List.
-	for _, service := range serviceList {
-		(func() {
-			// Get UTF16 service name.
-			serviceName, err := syscall.UTF16PtrFromString(service)
-			if err != nil {
-				_ = level.Warn(c.logger).Log("msg", fmt.Sprintf("Service %s get name error:  %#v", service, err))
-				return
-			}
-
-			// Open connection for service handler.
-			serviceHandle, err := windows.OpenService(svcmgrConnection.Handle, serviceName, windows.GENERIC_READ)
-			if err != nil {
-				_ = level.Warn(c.logger).Log("msg", fmt.Sprintf("Open service %s error:  %#v", service, err))
-				return
-			}
-
-			// Create handle for each service.
-			serviceManager := &mgr.Service{Name: service, Handle: serviceHandle}
-			defer serviceManager.Close()
-
-			// Get Service Configuration.
-			serviceConfig, err := serviceManager.Config()
-			if err != nil {
-				_ = level.Warn(c.logger).Log("msg", fmt.Sprintf("Get service %s config error:  %#v", service, err))
-				return
-			}
-
-			// Get Service Current Status.
-			serviceStatus, err := serviceManager.Query()
-			if err != nil {
-				_ = level.Warn(c.logger).Log("msg", fmt.Sprintf("Get service %s status error:  %#v", service, err))
-				return
-			}
-
-			pid := strconv.FormatUint(uint64(serviceStatus.ProcessId), 10)
-
-			ch <- prometheus.MustNewConstMetric(
-				c.Information,
-				prometheus.GaugeValue,
-				1.0,
-				strings.ToLower(service),
-				serviceConfig.DisplayName,
-				pid,
-				serviceConfig.ServiceStartName,
-			)
-
-			for _, state := range apiStateValues {
-				isCurrentState := 0.0
-				if state == apiStateValues[uint32(serviceStatus.State)] {
-					isCurrentState = 1.0
-				}
-				ch <- prometheus.MustNewConstMetric(
-					c.State,
-					prometheus.GaugeValue,
-					isCurrentState,
-					strings.ToLower(service),
-					state,
-				)
-			}
-
-			for _, startMode := range apiStartModeValues {
-				isCurrentStartMode := 0.0
-				if startMode == apiStartModeValues[serviceConfig.StartType] {
-					isCurrentStartMode = 1.0
-				}
-				ch <- prometheus.MustNewConstMetric(
-					c.StartMode,
-					prometheus.GaugeValue,
-					isCurrentStartMode,
-					strings.ToLower(service),
-					startMode,
-				)
-			}
-		})()
-	}
-	return nil
-}
-
-func (c *Collector) collectAPIV2(ch chan<- prometheus.Metric) error {
-	services, err := c.queryAllServiceStates()
+func (c *Collector) collect(ch chan<- prometheus.Metric) error {
+	services, err := c.queryAllServices()
 	if err != nil {
 		_ = level.Warn(c.logger).Log("msg", "Failed to query services", "err", err)
 		return err
@@ -406,7 +139,7 @@ func (c *Collector) collectAPIV2(ch chan<- prometheus.Metric) error {
 			}
 
 			ch <- prometheus.MustNewConstMetric(
-				c.StateV2,
+				c.state,
 				prometheus.GaugeValue,
 				isCurrentState,
 				windows.UTF16PtrToString(svc.ServiceName),
@@ -414,49 +147,38 @@ func (c *Collector) collectAPIV2(ch chan<- prometheus.Metric) error {
 				stateValue,
 			)
 		}
+
+		ch <- prometheus.MustNewConstMetric(
+			c.processID,
+			prometheus.GaugeValue,
+			1.0,
+			windows.UTF16PtrToString(svc.ServiceName),
+			strconv.FormatUint(uint64(svc.ServiceStatusProcess.ProcessId), 10),
+		)
 	}
 
 	return nil
 }
 
-// queryAllServiceStates returns all service states of the current Windows system
+// queryAllServices returns all service states of the current Windows system
 // This is realized by ask Service Manager directly.
-//
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-//
-// Source: https://github.com/DataDog/datadog-agent/blob/afbd8b6c87939c92610c654cb07fdfd439e4fb27/pkg/util/winutil/scmmonitor.go#L61-L96
-func (c *Collector) queryAllServiceStates() ([]windows.ENUM_SERVICE_STATUS_PROCESS, error) {
-	// EnumServiceStatusEx requires only SC_MANAGER_ENUM_SERVICE.
-	h, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_ENUMERATE_SERVICE)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open scm: %w", err)
-	}
-
-	m := &mgr.Mgr{Handle: h}
-	defer func() {
-		if err := m.Disconnect(); err != nil {
-			_ = level.Warn(c.logger).Log("msg", "Failed to disconnect from scm", "err", err)
-		}
-	}()
-
+func (c *Collector) queryAllServices() ([]windows.ENUM_SERVICE_STATUS_PROCESS, error) {
 	var bytesNeeded, servicesReturned uint32
 	var buf []byte
+	var err error
 	for {
 		var p *byte
 		if len(buf) > 0 {
 			p = &buf[0]
 		}
-		err = windows.EnumServicesStatusEx(m.Handle, windows.SC_ENUM_PROCESS_INFO,
+		err = windows.EnumServicesStatusEx(c.serviceManagerHandle.Handle, windows.SC_ENUM_PROCESS_INFO,
 			windows.SERVICE_WIN32, windows.SERVICE_STATE_ALL,
 			p, uint32(len(buf)), &bytesNeeded, &servicesReturned, nil, nil)
 		if err == nil {
 			break
 		}
-		if !errors.Is(err, windows.ERROR_MORE_DATA) {
-			return nil, fmt.Errorf("failed to enum services %w", err)
+		if !errors.Is(err, syscall.ERROR_MORE_DATA) {
+			return nil, err
 		}
 		if bytesNeeded <= uint32(len(buf)) {
 			return nil, err
@@ -467,8 +189,7 @@ func (c *Collector) queryAllServiceStates() ([]windows.ENUM_SERVICE_STATUS_PROCE
 	if servicesReturned == 0 {
 		return nil, nil
 	}
-
-	services := unsafe.Slice((*windows.ENUM_SERVICE_STATUS_PROCESS)(unsafe.Pointer(&buf[0])), servicesReturned)
+	services := unsafe.Slice((*windows.ENUM_SERVICE_STATUS_PROCESS)(unsafe.Pointer(&buf[0])), int(servicesReturned))
 
 	return services, nil
 }

--- a/pkg/collector/service/service.go
+++ b/pkg/collector/service/service.go
@@ -36,6 +36,7 @@ var apiStateValues = map[uint32]string{
 
 // A Collector is a Prometheus Collector for WMI Win32_Service metrics.
 type Collector struct {
+	config Config
 	logger log.Logger
 
 	state     *prometheus.Desc
@@ -49,7 +50,10 @@ func New(logger log.Logger, config *Config) *Collector {
 		config = &ConfigDefaults
 	}
 
-	c := &Collector{}
+	c := &Collector{
+		config: *config,
+	}
+
 	c.SetLogger(logger)
 
 	return c

--- a/pkg/collector/service_info/service_info.go
+++ b/pkg/collector/service_info/service_info.go
@@ -75,7 +75,7 @@ func (c *Collector) GetPerfCounter() ([]string, error) {
 
 func (c *Collector) Build() error {
 	c.info = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "info"),
+		prometheus.BuildFQName(types.Namespace, "", Name),
 		"Information about the service",
 		[]string{"name", "run_as", "path_name"},
 		nil,

--- a/pkg/collector/service_info/service_info.go
+++ b/pkg/collector/service_info/service_info.go
@@ -1,0 +1,238 @@
+//go:build windows
+
+package service_info
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus-community/windows_exporter/pkg/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+const Name = "service_info"
+
+type Config struct{}
+
+var ConfigDefaults = Config{}
+
+var apiStartModeValues = map[uint32]string{
+	windows.SERVICE_AUTO_START:   "auto",
+	windows.SERVICE_BOOT_START:   "boot",
+	windows.SERVICE_DEMAND_START: "manual",
+	windows.SERVICE_DISABLED:     "disabled",
+	windows.SERVICE_SYSTEM_START: "system",
+}
+
+// A Collector is a Prometheus Collector for WMI Win32_Service metrics
+type Collector struct {
+	logger log.Logger
+
+	runAs     *prometheus.Desc
+	startMode *prometheus.Desc
+
+	serviceManagerHandle *mgr.Mgr
+}
+
+func New(logger log.Logger, config *Config) *Collector {
+	if config == nil {
+		config = &ConfigDefaults
+	}
+
+	c := &Collector{}
+	c.SetLogger(logger)
+
+	return c
+}
+
+func NewWithFlags(_ *kingpin.Application) *Collector {
+	return &Collector{}
+}
+
+func (c *Collector) GetName() string {
+	return Name
+}
+
+func (c *Collector) SetLogger(logger log.Logger) {
+	c.logger = log.With(logger, "collector", Name)
+}
+
+func (c *Collector) GetPerfCounter() ([]string, error) {
+	return []string{}, nil
+}
+
+func (c *Collector) Build() error {
+	c.runAs = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, Name, "run_as"),
+		"The start mode of the service (StartMode)",
+		[]string{"name", "run_as"},
+		nil,
+	)
+	c.startMode = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, Name, "start_mode"),
+		"The start mode of the service (StartMode)",
+		[]string{"name", "start_mode"},
+		nil,
+	)
+
+	// EnumServiceStatusEx requires only SC_MANAGER_ENUM_SERVICE.
+	handle, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_ENUMERATE_SERVICE)
+	if err != nil {
+		return fmt.Errorf("failed to open scm: %w", err)
+	}
+
+	c.serviceManagerHandle = &mgr.Mgr{Handle: handle}
+
+	return nil
+}
+
+func (c *Collector) Close() error {
+	if err := c.serviceManagerHandle.Disconnect(); err != nil {
+		_ = level.Warn(c.logger).Log("msg", "Failed to disconnect from scm", "err", err)
+	}
+
+	return nil
+}
+
+// Collect sends the metric values for each metric
+// to the provided prometheus Metric channel.
+func (c *Collector) Collect(_ *types.ScrapeContext, ch chan<- prometheus.Metric) error {
+	var err error
+
+	if err = c.collect(ch); err != nil {
+		_ = level.Error(c.logger).Log("msg", "failed collecting API service metrics", "err", err)
+	}
+
+	return err
+}
+
+func (c *Collector) collect(ch chan<- prometheus.Metric) error {
+	// List All Services from the Services Manager.
+	serviceList, err := c.queryAllServices()
+	if err != nil {
+		return err
+	}
+
+	serviceWorker := make(chan *uint16, len(serviceList))
+
+	// Iterate through the Services List.
+	for _, service := range serviceList {
+		serviceWorker <- service.ServiceName
+	}
+
+	close(serviceWorker)
+
+	wg := sync.WaitGroup{}
+	wg.Add(runtime.NumCPU())
+
+	for range runtime.NumCPU() {
+		go func() {
+			defer wg.Done()
+
+			for serviceName := range serviceWorker {
+				if err := c.collectServiceInfo(ch, serviceName); err != nil {
+					_ = level.Warn(c.logger).Log("msg", "failed collecting service info", "err", err, "service", windows.UTF16PtrToString(serviceName))
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	return nil
+}
+
+func (c *Collector) collectServiceInfo(ch chan<- prometheus.Metric, serviceName *uint16) error {
+	// Open connection for service handler.
+	serviceHandle, err := windows.OpenService(c.serviceManagerHandle.Handle, serviceName, windows.SERVICE_QUERY_CONFIG)
+	if err != nil {
+		return fmt.Errorf("failed to open service: %w", err)
+	}
+
+	serviceNameString := windows.UTF16PtrToString(serviceName)
+
+	// Create handle for each service.
+	serviceManager := &mgr.Service{Name: serviceNameString, Handle: serviceHandle}
+	defer func(serviceManager *mgr.Service) {
+		if err := serviceManager.Close(); err != nil {
+			_ = level.Warn(c.logger).Log("msg", "failed to close service handle", "err", err)
+		}
+	}(serviceManager)
+
+	// Get Service Configuration.
+	serviceConfig, err := serviceManager.Config()
+	if err != nil {
+		if !errors.Is(err, windows.ERROR_FILE_NOT_FOUND) && !errors.Is(err, windows.ERROR_MUI_FILE_NOT_FOUND) {
+			return fmt.Errorf("failed to get service configuration: %w", err)
+		}
+
+		_ = level.Debug(c.logger).Log("msg", "failed collecting service info", "err", err, "service", serviceName)
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.runAs,
+		prometheus.GaugeValue,
+		1.0,
+		serviceNameString,
+		serviceConfig.ServiceStartName,
+	)
+
+	for _, startMode := range apiStartModeValues {
+		isCurrentStartMode := 0.0
+		if startMode == apiStartModeValues[serviceConfig.StartType] {
+			isCurrentStartMode = 1.0
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.startMode,
+			prometheus.GaugeValue,
+			isCurrentStartMode,
+			serviceNameString,
+			startMode,
+		)
+	}
+
+	return nil
+}
+
+// queryAllServices returns all service states of the current Windows system
+// This is realized by ask Service Manager directly.
+func (c *Collector) queryAllServices() ([]windows.ENUM_SERVICE_STATUS_PROCESS, error) {
+	var bytesNeeded, servicesReturned uint32
+	var buf []byte
+	var err error
+	for {
+		var p *byte
+		if len(buf) > 0 {
+			p = &buf[0]
+		}
+		err = windows.EnumServicesStatusEx(c.serviceManagerHandle.Handle, windows.SC_ENUM_PROCESS_INFO,
+			windows.SERVICE_WIN32, windows.SERVICE_STATE_ALL,
+			p, uint32(len(buf)), &bytesNeeded, &servicesReturned, nil, nil)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, syscall.ERROR_MORE_DATA) {
+			return nil, err
+		}
+		if bytesNeeded <= uint32(len(buf)) {
+			return nil, err
+		}
+		buf = make([]byte, bytesNeeded)
+	}
+
+	if servicesReturned == 0 {
+		return nil, nil
+	}
+	services := unsafe.Slice((*windows.ENUM_SERVICE_STATUS_PROCESS)(unsafe.Pointer(&buf[0])), int(servicesReturned))
+
+	return services, nil
+}

--- a/pkg/collector/service_info/service_info.go
+++ b/pkg/collector/service_info/service_info.go
@@ -76,7 +76,7 @@ func (c *Collector) GetPerfCounter() ([]string, error) {
 func (c *Collector) Build() error {
 	c.info = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, "", Name),
-		"Information about the service",
+		"A metric with a constant '1' value labeled with service information",
 		[]string{"name", "run_as", "path_name"},
 		nil,
 	)

--- a/pkg/collector/service_info/service_info.go
+++ b/pkg/collector/service_info/service_info.go
@@ -32,7 +32,7 @@ var apiStartModeValues = map[uint32]string{
 	windows.SERVICE_SYSTEM_START: "system",
 }
 
-// A Collector is a Prometheus Collector for WMI Win32_Service metrics
+// A Collector is a Prometheus Collector for service info metrics.
 type Collector struct {
 	config Config
 	logger log.Logger

--- a/pkg/collector/service_info/service_info.go
+++ b/pkg/collector/service_info/service_info.go
@@ -34,6 +34,7 @@ var apiStartModeValues = map[uint32]string{
 
 // A Collector is a Prometheus Collector for WMI Win32_Service metrics
 type Collector struct {
+	config Config
 	logger log.Logger
 
 	info      *prometheus.Desc
@@ -47,7 +48,10 @@ func New(logger log.Logger, config *Config) *Collector {
 		config = &ConfigDefaults
 	}
 
-	c := &Collector{}
+	c := &Collector{
+		config: *config,
+	}
+
 	c.SetLogger(logger)
 
 	return c

--- a/pkg/collector/service_info/service_info_test.go
+++ b/pkg/collector/service_info/service_info_test.go
@@ -1,0 +1,12 @@
+package service_info_test
+
+import (
+	"testing"
+
+	"github.com/prometheus-community/windows_exporter/pkg/collector/service_info"
+	"github.com/prometheus-community/windows_exporter/pkg/testutils"
+)
+
+func BenchmarkCollector(b *testing.B) {
+	testutils.FuncBenchmarkCollector(b, service_info.Name, service_info.NewWithFlags)
+}

--- a/tools/e2e-output.txt
+++ b/tools/e2e-output.txt
@@ -180,8 +180,8 @@ windows_scheduled_task_state{state="running",task="/Microsoft/Windows/Maintenanc
 windows_scheduled_task_state{state="unknown",task="/Microsoft/Windows/Maintenance/WinSAT"} 0
 # HELP windows_service_info A metric with a constant '1' value labeled with service information
 # TYPE windows_service_info gauge
-# HELP windows_service_start_mode The start mode of the service (StartMode)
-# TYPE windows_service_start_mode gauge
+# HELP windows_service_info_start_mode The start mode of the service (StartMode)
+# TYPE windows_service_info_start_mode gauge
 # HELP windows_service_state The state of the service (State)
 # TYPE windows_service_state gauge
 # HELP windows_service_status The status of the service (Status)

--- a/tools/e2e-output.txt
+++ b/tools/e2e-output.txt
@@ -45,6 +45,7 @@ windows_exporter_collector_success{collector="net"} 1
 windows_exporter_collector_success{collector="os"} 1
 windows_exporter_collector_success{collector="scheduled_task"} 1
 windows_exporter_collector_success{collector="service"} 1
+windows_exporter_collector_success{collector="service_info"} 1
 windows_exporter_collector_success{collector="system"} 1
 windows_exporter_collector_success{collector="textfile"} 1
 # HELP windows_exporter_collector_timeout windows_exporter: Whether the collector timed out.
@@ -57,6 +58,7 @@ windows_exporter_collector_timeout{collector="net"} 0
 windows_exporter_collector_timeout{collector="os"} 0
 windows_exporter_collector_timeout{collector="scheduled_task"} 0
 windows_exporter_collector_timeout{collector="service"} 0
+windows_exporter_collector_timeout{collector="service_info"} 0
 windows_exporter_collector_timeout{collector="system"} 0
 windows_exporter_collector_timeout{collector="textfile"} 0
 # HELP windows_exporter_perflib_snapshot_duration_seconds Duration of perflib snapshot capture
@@ -182,10 +184,10 @@ windows_scheduled_task_state{state="unknown",task="/Microsoft/Windows/Maintenanc
 # TYPE windows_service_info gauge
 # HELP windows_service_info_start_mode The start mode of the service (StartMode)
 # TYPE windows_service_info_start_mode gauge
+# HELP windows_service_process_id Process ID of started service
+# TYPE windows_service_process_id gauge
 # HELP windows_service_state The state of the service (State)
 # TYPE windows_service_state gauge
-# HELP windows_service_status The status of the service (Status)
-# TYPE windows_service_status gauge
 # HELP windows_system_context_switches_total Total number of context switches (WMI source: PerfOS_System.ContextSwitchesPersec)
 # TYPE windows_system_context_switches_total counter
 # HELP windows_system_exception_dispatches_total Total number of exceptions dispatched (WMI source: PerfOS_System.ExceptionDispatchesPersec)

--- a/tools/end-to-end-test.ps1
+++ b/tools/end-to-end-test.ps1
@@ -25,7 +25,7 @@ $skip_re = "^(go_|windows_exporter_build_info|windows_exporter_collector_duratio
 $exporter_proc = Start-Process `
     -PassThru `
     -FilePath ..\windows_exporter.exe `
-    -ArgumentList "--log.level=debug --web.disable-exporter-metrics --collectors.enabled=[defaults],textfile,scheduled_task --collector.scheduled_task.include=.*WinSAT --collector.textfile.directories=$($textfile_dir)" `
+    -ArgumentList "--log.level=debug --web.disable-exporter-metrics --collectors.enabled=[defaults],textfile,service_info,scheduled_task --collector.scheduled_task.include=.*WinSAT --collector.textfile.directories=$($textfile_dir)" `
     -WindowStyle Hidden `
     -RedirectStandardOutput "$($temp_dir)/windows_exporter.log" `
     -RedirectStandardError "$($temp_dir)/windows_exporter_error.log"


### PR DESCRIPTION
This PR remove various service collector solution by one.

This is a fast-path implementation that takes approx 300ms to get all services states.
There is a slower implementation that takes the whole configuration from each single server. This is present as service_info collector.
