### PR TITLE
cpu: Fetch performance counter via PDH.dll via feature toggle. (off by default)

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -216,6 +216,9 @@ func run() int {
 	logCurrentUser(logger)
 
 	logger.Info("Enabled collectors: " + strings.Join(enabledCollectorList, ", "))
+	if utils.PDHEnabled() {
+		logger.Info("Using performance data helper from PHD.dll for performance counter collection. This is in experimental state.")
+	}
 
 	mux := http.NewServeMux()
 	mux.Handle("GET /health", httphandler.NewHealthHandler())

--- a/exporter.go
+++ b/exporter.go
@@ -216,6 +216,7 @@ func run() int {
 	logCurrentUser(logger)
 
 	logger.Info("Enabled collectors: " + strings.Join(enabledCollectorList, ", "))
+
 	if utils.PDHEnabled() {
 		logger.Info("Using performance data helper from PHD.dll for performance counter collection. This is in experimental state.")
 	}

--- a/pkg/collector/cpu/const.go
+++ b/pkg/collector/cpu/const.go
@@ -1,0 +1,28 @@
+package cpu
+
+// Processor performance counters
+const (
+	C1TimeSeconds            = "% C1 Time"
+	C2TimeSeconds            = "% C2 Time"
+	C3TimeSeconds            = "% C3 Time"
+	C1TransitionsTotal       = "C1 Transitions/sec"
+	C2TransitionsTotal       = "C2 Transitions/sec"
+	C3TransitionsTotal       = "C3 Transitions/sec"
+	ClockInterruptsTotal     = "Clock Interrupts/sec"
+	DPCsQueuedTotal          = "DPCs Queued/sec"
+	DPCTimeSeconds           = "% DPC Time"
+	IdleBreakEventsTotal     = "Idle Break Events/sec"
+	IdleTimeSeconds          = "% Idle Time"
+	InterruptsTotal          = "Interrupts/sec"
+	InterruptTimeSeconds     = "% Interrupt Time"
+	ParkingStatus            = "Parking Status"
+	PerformanceLimitPercent  = "% Performance Limit"
+	PriorityTimeSeconds      = "% Priority Time"
+	PrivilegedTimeSeconds    = "% Privileged Time"
+	PrivilegedUtilitySeconds = "% Privileged Utility"
+	ProcessorFrequencyMHz    = "Processor Frequency"
+	ProcessorPerformance     = "% Processor Performance"
+	ProcessorTimeSeconds     = "% Processor Time"
+	ProcessorUtilityRate     = "% Processor Utility"
+	UserTimeSeconds          = "% User Time"
+)

--- a/pkg/collector/cpu/const.go
+++ b/pkg/collector/cpu/const.go
@@ -1,6 +1,6 @@
 package cpu
 
-// Processor performance counters
+// Processor performance counters.
 const (
 	C1TimeSeconds            = "% C1 Time"
 	C2TimeSeconds            = "% C2 Time"

--- a/pkg/utils/collector.go
+++ b/pkg/utils/collector.go
@@ -3,6 +3,7 @@
 package utils
 
 import (
+	"os"
 	"strings"
 
 	"github.com/prometheus-community/windows_exporter/pkg/types"
@@ -25,4 +26,12 @@ func ExpandEnabledCollectors(enabled string) []string {
 	}
 
 	return result
+}
+
+func PDHEnabled() bool {
+	if v, ok := os.LookupEnv("WINDOWS_EXPORTER_PERF_COUNTERS_ENGINE"); ok && v == "pdh" {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
interested user can enable that feature with env var `WINDOWS_EXPORTER_PERF_COUNTERS_ENGINE=pdh`