### PR TITLE
*: replace `--collectors.[name].*` with `--collector.[name].*` flags (click PR number for more information)

### DIFF
--- a/pkg/collector/dfsr/dfsr.go
+++ b/pkg/collector/dfsr/dfsr.go
@@ -122,7 +122,7 @@ func NewWithFlags(app *kingpin.Application) *Collector {
 
 	var collectorsEnabled string
 
-	app.Flag("collectors.dfsr.sources-enabled", "Comma-separated list of DFSR Perflib sources to use.").
+	app.Flag("collector.dfsr.sources-enabled", "Comma-separated list of DFSR Perflib sources to use.").
 		Default(strings.Join(ConfigDefaults.CollectorsEnabled, ",")).StringVar(&collectorsEnabled)
 
 	app.Action(func(*kingpin.ParseContext) error {

--- a/pkg/collector/exchange/exchange.go
+++ b/pkg/collector/exchange/exchange.go
@@ -106,12 +106,12 @@ func NewWithFlags(app *kingpin.Application) *Collector {
 	var collectorsEnabled string
 
 	app.Flag(
-		"collectors.exchange.list",
+		"collector.exchange.list",
 		"List the collectors along with their perflib object name/ids",
 	).BoolVar(&listAllCollectors)
 
 	app.Flag(
-		"collectors.exchange.enabled",
+		"collector.exchange.enabled",
 		"Comma-separated list of collectors to use. Defaults to all, if not specified.",
 	).Default(strings.Join(ConfigDefaults.CollectorsEnabled, ",")).StringVar(&collectorsEnabled)
 

--- a/pkg/collector/filetime/filetime.go
+++ b/pkg/collector/filetime/filetime.go
@@ -59,7 +59,7 @@ func NewWithFlags(app *kingpin.Application) *Collector {
 	var filePatterns string
 
 	app.Flag(
-		"collectors.filetime.file-patterns",
+		"collector.filetime.file-patterns",
 		"Comma-separated list of file patterns. Each pattern is a glob pattern that can contain `*`, `?`, and `**` (recursive). See https://github.com/bmatcuk/doublestar#patterns",
 	).Default(strings.Join(ConfigDefaults.filePatterns, ",")).StringVar(&filePatterns)
 

--- a/pkg/collector/mscluster/mscluster.go
+++ b/pkg/collector/mscluster/mscluster.go
@@ -196,7 +196,7 @@ func NewWithFlags(app *kingpin.Application) *Collector {
 	var collectorsEnabled string
 
 	app.Flag(
-		"collectors.mscluster.enabled",
+		"collector.mscluster.enabled",
 		"Comma-separated list of collectors to use.",
 	).Default(strings.Join(ConfigDefaults.CollectorsEnabled, ",")).StringVar(&collectorsEnabled)
 

--- a/pkg/collector/mssql/mssql.go
+++ b/pkg/collector/mssql/mssql.go
@@ -452,12 +452,12 @@ func NewWithFlags(app *kingpin.Application) *Collector {
 	var collectorsEnabled string
 
 	app.Flag(
-		"collectors.mssql.class-print",
+		"collector.mssql.class-print",
 		"If true, print available mssql WMI classes and exit.  Only displays if the mssql collector is enabled.",
 	).BoolVar(&listAllCollectors)
 
 	app.Flag(
-		"collectors.mssql.classes-enabled",
+		"collector.mssql.classes-enabled",
 		"Comma-separated list of mssql WMI classes to use.",
 	).Default(strings.Join(c.config.CollectorsEnabled, ",")).StringVar(&collectorsEnabled)
 


### PR DESCRIPTION
Unify the name of flags:

| Old | New |
|--------|--------|
| `--collectors.dfsr.sources-enabled` | `--collector.dfsr.sources-enabled` |
| `--collectors.exchange.list` | `--collector.exchange.list` |
| `--collectors.exchange.enabled` | `--collector.exchange.enabled` |
| `--collectors.filetime.file-patterns` | `--collector.filetime.file-patterns` |
| `--collectors.mscluster.enabled` | `--collector.mscluster.enabled` | 
| `--collectors.mssql.class-print` | `--collector.mssql.class-print` | 
| `--collectors.mssql.classes-enabled` | `--collector.mssql.classes-enabled` | 