### PR TITLE
process: Implement PDH collector and add support for Process V2

### DIFF
--- a/internal/collector/adcs/adcs.go
+++ b/internal/collector/adcs/adcs.go
@@ -304,92 +304,92 @@ func (c *Collector) collectADCSCounters(ctx *types.ScrapeContext, logger *slog.L
 }
 
 func (c *Collector) collectPDH(ch chan<- prometheus.Metric) error {
-	data, err := c.perfDataCollector.Collect()
+	perfData, err := c.perfDataCollector.Collect()
 	if err != nil {
 		return fmt.Errorf("failed to collect Certification Authority (ADCS) metrics: %w", err)
 	}
 
-	if len(data) == 0 {
+	if len(perfData) == 0 {
 		return errors.New("perflib query for Certification Authority (ADCS) returned empty result set")
 	}
 
-	for name, adcsData := range data {
+	for name, data := range perfData {
 		ch <- prometheus.MustNewConstMetric(
 			c.requestsPerSecond,
 			prometheus.CounterValue,
-			adcsData[requestsPerSecond].FirstValue,
+			data[requestsPerSecond].FirstValue,
 			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.requestProcessingTime,
 			prometheus.GaugeValue,
-			utils.MilliSecToSec(adcsData[requestProcessingTime].FirstValue),
+			utils.MilliSecToSec(data[requestProcessingTime].FirstValue),
 			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.retrievalsPerSecond,
 			prometheus.CounterValue,
-			adcsData[retrievalsPerSecond].FirstValue,
+			data[retrievalsPerSecond].FirstValue,
 			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.retrievalProcessingTime,
 			prometheus.GaugeValue,
-			utils.MilliSecToSec(adcsData[retrievalProcessingTime].FirstValue),
+			utils.MilliSecToSec(data[retrievalProcessingTime].FirstValue),
 			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.failedRequestsPerSecond,
 			prometheus.CounterValue,
-			adcsData[failedRequestsPerSecond].FirstValue,
+			data[failedRequestsPerSecond].FirstValue,
 			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.issuedRequestsPerSecond,
 			prometheus.CounterValue,
-			adcsData[issuedRequestsPerSecond].FirstValue,
+			data[issuedRequestsPerSecond].FirstValue,
 			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.pendingRequestsPerSecond,
 			prometheus.CounterValue,
-			adcsData[pendingRequestsPerSecond].FirstValue,
+			data[pendingRequestsPerSecond].FirstValue,
 			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.requestCryptographicSigningTime,
 			prometheus.GaugeValue,
-			utils.MilliSecToSec(adcsData[requestCryptographicSigningTime].FirstValue),
+			utils.MilliSecToSec(data[requestCryptographicSigningTime].FirstValue),
 			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.requestPolicyModuleProcessingTime,
 			prometheus.GaugeValue,
-			utils.MilliSecToSec(adcsData[requestPolicyModuleProcessingTime].FirstValue),
+			utils.MilliSecToSec(data[requestPolicyModuleProcessingTime].FirstValue),
 			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.challengeResponsesPerSecond,
 			prometheus.CounterValue,
-			adcsData[challengeResponsesPerSecond].FirstValue,
+			data[challengeResponsesPerSecond].FirstValue,
 			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.challengeResponseProcessingTime,
 			prometheus.GaugeValue,
-			utils.MilliSecToSec(adcsData[challengeResponseProcessingTime].FirstValue),
+			utils.MilliSecToSec(data[challengeResponseProcessingTime].FirstValue),
 			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.signedCertificateTimestampListsPerSecond,
 			prometheus.CounterValue,
-			adcsData[signedCertificateTimestampListsPerSecond].FirstValue,
+			data[signedCertificateTimestampListsPerSecond].FirstValue,
 			name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.signedCertificateTimestampListProcessingTime,
 			prometheus.GaugeValue,
-			utils.MilliSecToSec(adcsData[signedCertificateTimestampListProcessingTime].FirstValue),
+			utils.MilliSecToSec(data[signedCertificateTimestampListProcessingTime].FirstValue),
 			name,
 		)
 	}

--- a/internal/collector/process/const.go
+++ b/internal/collector/process/const.go
@@ -1,0 +1,69 @@
+package process
+
+const (
+	percentProcessorTime    = "% Processor Time"
+	percentPrivilegedTime   = "% Privileged Time"
+	percentUserTime         = "% User Time"
+	creatingProcessID       = "Creating Process ID"
+	elapsedTime             = "Elapsed Time"
+	handleCount             = "Handle Count"
+	ioDataBytesPerSec       = "IO Data Bytes/sec"
+	ioDataOperationsPerSec  = "IO Data Operations/sec"
+	ioOtherBytesPerSec      = "IO Other Bytes/sec"
+	ioOtherOperationsPerSec = "IO Other Operations/sec"
+	ioReadBytesPerSec       = "IO Read Bytes/sec"
+	ioReadOperationsPerSec  = "IO Read Operations/sec"
+	ioWriteBytesPerSec      = "IO Write Bytes/sec"
+	ioWriteOperationsPerSec = "IO Write Operations/sec"
+	pageFaultsPerSec        = "Page Faults/sec"
+	pageFileBytesPeak       = "Page File Bytes Peak"
+	pageFileBytes           = "Page File Bytes"
+	poolNonPagedBytes       = "Pool Nonpaged Bytes"
+	poolPagedBytes          = "Pool Paged Bytes"
+	priorityBase            = "Priority Base"
+	privateBytes            = "Private Bytes"
+	threadCount             = "Thread Count"
+	virtualBytesPeak        = "Virtual Bytes Peak"
+	virtualBytes            = "Virtual Bytes"
+	workingSetPrivate       = "Working Set - Private"
+	workingSetPeak          = "Working Set Peak"
+	workingSet              = "Working Set"
+
+	// Process V1.
+	idProcess = "ID Process"
+
+	// Process V2.
+	processID = "Process ID"
+)
+
+type perflibProcess struct {
+	Name                    string
+	PercentProcessorTime    float64 `perflib:"% Processor Time"`
+	PercentPrivilegedTime   float64 `perflib:"% Privileged Time"`
+	PercentUserTime         float64 `perflib:"% User Time"`
+	CreatingProcessID       float64 `perflib:"Creating Process ID"`
+	ElapsedTime             float64 `perflib:"Elapsed Time"`
+	HandleCount             float64 `perflib:"Handle Count"`
+	IDProcess               float64 `perflib:"ID Process"`
+	IODataBytesPerSec       float64 `perflib:"IO Data Bytes/sec"`
+	IODataOperationsPerSec  float64 `perflib:"IO Data Operations/sec"`
+	IOOtherBytesPerSec      float64 `perflib:"IO Other Bytes/sec"`
+	IOOtherOperationsPerSec float64 `perflib:"IO Other Operations/sec"`
+	IOReadBytesPerSec       float64 `perflib:"IO Read Bytes/sec"`
+	IOReadOperationsPerSec  float64 `perflib:"IO Read Operations/sec"`
+	IOWriteBytesPerSec      float64 `perflib:"IO Write Bytes/sec"`
+	IOWriteOperationsPerSec float64 `perflib:"IO Write Operations/sec"`
+	PageFaultsPerSec        float64 `perflib:"Page Faults/sec"`
+	PageFileBytesPeak       float64 `perflib:"Page File Bytes Peak"`
+	PageFileBytes           float64 `perflib:"Page File Bytes"`
+	PoolNonPagedBytes       float64 `perflib:"Pool Nonpaged Bytes"`
+	PoolPagedBytes          float64 `perflib:"Pool Paged Bytes"`
+	PriorityBase            float64 `perflib:"Priority Base"`
+	PrivateBytes            float64 `perflib:"Private Bytes"`
+	ThreadCount             float64 `perflib:"Thread Count"`
+	VirtualBytesPeak        float64 `perflib:"Virtual Bytes Peak"`
+	VirtualBytes            float64 `perflib:"Virtual Bytes"`
+	WorkingSetPrivate       float64 `perflib:"Working Set - Private"`
+	WorkingSetPeak          float64 `perflib:"Working Set Peak"`
+	WorkingSet              float64 `perflib:"Working Set"`
+}


### PR DESCRIPTION
To enable `Process V2` collector support, set `engine=pdh` to msi installer.