### PR TITLE
chore(docs): fix link to update collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Name     | Description | Enabled by default
 [textfile](docs/collector.textfile.md) | Read prometheus metrics from a text file |
 [thermalzone](docs/collector.thermalzone.md) | Thermal information |
 [time](docs/collector.time.md) | Windows Time Service |
-[updates](docs/collector.updates.md) | Windows Update Service |
+[update](docs/collector.update.md) | Windows Update Service |
 [vmware_blast](docs/collector.vmware_blast.md) | VMware Blast session metrics |
 [vmware](docs/collector.vmware.md) | Performance counters installed by the Vmware Guest agent |
 


### PR DESCRIPTION
Probably the collector got renamed from `updates` to `update` at some point but the link in the README was forgotten.