### PR TITLE
docs: add actual Windows Update service name

### DIFF
--- a/docs/collector.update.md
+++ b/docs/collector.update.md
@@ -1,19 +1,20 @@
 # update collector
 
-The update collector exposes the Windows Update Service metrics. Note that the Windows Update Service must be running, else metric collection will fail.
+The update collector exposes the Windows Update service metrics. Note that the Windows Update service (`wuauserv`) must be running, else metric collection will fail.
 
-The Windows Update Service is responsible for managing the installation of updates for the operating system and other Microsoft software. The service can be configured to automatically download and install updates, or to notify the user when updates are available.
+The Windows Update service is responsible for managing the installation of updates for the operating system and other Microsoft software. The service can be configured to automatically download and install updates, or to notify the user when updates are available.
 
 
 |                     |                        |
 |---------------------|------------------------|
 | Metric name prefix  | `update`               |
-| Data source         | Windows Update Service |
+| Data source         | Windows Update service |
 | Enabled by default? | No                     |
+
 ## Flags
 
 ### `--collector.updates.online`
-Whether to search for updates online. If set to `false`, the collector will only list updates that are already found by the Windows Update Service.
+Whether to search for updates online. If set to `false`, the collector will only list updates that are already found by the Windows Update service.
 Set to `true` to search for updates online, which will take longer to complete.
 
 ### `--collector.updates.scrape-interval`


### PR DESCRIPTION
To check if the _Windows Update_ service is running it is useful to run the `Get-Service` cmdlet, therefore it's good to know the actual service _name_ (as opposed to the _display name_ that is used e.g. by the Services snap-in).

For example

```
Get-Service wuauserv
```

will show the current status of the update service.

Additionally, this commit modifies several *s* to be lowercase, as the full *display name* of the corresponding service is "Windows Update", not "Windows Update Service" - at least on all the Windows versions I was able to check.