### PR TITLE
collector: add username to windows_process_private_bytes metric (#1696)

### DIFF
--- a/pkg/collector/process/process.go
+++ b/pkg/collector/process/process.go
@@ -207,9 +207,10 @@ func (c *Collector) Build(logger *slog.Logger, wmiClient *wmi.Client) error {
 	c.privateBytes = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, Name, "private_bytes"),
 		"Current number of bytes this process has allocated that cannot be shared with other processes.",
-		[]string{"process", "process_id"},
+		[]string{"process", "process_id", "username"},
 		nil,
 	)
+
 	c.threadCount = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, Name, "threads"),
 		"Number of threads currently active in this process.",
@@ -447,7 +448,7 @@ func (c *Collector) Collect(ctx *types.ScrapeContext, logger *slog.Logger, ch ch
 			c.privateBytes,
 			prometheus.GaugeValue,
 			process.PrivateBytes,
-			processName, pid,
+			processName, pid, processOwner,
 		)
 
 		ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
Hello

Problem Statement
The current windows_process_private_bytes metric lacks information about the process owner (username). This information is valuable for detailed process monitoring and security analysis.

Proposed Enhancement:

Extend the windows_process_private_bytes metric to include a "username" label.
Update the collect method to include the process owner information.
Utilize the existing getProcessInformation function to retrieve the process owner


Issue
https://github.com/prometheus-community/windows_exporter/issues/1696