### PR TITLE
docs: Update textfile collector defaults inclusion

### DIFF
--- a/docs/collector.textfile.md
+++ b/docs/collector.textfile.md
@@ -6,7 +6,7 @@ The textfile collector exposes metrics from files written by other processes.
 -|-
 Metric name prefix  | `textfile`
 Classes             | None
-Enabled by default? | Yes
+Enabled by default? | No
 
 ## Flags
 


### PR DESCRIPTION
`textfile` collector was disabled by default in #1560 but the collector documentation was not updated to match.