### PR TITLE
feat: add perfcounter.engine CLI option as alternative to WINDOWS_EXPORTER_PERF_COUNTERS_ENGINE env

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: check
         run: |
           PR_TITLE_PREFIX=$(echo "$PR_TITLE" | cut -d':' -f1)
-          if [[ -d "internal/collector/$PR_TITLE_PREFIX" ]] || [[ -d "internal/$PR_TITLE_PREFIX" ]] || [[ -d "pkg/$PR_TITLE_PREFIX" ]] || [[ -d "$PR_TITLE_PREFIX" ]] || [[ "$PR_TITLE_PREFIX" == "docs" ]] || [[ "$PR_TITLE_PREFIX" == "ci" ]] || [[ "$PR_TITLE_PREFIX" == "revert" ]] || [[ "$PR_TITLE_PREFIX" == "fix" ]] || [[ "$PR_TITLE_PREFIX" == "chore" ]] || [[ "$PR_TITLE_PREFIX" == "chore(docs)" ]] || [[ "$PR_TITLE_PREFIX" == "chore(deps)" ]] || [[ "$PR_TITLE_PREFIX" == "*" ]] || [[ "$PR_TITLE_PREFIX" == "Synchronize common files from prometheus/prometheus" ]]; then
+          if [[ -d "internal/collector/$PR_TITLE_PREFIX" ]] || [[ -d "internal/$PR_TITLE_PREFIX" ]] || [[ -d "pkg/$PR_TITLE_PREFIX" ]] || [[ -d "$PR_TITLE_PREFIX" ]] || [[ "$PR_TITLE_PREFIX" == "docs" ]] || [[ "$PR_TITLE_PREFIX" == "ci" ]] || [[ "$PR_TITLE_PREFIX" == "revert" ]] || [[ "$PR_TITLE_PREFIX" == "fix" ]]  || [[ "$PR_TITLE_PREFIX" == "feat" ]] || [[ "$PR_TITLE_PREFIX" == "chore" ]] || [[ "$PR_TITLE_PREFIX" == "chore(docs)" ]] || [[ "$PR_TITLE_PREFIX" == "chore(deps)" ]] || [[ "$PR_TITLE_PREFIX" == "*" ]] || [[ "$PR_TITLE_PREFIX" == "Synchronize common files from prometheus/prometheus" ]]; then
             exit 0
           fi
 

--- a/exporter.go
+++ b/exporter.go
@@ -8,6 +8,7 @@ package main
 //nolint:gofumpt
 import (
 	"github.com/prometheus-community/windows_exporter/internal/initiate"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 
 	"context"
 	"errors"
@@ -96,6 +97,11 @@ func run() int {
 			"process.priority",
 			"Priority of the exporter process. Higher priorities may improve exporter responsiveness during periods of system load. Can be one of [\"realtime\", \"high\", \"abovenormal\", \"normal\", \"belownormal\", \"low\"]",
 		).Default("normal").String()
+
+		togglePDH = app.Flag(
+			"perfcounter.engine",
+			"EXPERIMENTAL: Performance counter engine to use. Can be one of [\"pdh\", \"registy\"]. PDH is in experimental state. This flag will be removed in 0.31.",
+		).Default("registry").String()
 	)
 
 	logConfig := &log.Config{}
@@ -215,8 +221,10 @@ func run() int {
 
 	logger.Info("Enabled collectors: " + strings.Join(enabledCollectorList, ", "))
 
-	if utils.PDHEnabled() {
+	if v, ok := os.LookupEnv("WINDOWS_EXPORTER_PERF_COUNTERS_ENGINE"); ok && v == "pdh" || *togglePDH == "pdh" {
 		logger.Info("Using performance data helper from PHD.dll for performance counter collection. This is in experimental state.")
+
+		toggle.PHDEnabled = true
 	}
 
 	mux := http.NewServeMux()

--- a/exporter.go
+++ b/exporter.go
@@ -8,7 +8,6 @@ package main
 //nolint:gofumpt
 import (
 	"github.com/prometheus-community/windows_exporter/internal/initiate"
-	"github.com/prometheus-community/windows_exporter/internal/toggle"
 
 	"context"
 	"errors"
@@ -29,6 +28,7 @@ import (
 	"github.com/prometheus-community/windows_exporter/internal/httphandler"
 	"github.com/prometheus-community/windows_exporter/internal/log"
 	"github.com/prometheus-community/windows_exporter/internal/log/flag"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus-community/windows_exporter/pkg/collector"
@@ -100,7 +100,7 @@ func run() int {
 
 		togglePDH = app.Flag(
 			"perfcounter.engine",
-			"EXPERIMENTAL: Performance counter engine to use. Can be one of [\"pdh\", \"registy\"]. PDH is in experimental state. This flag will be removed in 0.31.",
+			"EXPERIMENTAL: Performance counter engine to use. Can be one of \"pdh\", \"registry\". PDH is in experimental state. This flag will be removed in 0.31.",
 		).Default("registry").String()
 	)
 

--- a/internal/collector/adcs/adcs.go
+++ b/internal/collector/adcs/adcs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus-community/windows_exporter/internal/mi"
 	"github.com/prometheus-community/windows_exporter/internal/perfdata"
 	v1 "github.com/prometheus-community/windows_exporter/internal/perfdata/v1"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -63,7 +64,7 @@ func (c *Collector) GetName() string {
 }
 
 func (c *Collector) GetPerfCounter(_ *slog.Logger) ([]string, error) {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return []string{}, nil
 	}
 
@@ -75,7 +76,7 @@ func (c *Collector) Close(_ *slog.Logger) error {
 }
 
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		counters := []string{
 			requestsPerSecond,
 			requestProcessingTime,
@@ -183,7 +184,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 }
 
 func (c *Collector) Collect(ctx *types.ScrapeContext, logger *slog.Logger, ch chan<- prometheus.Metric) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return c.collectPDH(ch)
 	}
 

--- a/internal/collector/adfs/adfs.go
+++ b/internal/collector/adfs/adfs.go
@@ -14,8 +14,8 @@ import (
 	"github.com/prometheus-community/windows_exporter/internal/mi"
 	"github.com/prometheus-community/windows_exporter/internal/perfdata"
 	v1 "github.com/prometheus-community/windows_exporter/internal/perfdata/v1"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
-	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -96,7 +96,7 @@ func (c *Collector) GetName() string {
 }
 
 func (c *Collector) GetPerfCounter(_ *slog.Logger) ([]string, error) {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return []string{}, nil
 	}
 
@@ -108,7 +108,7 @@ func (c *Collector) Close(_ *slog.Logger) error {
 }
 
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		counters := []string{
 			adLoginConnectionFailures,
 			certificateAuthentications,
@@ -426,7 +426,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 }
 
 func (c *Collector) Collect(ctx *types.ScrapeContext, logger *slog.Logger, ch chan<- prometheus.Metric) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return c.collectPDH(ch)
 	}
 

--- a/internal/collector/cache/cache.go
+++ b/internal/collector/cache/cache.go
@@ -12,8 +12,8 @@ import (
 	"github.com/prometheus-community/windows_exporter/internal/perfdata"
 	"github.com/prometheus-community/windows_exporter/internal/perfdata/perftypes"
 	v1 "github.com/prometheus-community/windows_exporter/internal/perfdata/v1"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
-	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -81,7 +81,7 @@ func (c *Collector) GetName() string {
 }
 
 func (c *Collector) GetPerfCounter(_ *slog.Logger) ([]string, error) {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return []string{}, nil
 	}
 
@@ -93,7 +93,7 @@ func (c *Collector) Close(_ *slog.Logger) error {
 }
 
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		counters := []string{
 			asyncCopyReadsTotal,
 			asyncDataMapsTotal,
@@ -314,7 +314,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 // Collect implements the Collector interface.
 func (c *Collector) Collect(ctx *types.ScrapeContext, logger *slog.Logger, ch chan<- prometheus.Metric) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return c.collectPDH(ch)
 	}
 

--- a/internal/collector/cpu/cpu.go
+++ b/internal/collector/cpu/cpu.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/prometheus-community/windows_exporter/internal/perfdata/v1"
 	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
+	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/internal/collector/cpu/cpu.go
+++ b/internal/collector/cpu/cpu.go
@@ -11,8 +11,8 @@ import (
 	"github.com/prometheus-community/windows_exporter/internal/mi"
 	"github.com/prometheus-community/windows_exporter/internal/perfdata"
 	v1 "github.com/prometheus-community/windows_exporter/internal/perfdata/v1"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
-	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -67,7 +67,7 @@ func (c *Collector) GetName() string {
 }
 
 func (c *Collector) GetPerfCounter(_ *slog.Logger) ([]string, error) {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return []string{}, nil
 	}
 
@@ -79,7 +79,7 @@ func (c *Collector) Close(_ *slog.Logger) error {
 }
 
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		counters := []string{
 			c1TimeSeconds,
 			c2TimeSeconds,
@@ -231,7 +231,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 }
 
 func (c *Collector) Collect(ctx *types.ScrapeContext, logger *slog.Logger, ch chan<- prometheus.Metric) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return c.collectPDH(ch)
 	}
 

--- a/internal/collector/dfsr/dfsr.go
+++ b/internal/collector/dfsr/dfsr.go
@@ -13,8 +13,8 @@ import (
 	"github.com/prometheus-community/windows_exporter/internal/mi"
 	"github.com/prometheus-community/windows_exporter/internal/perfdata"
 	v1 "github.com/prometheus-community/windows_exporter/internal/perfdata/v1"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
-	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -148,7 +148,7 @@ func (c *Collector) GetName() string {
 }
 
 func (c *Collector) GetPerfCounter(_ *slog.Logger) ([]string, error) {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return []string{}, nil
 	}
 
@@ -173,7 +173,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 	logger.Info("dfsr collector is in an experimental state! Metrics for this collector have not been tested.")
 
 	//nolint:nestif
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		var err error
 
 		if slices.Contains(c.config.CollectorsEnabled, "connection") {
@@ -567,7 +567,7 @@ func (c *Collector) getDFSRChildCollectors(enabledCollectors []string) []dfsrCol
 // Collect implements the Collector interface.
 // Sends metric values for each metric to the provided prometheus Metric channel.
 func (c *Collector) Collect(ctx *types.ScrapeContext, logger *slog.Logger, ch chan<- prometheus.Metric) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return c.collectPDH(ch)
 	}
 

--- a/internal/collector/dhcp/dhcp.go
+++ b/internal/collector/dhcp/dhcp.go
@@ -12,8 +12,8 @@ import (
 	"github.com/prometheus-community/windows_exporter/internal/perfdata"
 	"github.com/prometheus-community/windows_exporter/internal/perfdata/perftypes"
 	v1 "github.com/prometheus-community/windows_exporter/internal/perfdata/v1"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
-	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -77,7 +77,7 @@ func (c *Collector) GetName() string {
 }
 
 func (c *Collector) GetPerfCounter(_ *slog.Logger) ([]string, error) {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return []string{}, nil
 	}
 
@@ -89,7 +89,7 @@ func (c *Collector) Close(_ *slog.Logger) error {
 }
 
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		counters := []string{
 			acksTotal,
 			activeQueueLength,
@@ -281,7 +281,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 }
 
 func (c *Collector) Collect(ctx *types.ScrapeContext, logger *slog.Logger, ch chan<- prometheus.Metric) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return c.collectPDH(ch)
 	}
 

--- a/internal/collector/exchange/exchange.go
+++ b/internal/collector/exchange/exchange.go
@@ -12,8 +12,8 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
 	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
-	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -185,7 +185,7 @@ func (c *Collector) GetName() string {
 }
 
 func (c *Collector) GetPerfCounter(_ *slog.Logger) ([]string, error) {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return []string{}, nil
 	}
 
@@ -208,7 +208,7 @@ func (c *Collector) Close(_ *slog.Logger) error {
 }
 
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		collectorFuncs := map[string]func() error{
 			adAccessProcesses:   c.buildADAccessProcesses,
 			transportQueues:     c.buildTransportQueues,
@@ -283,7 +283,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 // Collect collects exchange metrics and sends them to prometheus.
 func (c *Collector) Collect(ctx *types.ScrapeContext, logger *slog.Logger, ch chan<- prometheus.Metric) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return c.collectPDH(ch)
 	}
 

--- a/internal/collector/logical_disk/logical_disk.go
+++ b/internal/collector/logical_disk/logical_disk.go
@@ -17,8 +17,8 @@ import (
 	"github.com/prometheus-community/windows_exporter/internal/perfdata"
 	"github.com/prometheus-community/windows_exporter/internal/perfdata/perftypes"
 	v1 "github.com/prometheus-community/windows_exporter/internal/perfdata/v1"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
-	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/windows"
 )
@@ -130,7 +130,7 @@ func (c *Collector) GetName() string {
 }
 
 func (c *Collector) GetPerfCounter(_ *slog.Logger) ([]string, error) {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return []string{}, nil
 	}
 
@@ -142,7 +142,7 @@ func (c *Collector) Close(_ *slog.Logger) error {
 }
 
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		counters := []string{
 			currentDiskQueueLength,
 			avgDiskReadQueueLength,
@@ -302,7 +302,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 func (c *Collector) Collect(ctx *types.ScrapeContext, logger *slog.Logger, ch chan<- prometheus.Metric) error {
 	logger = logger.With(slog.String("collector", Name))
 
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return c.collectPDH(logger, ch)
 	}
 

--- a/internal/collector/memory/memory.go
+++ b/internal/collector/memory/memory.go
@@ -16,8 +16,8 @@ import (
 	"github.com/prometheus-community/windows_exporter/internal/perfdata"
 	"github.com/prometheus-community/windows_exporter/internal/perfdata/perftypes"
 	v1 "github.com/prometheus-community/windows_exporter/internal/perfdata/v1"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
-	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -94,7 +94,7 @@ func (c *Collector) GetName() string {
 }
 
 func (c *Collector) GetPerfCounter(_ *slog.Logger) ([]string, error) {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return []string{}, nil
 	}
 
@@ -106,7 +106,7 @@ func (c *Collector) Close(_ *slog.Logger) error {
 }
 
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		counters := []string{
 			availableBytes,
 			availableKBytes,
@@ -386,7 +386,7 @@ func (c *Collector) Collect(ctx *types.ScrapeContext, logger *slog.Logger, ch ch
 	errs := make([]error, 0, 2)
 
 	var err error
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		err = c.collectPDH(ch)
 	} else {
 		err = c.collectPerformanceData(ctx, logger, ch)

--- a/internal/collector/net/net.go
+++ b/internal/collector/net/net.go
@@ -16,8 +16,8 @@ import (
 	"github.com/prometheus-community/windows_exporter/internal/mi"
 	"github.com/prometheus-community/windows_exporter/internal/perfdata"
 	v1 "github.com/prometheus-community/windows_exporter/internal/perfdata/v1"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
-	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/windows"
 )
@@ -138,7 +138,7 @@ func (c *Collector) GetName() string {
 }
 
 func (c *Collector) GetPerfCounter(_ *slog.Logger) ([]string, error) {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return []string{}, nil
 	}
 
@@ -150,7 +150,7 @@ func (c *Collector) Close(_ *slog.Logger) error {
 }
 
 func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		counters := []string{
 			BytesReceivedPerSec,
 			BytesSentPerSec,
@@ -283,7 +283,7 @@ func (c *Collector) Collect(ctx *types.ScrapeContext, logger *slog.Logger, ch ch
 	if slices.Contains(c.config.CollectorsEnabled, "metrics") {
 		var err error
 
-		if utils.PDHEnabled() {
+		if toggle.IsPDHEnabled() {
 			err = c.collectPDH(ch)
 		} else {
 			err = c.collect(ctx, logger, ch)

--- a/internal/collector/process/process.go
+++ b/internal/collector/process/process.go
@@ -16,8 +16,8 @@ import (
 	"github.com/prometheus-community/windows_exporter/internal/perfdata"
 	v1 "github.com/prometheus-community/windows_exporter/internal/perfdata/v1"
 	v2 "github.com/prometheus-community/windows_exporter/internal/perfdata/v2"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/internal/types"
-	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/windows"
 )
@@ -130,7 +130,7 @@ func (c *Collector) GetName() string {
 }
 
 func (c *Collector) GetPerfCounter(_ *slog.Logger) ([]string, error) {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return []string{}, nil
 	}
 
@@ -156,7 +156,7 @@ func (c *Collector) Build(logger *slog.Logger, miSession *mi.Session) error {
 	c.workerProcessMIQueryQuery = miQuery
 	c.miSession = miSession
 
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		counters := []string{
 			processID,
 			percentProcessorTime,
@@ -315,7 +315,7 @@ type WorkerProcess struct {
 }
 
 func (c *Collector) Collect(ctx *types.ScrapeContext, logger *slog.Logger, ch chan<- prometheus.Metric) error {
-	if utils.PDHEnabled() {
+	if toggle.IsPDHEnabled() {
 		return c.collectPDH(logger, ch)
 	}
 

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
+	"github.com/prometheus-community/windows_exporter/internal/toggle"
 	"github.com/prometheus-community/windows_exporter/pkg/collector"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -46,7 +47,8 @@ func FuncBenchmarkCollector[C collector.Collector](b *testing.B, name string, co
 
 func TestCollector[C collector.Collector, V interface{}](t *testing.T, fn func(*V) C, conf *V) {
 	t.Helper()
-	t.Setenv("WINDOWS_EXPORTER_PERF_COUNTERS_ENGINE", "pdh")
+
+	toggle.PHDEnabled = true
 
 	var (
 		metrics []prometheus.Metric

--- a/internal/toggle/main.go
+++ b/internal/toggle/main.go
@@ -1,0 +1,7 @@
+package toggle
+
+var PHDEnabled bool
+
+func IsPDHEnabled() bool {
+	return PHDEnabled
+}

--- a/internal/utils/collector.go
+++ b/internal/utils/collector.go
@@ -3,7 +3,6 @@
 package utils
 
 import (
-	"os"
 	"strings"
 
 	"github.com/prometheus-community/windows_exporter/internal/types"
@@ -26,20 +25,4 @@ func ExpandEnabledCollectors(enabled string) []string {
 	}
 
 	return result
-}
-
-func PDHEnabled() bool {
-	if v, ok := os.LookupEnv("WINDOWS_EXPORTER_PERF_COUNTERS_ENGINE"); ok && v == "pdh" {
-		return true
-	}
-
-	return false
-}
-
-func MIEnabled() bool {
-	if v, ok := os.LookupEnv("WINDOWS_EXPORTER_WMI_ENGINE"); ok && v == "mi" {
-		return true
-	}
-
-	return false
 }


### PR DESCRIPTION
Ref: https://github.com/prometheus-community/windows_exporter/issues/1350#issuecomment-2466181287