### PR TITLE
fix: use log.file=eventlog as default value, if running as windows service

### DIFF
--- a/cmd/windows_exporter/main.go
+++ b/cmd/windows_exporter/main.go
@@ -109,7 +109,14 @@ func run() int {
 		).Default("normal").String()
 	)
 
-	logConfig := &log.Config{}
+	logFile := &log.AllowedFile{}
+
+	_ = logFile.Set("stdout")
+	if windowsservice.IsService {
+		_ = logFile.Set("eventlog")
+	}
+
+	logConfig := &log.Config{File: logFile}
 	flag.AddFlags(app, logConfig)
 
 	app.Version(version.Print("windows_exporter"))

--- a/installer/files.wxs
+++ b/installer/files.wxs
@@ -13,8 +13,8 @@
   ~ limitations under the License.
   -->
 
-<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
-     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+<Wix xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util"
+     xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <DirectoryRef Id="APPLICATIONFOLDER">
             <Component Transitive="yes">
@@ -28,7 +28,7 @@
                     Start="auto"
                     Type="ownProcess"
                     Vital="yes"
-                    Arguments="--log.file eventlog [ConfigFileFlag] [CollectorsFlag] [ListenFlag] [MetricsPathFlag] [TextfileDirsFlag] [ExtraFlags]">
+                    Arguments="[ConfigFileFlag] [CollectorsFlag] [ListenFlag] [MetricsPathFlag] [TextfileDirsFlag] [ExtraFlags]">
                     <util:ServiceConfig
                         ResetPeriodInDays="1"
                         FirstFailureActionType="restart"

--- a/installer/main.wxs
+++ b/installer/main.wxs
@@ -24,9 +24,9 @@
   ~ limitations under the License.
   -->
 
-<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
-     xmlns:fw="http://wixtoolset.org/schemas/v4/wxs/firewall"
-     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+<Wix xmlns:fw="http://wixtoolset.org/schemas/v4/wxs/firewall"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui"
+     xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Package UpgradeCode="66a6eb5b-1fc2-4b14-a362-5ceec6413308" Name="$(var.ProductName)" Version="$(var.Version)"
              Manufacturer="prometheus-community" Language="1033" Scope="perMachine">
         <SummaryInformation Manufacturer="prometheus-community" Description="$(var.ProductName) $(var.Version) installer" />

--- a/internal/log/flag/flag.go
+++ b/internal/log/flag/flag.go
@@ -34,6 +34,8 @@ func AddFlags(a *kingpin.Application, config *log.Config) {
 	config.Config = new(promslog.Config)
 	flag.AddFlags(a, config.Config)
 
-	config.File = &log.AllowedFile{}
-	a.Flag(FileFlagName, FileFlagHelp).Default("stderr").SetValue(config.File)
+	if config.File == nil {
+		config.File = &log.AllowedFile{}
+	}
+	a.Flag(FileFlagName, FileFlagHelp).Default(config.File.String()).SetValue(config.File)
 }

--- a/internal/log/flag/flag.go
+++ b/internal/log/flag/flag.go
@@ -37,5 +37,6 @@ func AddFlags(a *kingpin.Application, config *log.Config) {
 	if config.File == nil {
 		config.File = &log.AllowedFile{}
 	}
+
 	a.Flag(FileFlagName, FileFlagHelp).Default(config.File.String()).SetValue(config.File)
 }

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -34,6 +34,10 @@ type AllowedFile struct {
 }
 
 func (f *AllowedFile) String() string {
+	if f == nil {
+		return ""
+	}
+
 	return f.s
 }
 


### PR DESCRIPTION



fixes https://github.com/prometheus-community/windows_exporter/pull/1702#issuecomment-2492833757