### PR TITLE
system: BREAKING rename `windows_system_system_up_time` to `windows_system_boot_time_timestamp_seconds`

### DIFF
--- a/docs/collector.system.md
+++ b/docs/collector.system.md
@@ -14,16 +14,16 @@ None
 
 ## Metrics
 
-| Name                                        | Description                                                                                                                                                                                                       | Type    | Labels |
-|---------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|--------|
-| `windows_system_context_switches_total`     | Total number of [context switches](https://en.wikipedia.org/wiki/Context_switch)                                                                                                                                  | counter | None   |
-| `windows_system_exception_dispatches_total` | Total exceptions dispatched by the system                                                                                                                                                                         | counter | None   |
-| `windows_system_processes`                  | Number of process contexts currently loaded or running on the operating system                                                                                                                                    | gauge   | None   |
-| `windows_system_process_limit`              | The size of the user-mode portion of the virtual address space of the calling process, in bytes. This value depends on the type of process, the type of processor, and the configuration of the operating system. | gauge   | None   |
-| `windows_system_processor_queue_length`     | Number of threads in the processor queue. There is a single queue for processor time even on computers with multiple processors.                                                                                  | gauge   | None   |
-| `windows_system_system_calls_total`         | Total combined calls to Windows NT system service routines by all processes running on the computer                                                                                                               | counter | None   |
-| `windows_system_system_up_time`             | Time of last boot of system                                                                                                                                                                                       | gauge   | None   |
-| `windows_system_threads`                    | Number of Windows system [threads](https://en.wikipedia.org/wiki/Thread_(computing))                                                                                                                              | gauge   | None   |
+| Name                                         | Description                                                                                                                                                                                                       | Type    | Labels |
+|----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|--------|
+| `windows_system_boot_time_timestamp_seconds` | Unix timestamp of last system boot                                                                                                                                                                                | gauge   | None   |
+| `windows_system_context_switches_total`      | Total number of [context switches](https://en.wikipedia.org/wiki/Context_switch)                                                                                                                                  | counter | None   |
+| `windows_system_exception_dispatches_total`  | Total exceptions dispatched by the system                                                                                                                                                                         | counter | None   |
+| `windows_system_processes`                   | Number of process contexts currently loaded or running on the operating system                                                                                                                                    | gauge   | None   |
+| `windows_system_process_limit`               | The size of the user-mode portion of the virtual address space of the calling process, in bytes. This value depends on the type of process, the type of processor, and the configuration of the operating system. | gauge   | None   |
+| `windows_system_processor_queue_length`      | Number of threads in the processor queue. There is a single queue for processor time even on computers with multiple processors.                                                                                  | gauge   | None   |
+| `windows_system_system_calls_total`          | Total combined calls to Windows NT system service routines by all processes running on the computer                                                                                                               | counter | None   |
+| `windows_system_threads`                     | Number of Windows system [threads](https://en.wikipedia.org/wiki/Thread_(computing))                                                                                                                              | gauge   | None   |
 
 
 
@@ -41,7 +41,7 @@ windows_system_processes{instance="localhost"}
 ## Useful queries
 Find hosts that have rebooted in the last 24 hours
 ```
-time() - windows_system_system_up_time < 86400
+time() - windows_system_boot_time_timestamp_seconds < 86400
 ```
 
 ## Alerting examples

--- a/internal/collector/system/system.go
+++ b/internal/collector/system/system.go
@@ -46,7 +46,7 @@ type Collector struct {
 	processes                *prometheus.Desc
 	processesLimit           *prometheus.Desc
 	systemCallsTotal         *prometheus.Desc
-	systemUpTime             *prometheus.Desc
+	bootTime                 *prometheus.Desc
 	threads                  *prometheus.Desc
 }
 
@@ -92,6 +92,12 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		return fmt.Errorf("failed to create System collector: %w", err)
 	}
 
+	c.bootTime = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, Name, "boot_time_timestamp_seconds"),
+		"Unix timestamp of system boot time",
+		nil,
+		nil,
+	)
 	c.contextSwitchesTotal = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, Name, "context_switches_total"),
 		"Total number of context switches (WMI source: PerfOS_System.ContextSwitchesPersec)",
@@ -126,12 +132,6 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	c.systemCallsTotal = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, Name, "system_calls_total"),
 		"Total number of system calls (WMI source: PerfOS_System.SystemCallsPersec)",
-		nil,
-		nil,
-	)
-	c.systemUpTime = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "system_up_time"),
-		"System boot time (WMI source: PerfOS_System.SystemUpTime)",
 		nil,
 		nil,
 	)
@@ -184,7 +184,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		data[systemCallsPersec].FirstValue,
 	)
 	ch <- prometheus.MustNewConstMetric(
-		c.systemUpTime,
+		c.bootTime,
 		prometheus.GaugeValue,
 		data[systemUpTime].FirstValue,
 	)

--- a/tools/e2e-output.txt
+++ b/tools/e2e-output.txt
@@ -387,6 +387,8 @@ windows_service_state{name="Themes",state="running"} 1
 windows_service_state{name="Themes",state="start pending"} 0
 windows_service_state{name="Themes",state="stop pending"} 0
 windows_service_state{name="Themes",state="stopped"} 0
+# HELP windows_system_boot_time_timestamp_seconds Unix timestamp of system boot time
+# TYPE windows_system_boot_time_timestamp_seconds gauge
 # HELP windows_system_context_switches_total Total number of context switches (WMI source: PerfOS_System.ContextSwitchesPersec)
 # TYPE windows_system_context_switches_total counter
 # HELP windows_system_exception_dispatches_total Total number of exceptions dispatched (WMI source: PerfOS_System.ExceptionDispatchesPersec)
@@ -399,8 +401,6 @@ windows_service_state{name="Themes",state="stopped"} 0
 # TYPE windows_system_processor_queue_length gauge
 # HELP windows_system_system_calls_total Total number of system calls (WMI source: PerfOS_System.SystemCallsPersec)
 # TYPE windows_system_system_calls_total counter
-# HELP windows_system_system_up_time System boot time (WMI source: PerfOS_System.SystemUpTime)
-# TYPE windows_system_system_up_time gauge
 # HELP windows_system_threads Current number of threads (WMI source: PerfOS_System.Threads)
 # TYPE windows_system_threads gauge
 # HELP windows_tcp_connection_failures_total (TCP.ConnectionFailures)


### PR DESCRIPTION
Fixes #1783 

Renaming metric to clarify the value