### PR TITLE
hyperv: Removed `% Guest Idle Time` performance counters (introduced in 0.30.0-beta.4)

### DIFF
--- a/internal/collector/hyperv/hyperv_hypervisor_root_virtual_processor.go
+++ b/internal/collector/hyperv/hyperv_hypervisor_root_virtual_processor.go
@@ -28,7 +28,6 @@ import (
 type collectorHypervisorRootVirtualProcessor struct {
 	perfDataCollectorHypervisorRootVirtualProcessor *perfdata.Collector
 
-	// \Hyper-V Hypervisor Root Virtual Processor(*)\% Guest Idle Time
 	// \Hyper-V Hypervisor Root Virtual Processor(*)\% Guest Run Time
 	// \Hyper-V Hypervisor Root Virtual Processor(*)\% Hypervisor Run Time
 	// \Hyper-V Hypervisor Root Virtual Processor(*)\% Remote Run Time
@@ -39,7 +38,6 @@ type collectorHypervisorRootVirtualProcessor struct {
 }
 
 const (
-	hypervisorRootVirtualProcessorGuestIdleTimePercent     = "% Guest Idle Time"
 	hypervisorRootVirtualProcessorGuestRunTimePercent      = "% Guest Run Time"
 	hypervisorRootVirtualProcessorHypervisorRunTimePercent = "% Hypervisor Run Time"
 	hypervisorRootVirtualProcessorTotalRunTimePercent      = "% Total Run Time"
@@ -51,7 +49,6 @@ func (c *Collector) buildHypervisorRootVirtualProcessor() error {
 	var err error
 
 	c.perfDataCollectorHypervisorRootVirtualProcessor, err = perfdata.NewCollector("Hyper-V Hypervisor Root Virtual Processor", perfdata.InstancesAll, []string{
-		hypervisorRootVirtualProcessorGuestIdleTimePercent,
 		hypervisorRootVirtualProcessorGuestRunTimePercent,
 		hypervisorRootVirtualProcessorHypervisorRunTimePercent,
 		hypervisorRootVirtualProcessorTotalRunTimePercent,
@@ -113,13 +110,6 @@ func (c *Collector) collectHypervisorRootVirtualProcessor(ch chan<- prometheus.M
 			prometheus.CounterValue,
 			coreData[hypervisorRootVirtualProcessorHypervisorRunTimePercent].FirstValue,
 			coreId, "hypervisor",
-		)
-
-		ch <- prometheus.MustNewConstMetric(
-			c.hypervisorRootVirtualProcessorTimeTotal,
-			prometheus.CounterValue,
-			coreData[hypervisorRootVirtualProcessorGuestIdleTimePercent].FirstValue,
-			coreId, "guest_idle",
 		)
 
 		ch <- prometheus.MustNewConstMetric(

--- a/internal/collector/hyperv/hyperv_hypervisor_virtual_processor.go
+++ b/internal/collector/hyperv/hyperv_hypervisor_virtual_processor.go
@@ -28,7 +28,6 @@ import (
 type collectorHypervisorVirtualProcessor struct {
 	perfDataCollectorHypervisorVirtualProcessor *perfdata.Collector
 
-	// \Hyper-V Hypervisor Virtual Processor(*)\% Guest Idle Time
 	// \Hyper-V Hypervisor Virtual Processor(*)\% Guest Run Time
 	// \Hyper-V Hypervisor Virtual Processor(*)\% Hypervisor Run Time
 	// \Hyper-V Hypervisor Virtual Processor(*)\% Remote Run Time
@@ -38,7 +37,6 @@ type collectorHypervisorVirtualProcessor struct {
 }
 
 const (
-	hypervisorVirtualProcessorGuestRunTimePercent      = "% Guest Run Time"
 	hypervisorVirtualProcessorGuestIdleTimePercent     = "% Guest Idle Time"
 	hypervisorVirtualProcessorHypervisorRunTimePercent = "% Hypervisor Run Time"
 	hypervisorVirtualProcessorTotalRunTimePercent      = "% Total Run Time"
@@ -50,7 +48,6 @@ func (c *Collector) buildHypervisorVirtualProcessor() error {
 	var err error
 
 	c.perfDataCollectorHypervisorVirtualProcessor, err = perfdata.NewCollector("Hyper-V Hypervisor Virtual Processor", perfdata.InstancesAll, []string{
-		hypervisorVirtualProcessorGuestRunTimePercent,
 		hypervisorVirtualProcessorGuestIdleTimePercent,
 		hypervisorVirtualProcessorHypervisorRunTimePercent,
 		hypervisorVirtualProcessorTotalRunTimePercent,
@@ -103,13 +100,6 @@ func (c *Collector) collectHypervisorVirtualProcessor(ch chan<- prometheus.Metri
 
 		vmName := parts[0]
 		coreId := coreParts[2]
-
-		ch <- prometheus.MustNewConstMetric(
-			c.hypervisorVirtualProcessorTimeTotal,
-			prometheus.CounterValue,
-			coreData[hypervisorVirtualProcessorGuestRunTimePercent].FirstValue,
-			vmName, coreId, "guest_run",
-		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.hypervisorVirtualProcessorTimeTotal,


### PR DESCRIPTION
% Guest Idle Time was removed in Server 2025

Ref: https://github.com/prometheus-community/windows_exporter/issues/1782#issuecomment-2508349337