### PR TITLE
process: fix metric labels for multiple process instances

### DIFF
--- a/internal/collector/process/process.go
+++ b/internal/collector/process/process.go
@@ -362,7 +362,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 
 	for name, process := range perfData {
 		// Duplicate processes are suffixed #, and an index number. Remove those.
-		name, _, _ = strings.Cut(name, "#")
+		name, _, _ = strings.Cut(name, ":")
 
 		if c.config.ProcessExclude.MatchString(name) || !c.config.ProcessInclude.MatchString(name) {
 			continue


### PR DESCRIPTION
Fixes #1801 