### PR TITLE
process: Use registry collector for V1 data

### DIFF
--- a/internal/collector/ad/ad.go
+++ b/internal/collector/ad/ad.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -36,7 +36,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	addressBookClientSessions                           *prometheus.Desc
 	addressBookOperationsTotal                          *prometheus.Desc
@@ -278,7 +278,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("DirectoryServices", perfdata.InstancesAll, counters)
+	c.perfDataCollector, err = pdh.NewCollector("DirectoryServices", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create DirectoryServices collector: %w", err)
 	}

--- a/internal/collector/ad/ad.go
+++ b/internal/collector/ad/ad.go
@@ -278,7 +278,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 	var err error
 
-	c.perfDataCollector, err = pdh.NewCollector("DirectoryServices", pdh.InstancesAll, counters)
+	c.perfDataCollector, err = pdh.NewCollector("DirectoryServices", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create DirectoryServices collector: %w", err)
 	}

--- a/internal/collector/adcs/adcs.go
+++ b/internal/collector/adcs/adcs.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -37,7 +37,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	challengeResponseProcessingTime              *prometheus.Desc
 	challengeResponsesPerSecond                  *prometheus.Desc
@@ -83,7 +83,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("Certification Authority", perfdata.InstancesAll, []string{
+	c.perfDataCollector, err = pdh.NewCollector("Certification Authority", pdh.InstancesAll, []string{
 		requestsPerSecond,
 		requestProcessingTime,
 		retrievalsPerSecond,

--- a/internal/collector/adcs/adcs.go
+++ b/internal/collector/adcs/adcs.go
@@ -97,7 +97,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		challengeResponseProcessingTime,
 		signedCertificateTimestampListsPerSecond,
 		signedCertificateTimestampListProcessingTime,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Certification Authority collector: %w", err)
 	}

--- a/internal/collector/adfs/adfs.go
+++ b/internal/collector/adfs/adfs.go
@@ -159,7 +159,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		configDBFailures,
 		avgConfigDBQueryTime,
 		federationMetadataRequests,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create AD FS collector: %w", err)
 	}

--- a/internal/collector/adfs/adfs.go
+++ b/internal/collector/adfs/adfs.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -39,7 +39,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	adLoginConnectionFailures                          *prometheus.Desc
 	artifactDBFailures                                 *prometheus.Desc
@@ -115,7 +115,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("AD FS", nil, []string{
+	c.perfDataCollector, err = pdh.NewCollector("AD FS", nil, []string{
 		adLoginConnectionFailures,
 		certificateAuthentications,
 		deviceAuthentications,

--- a/internal/collector/cache/cache.go
+++ b/internal/collector/cache/cache.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -37,7 +37,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	asyncCopyReadsTotal         *prometheus.Desc
 	asyncDataMapsTotal          *prometheus.Desc
@@ -99,7 +99,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("Cache", perfdata.InstancesAll, []string{
+	c.perfDataCollector, err = pdh.NewCollector("Cache", pdh.InstancesAll, []string{
 		asyncCopyReadsTotal,
 		asyncDataMapsTotal,
 		asyncFastReadsTotal,
@@ -319,7 +319,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("failed to collect Cache metrics: %w", err)
 	}
 
-	cacheData, ok := data[perfdata.InstanceEmpty]
+	cacheData, ok := data[pdh.InstanceEmpty]
 
 	if !ok {
 		return fmt.Errorf("failed to collect Cache metrics: %w", types.ErrNoData)

--- a/internal/collector/cache/cache.go
+++ b/internal/collector/cache/cache.go
@@ -129,7 +129,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		syncFastReadsTotal,
 		syncMDLReadsTotal,
 		syncPinReadsTotal,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Cache collector: %w", err)
 	}

--- a/internal/collector/container/container.go
+++ b/internal/collector/container/container.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Microsoft/hcsshim"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -322,19 +322,19 @@ func (c *Collector) collectContainer(ch chan<- prometheus.Metric, containerDetai
 	ch <- prometheus.MustNewConstMetric(
 		c.runtimeTotal,
 		prometheus.CounterValue,
-		float64(containerStats.Processor.TotalRuntime100ns)*perfdata.TicksToSecondScaleFactor,
+		float64(containerStats.Processor.TotalRuntime100ns)*pdh.TicksToSecondScaleFactor,
 		containerIdWithPrefix,
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.runtimeUser,
 		prometheus.CounterValue,
-		float64(containerStats.Processor.RuntimeUser100ns)*perfdata.TicksToSecondScaleFactor,
+		float64(containerStats.Processor.RuntimeUser100ns)*pdh.TicksToSecondScaleFactor,
 		containerIdWithPrefix,
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.runtimeKernel,
 		prometheus.CounterValue,
-		float64(containerStats.Processor.RuntimeKernel100ns)*perfdata.TicksToSecondScaleFactor,
+		float64(containerStats.Processor.RuntimeKernel100ns)*pdh.TicksToSecondScaleFactor,
 		containerIdWithPrefix,
 	)
 	ch <- prometheus.MustNewConstMetric(

--- a/internal/collector/cpu/cpu.go
+++ b/internal/collector/cpu/cpu.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -38,7 +38,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	mu sync.Mutex
 
@@ -92,7 +92,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 	c.mu = sync.Mutex{}
 
-	c.perfDataCollector, err = perfdata.NewCollector("Processor Information", perfdata.InstancesAll, []string{
+	c.perfDataCollector, err = pdh.NewCollector("Processor Information", pdh.InstancesAll, []string{
 		c1TimeSeconds,
 		c2TimeSeconds,
 		c3TimeSeconds,

--- a/internal/collector/cpu/cpu.go
+++ b/internal/collector/cpu/cpu.go
@@ -116,7 +116,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		processorTimeSeconds,
 		processorUtilityRate,
 		userTimeSeconds,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Processor Information collector: %w", err)
 	}

--- a/internal/collector/dfsr/dfsr.go
+++ b/internal/collector/dfsr/dfsr.go
@@ -170,7 +170,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 			rdcNumberOfFilesReceivedTotal,
 			rdcSizeOfFilesReceivedTotal,
 			sizeOfFilesReceivedTotal,
-		})
+		}, false)
 		if err != nil {
 			return fmt.Errorf("failed to create DFS Replication Connections collector: %w", err)
 		}
@@ -205,7 +205,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 			stagingFilesCleanedUpTotal,
 			stagingFilesGeneratedTotal,
 			updatesDroppedTotal,
-		})
+		}, false)
 		if err != nil {
 			return fmt.Errorf("failed to create DFS Replicated Folders collector: %w", err)
 		}
@@ -218,7 +218,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 			usnJournalRecordsReadTotal,
 			usnJournalRecordsAcceptedTotal,
 			usnJournalUnreadPercentage,
-		})
+		}, false)
 		if err != nil {
 			return fmt.Errorf("failed to create DFS Replication Service Volumes collector: %w", err)
 		}

--- a/internal/collector/dfsr/dfsr.go
+++ b/internal/collector/dfsr/dfsr.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -44,9 +44,9 @@ var ConfigDefaults = Config{
 type Collector struct {
 	config Config
 
-	perfDataCollectorConnection *perfdata.Collector
-	perfDataCollectorFolder     *perfdata.Collector
-	perfDataCollectorVolume     *perfdata.Collector
+	perfDataCollectorConnection *pdh.Collector
+	perfDataCollectorFolder     *pdh.Collector
+	perfDataCollectorVolume     *pdh.Collector
 
 	// connection source
 	connectionBandwidthSavingsUsingDFSReplicationTotal *prometheus.Desc
@@ -160,7 +160,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 	var err error
 
 	if slices.Contains(c.config.CollectorsEnabled, "connection") {
-		c.perfDataCollectorConnection, err = perfdata.NewCollector("DFS Replication Connections", perfdata.InstancesAll, []string{
+		c.perfDataCollectorConnection, err = pdh.NewCollector("DFS Replication Connections", pdh.InstancesAll, []string{
 			bandwidthSavingsUsingDFSReplicationTotal,
 			bytesReceivedTotal,
 			compressedSizeOfFilesReceivedTotal,
@@ -177,7 +177,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 	}
 
 	if slices.Contains(c.config.CollectorsEnabled, "folder") {
-		c.perfDataCollectorFolder, err = perfdata.NewCollector("DFS Replicated Folders", perfdata.InstancesAll, []string{
+		c.perfDataCollectorFolder, err = pdh.NewCollector("DFS Replicated Folders", pdh.InstancesAll, []string{
 			bandwidthSavingsUsingDFSReplicationTotal,
 			compressedSizeOfFilesReceivedTotal,
 			conflictBytesCleanedUpTotal,
@@ -212,7 +212,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 	}
 
 	if slices.Contains(c.config.CollectorsEnabled, "volume") {
-		c.perfDataCollectorVolume, err = perfdata.NewCollector("DFS Replication Service Volumes", perfdata.InstancesAll, []string{
+		c.perfDataCollectorVolume, err = pdh.NewCollector("DFS Replication Service Volumes", pdh.InstancesAll, []string{
 			databaseCommitsTotal,
 			databaseLookupsTotal,
 			usnJournalRecordsReadTotal,

--- a/internal/collector/dhcp/dhcp.go
+++ b/internal/collector/dhcp/dhcp.go
@@ -121,7 +121,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		packetsReceivedTotal,
 		releasesTotal,
 		requestsTotal,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create DHCP Server collector: %w", err)
 	}

--- a/internal/collector/dhcp/dhcp.go
+++ b/internal/collector/dhcp/dhcp.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -37,7 +37,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	acksTotal                                        *prometheus.Desc
 	activeQueueLength                                *prometheus.Desc
@@ -95,7 +95,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("DHCP Server", nil, []string{
+	c.perfDataCollector, err = pdh.NewCollector("DHCP Server", nil, []string{
 		acksTotal,
 		activeQueueLength,
 		conflictCheckQueueLength,
@@ -286,7 +286,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("failed to collect DHCP Server metrics: %w", err)
 	}
 
-	data, ok := perfData[perfdata.InstanceEmpty]
+	data, ok := perfData[pdh.InstanceEmpty]
 	if !ok {
 		return fmt.Errorf("failed to collect DHCP Server metrics: %w", types.ErrNoData)
 	}

--- a/internal/collector/dns/dns.go
+++ b/internal/collector/dns/dns.go
@@ -133,7 +133,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		winsReverseResponseSent,
 		zoneTransferFailure,
 		zoneTransferSOARequestSent,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create DNS collector: %w", err)
 	}

--- a/internal/collector/dns/dns.go
+++ b/internal/collector/dns/dns.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -37,7 +37,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	dynamicUpdatesFailures        *prometheus.Desc
 	dynamicUpdatesQueued          *prometheus.Desc
@@ -92,7 +92,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("DNS", perfdata.InstancesAll, []string{
+	c.perfDataCollector, err = pdh.NewCollector("DNS", pdh.InstancesAll, []string{
 		axfrRequestReceived,
 		axfrRequestSent,
 		axfrResponseReceived,
@@ -282,7 +282,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("failed to collect DNS metrics: %w", err)
 	}
 
-	data, ok := perfData[perfdata.InstanceEmpty]
+	data, ok := perfData[pdh.InstanceEmpty]
 	if !ok {
 		return fmt.Errorf("failed to collect DNS metrics: %w", types.ErrNoData)
 	}

--- a/internal/collector/exchange/exchange.go
+++ b/internal/collector/exchange/exchange.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -66,16 +66,16 @@ var ConfigDefaults = Config{
 type Collector struct {
 	config Config
 
-	perfDataCollectorADAccessProcesses           *perfdata.Collector
-	perfDataCollectorTransportQueues             *perfdata.Collector
-	perfDataCollectorHttpProxy                   *perfdata.Collector
-	perfDataCollectorActiveSync                  *perfdata.Collector
-	perfDataCollectorAvailabilityService         *perfdata.Collector
-	perfDataCollectorOWA                         *perfdata.Collector
-	perfDataCollectorAutoDiscover                *perfdata.Collector
-	perfDataCollectorWorkloadManagementWorkloads *perfdata.Collector
-	perfDataCollectorRpcClientAccess             *perfdata.Collector
-	perfDataCollectorMapiHttpEmsmdb              *perfdata.Collector
+	perfDataCollectorADAccessProcesses           *pdh.Collector
+	perfDataCollectorTransportQueues             *pdh.Collector
+	perfDataCollectorHttpProxy                   *pdh.Collector
+	perfDataCollectorActiveSync                  *pdh.Collector
+	perfDataCollectorAvailabilityService         *pdh.Collector
+	perfDataCollectorOWA                         *pdh.Collector
+	perfDataCollectorAutoDiscover                *pdh.Collector
+	perfDataCollectorWorkloadManagementWorkloads *pdh.Collector
+	perfDataCollectorRpcClientAccess             *pdh.Collector
+	perfDataCollectorMapiHttpEmsmdb              *pdh.Collector
 
 	activeMailboxDeliveryQueueLength        *prometheus.Desc
 	activeSyncRequestsPerSec                *prometheus.Desc

--- a/internal/collector/exchange/exchange_active_sync.go
+++ b/internal/collector/exchange/exchange_active_sync.go
@@ -18,7 +18,7 @@ package exchange
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -38,7 +38,7 @@ func (c *Collector) buildActiveSync() error {
 
 	var err error
 
-	c.perfDataCollectorActiveSync, err = perfdata.NewCollector("MSExchange ActiveSync", perfdata.InstancesAll, counters)
+	c.perfDataCollectorActiveSync, err = pdh.NewCollector("MSExchange ActiveSync", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange ActiveSync collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_active_sync.go
+++ b/internal/collector/exchange/exchange_active_sync.go
@@ -38,7 +38,7 @@ func (c *Collector) buildActiveSync() error {
 
 	var err error
 
-	c.perfDataCollectorActiveSync, err = pdh.NewCollector("MSExchange ActiveSync", pdh.InstancesAll, counters)
+	c.perfDataCollectorActiveSync, err = pdh.NewCollector("MSExchange ActiveSync", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange ActiveSync collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_ad_access_processes.go
+++ b/internal/collector/exchange/exchange_ad_access_processes.go
@@ -42,7 +42,7 @@ func (c *Collector) buildADAccessProcesses() error {
 
 	var err error
 
-	c.perfDataCollectorADAccessProcesses, err = pdh.NewCollector("MSExchange ADAccess Processes", pdh.InstancesAll, counters)
+	c.perfDataCollectorADAccessProcesses, err = pdh.NewCollector("MSExchange ADAccess Processes", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange ADAccess Processes collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_ad_access_processes.go
+++ b/internal/collector/exchange/exchange_ad_access_processes.go
@@ -18,7 +18,7 @@ package exchange
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -42,7 +42,7 @@ func (c *Collector) buildADAccessProcesses() error {
 
 	var err error
 
-	c.perfDataCollectorADAccessProcesses, err = perfdata.NewCollector("MSExchange ADAccess Processes", perfdata.InstancesAll, counters)
+	c.perfDataCollectorADAccessProcesses, err = pdh.NewCollector("MSExchange ADAccess Processes", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange ADAccess Processes collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_autodiscover.go
+++ b/internal/collector/exchange/exchange_autodiscover.go
@@ -30,7 +30,7 @@ func (c *Collector) buildAutoDiscover() error {
 
 	var err error
 
-	c.perfDataCollectorAutoDiscover, err = pdh.NewCollector("MSExchange Autodiscover", pdh.InstancesAll, counters)
+	c.perfDataCollectorAutoDiscover, err = pdh.NewCollector("MSExchange Autodiscover", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange Autodiscover collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_autodiscover.go
+++ b/internal/collector/exchange/exchange_autodiscover.go
@@ -18,7 +18,7 @@ package exchange
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -30,7 +30,7 @@ func (c *Collector) buildAutoDiscover() error {
 
 	var err error
 
-	c.perfDataCollectorAutoDiscover, err = perfdata.NewCollector("MSExchange Autodiscover", perfdata.InstancesAll, counters)
+	c.perfDataCollectorAutoDiscover, err = pdh.NewCollector("MSExchange Autodiscover", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange Autodiscover collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_availability_service.go
+++ b/internal/collector/exchange/exchange_availability_service.go
@@ -18,7 +18,7 @@ package exchange
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -30,7 +30,7 @@ func (c *Collector) buildAvailabilityService() error {
 
 	var err error
 
-	c.perfDataCollectorAvailabilityService, err = perfdata.NewCollector("MSExchange Availability Service", perfdata.InstancesAll, counters)
+	c.perfDataCollectorAvailabilityService, err = pdh.NewCollector("MSExchange Availability Service", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange Availability Service collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_availability_service.go
+++ b/internal/collector/exchange/exchange_availability_service.go
@@ -30,7 +30,7 @@ func (c *Collector) buildAvailabilityService() error {
 
 	var err error
 
-	c.perfDataCollectorAvailabilityService, err = pdh.NewCollector("MSExchange Availability Service", pdh.InstancesAll, counters)
+	c.perfDataCollectorAvailabilityService, err = pdh.NewCollector("MSExchange Availability Service", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange Availability Service collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_http_proxy.go
+++ b/internal/collector/exchange/exchange_http_proxy.go
@@ -18,7 +18,7 @@ package exchange
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -44,7 +44,7 @@ func (c *Collector) buildHTTPProxy() error {
 
 	var err error
 
-	c.perfDataCollectorHttpProxy, err = perfdata.NewCollector("MSExchange HttpProxy", perfdata.InstancesAll, counters)
+	c.perfDataCollectorHttpProxy, err = pdh.NewCollector("MSExchange HttpProxy", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange HttpProxy collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_http_proxy.go
+++ b/internal/collector/exchange/exchange_http_proxy.go
@@ -44,7 +44,7 @@ func (c *Collector) buildHTTPProxy() error {
 
 	var err error
 
-	c.perfDataCollectorHttpProxy, err = pdh.NewCollector("MSExchange HttpProxy", pdh.InstancesAll, counters)
+	c.perfDataCollectorHttpProxy, err = pdh.NewCollector("MSExchange HttpProxy", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange HttpProxy collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_mapi_http_emsmdb.go
+++ b/internal/collector/exchange/exchange_mapi_http_emsmdb.go
@@ -34,7 +34,7 @@ func (c *Collector) buildMapiHttpEmsmdb() error {
 
 	var err error
 
-	c.perfDataCollectorMapiHttpEmsmdb, err = pdh.NewCollector("MSExchange MapiHttp Emsmdb", pdh.InstancesAll, counters)
+	c.perfDataCollectorMapiHttpEmsmdb, err = pdh.NewCollector("MSExchange MapiHttp Emsmdb", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange MapiHttp Emsmdb: %w", err)
 	}

--- a/internal/collector/exchange/exchange_mapi_http_emsmdb.go
+++ b/internal/collector/exchange/exchange_mapi_http_emsmdb.go
@@ -18,7 +18,7 @@ package exchange
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -34,7 +34,7 @@ func (c *Collector) buildMapiHttpEmsmdb() error {
 
 	var err error
 
-	c.perfDataCollectorMapiHttpEmsmdb, err = perfdata.NewCollector("MSExchange MapiHttp Emsmdb", perfdata.InstancesAll, counters)
+	c.perfDataCollectorMapiHttpEmsmdb, err = pdh.NewCollector("MSExchange MapiHttp Emsmdb", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange MapiHttp Emsmdb: %w", err)
 	}

--- a/internal/collector/exchange/exchange_outlook_web_access.go
+++ b/internal/collector/exchange/exchange_outlook_web_access.go
@@ -18,7 +18,7 @@ package exchange
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -36,7 +36,7 @@ func (c *Collector) buildOWA() error {
 
 	var err error
 
-	c.perfDataCollectorOWA, err = perfdata.NewCollector("MSExchange OWA", perfdata.InstancesAll, counters)
+	c.perfDataCollectorOWA, err = pdh.NewCollector("MSExchange OWA", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange OWA collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_outlook_web_access.go
+++ b/internal/collector/exchange/exchange_outlook_web_access.go
@@ -36,7 +36,7 @@ func (c *Collector) buildOWA() error {
 
 	var err error
 
-	c.perfDataCollectorOWA, err = pdh.NewCollector("MSExchange OWA", pdh.InstancesAll, counters)
+	c.perfDataCollectorOWA, err = pdh.NewCollector("MSExchange OWA", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange OWA collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_rpc_client_access.go
+++ b/internal/collector/exchange/exchange_rpc_client_access.go
@@ -44,7 +44,7 @@ func (c *Collector) buildRPC() error {
 
 	var err error
 
-	c.perfDataCollectorRpcClientAccess, err = pdh.NewCollector("MSExchange RpcClientAccess", pdh.InstancesAll, counters)
+	c.perfDataCollectorRpcClientAccess, err = pdh.NewCollector("MSExchange RpcClientAccess", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange RpcClientAccess collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_rpc_client_access.go
+++ b/internal/collector/exchange/exchange_rpc_client_access.go
@@ -18,7 +18,7 @@ package exchange
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -44,7 +44,7 @@ func (c *Collector) buildRPC() error {
 
 	var err error
 
-	c.perfDataCollectorRpcClientAccess, err = perfdata.NewCollector("MSExchange RpcClientAccess", perfdata.InstancesAll, counters)
+	c.perfDataCollectorRpcClientAccess, err = pdh.NewCollector("MSExchange RpcClientAccess", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange RpcClientAccess collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_transport_queues.go
+++ b/internal/collector/exchange/exchange_transport_queues.go
@@ -70,7 +70,7 @@ func (c *Collector) buildTransportQueues() error {
 
 	var err error
 
-	c.perfDataCollectorTransportQueues, err = pdh.NewCollector("MSExchangeTransport Queues", pdh.InstancesAll, counters)
+	c.perfDataCollectorTransportQueues, err = pdh.NewCollector("MSExchangeTransport Queues", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchangeTransport Queues collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_transport_queues.go
+++ b/internal/collector/exchange/exchange_transport_queues.go
@@ -18,7 +18,7 @@ package exchange
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -70,7 +70,7 @@ func (c *Collector) buildTransportQueues() error {
 
 	var err error
 
-	c.perfDataCollectorTransportQueues, err = perfdata.NewCollector("MSExchangeTransport Queues", perfdata.InstancesAll, counters)
+	c.perfDataCollectorTransportQueues, err = pdh.NewCollector("MSExchangeTransport Queues", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchangeTransport Queues collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_workload_management.go
+++ b/internal/collector/exchange/exchange_workload_management.go
@@ -18,7 +18,7 @@ package exchange
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -42,7 +42,7 @@ func (c *Collector) buildWorkloadManagementWorkloads() error {
 
 	var err error
 
-	c.perfDataCollectorWorkloadManagementWorkloads, err = perfdata.NewCollector("MSExchange WorkloadManagement Workloads", perfdata.InstancesAll, counters)
+	c.perfDataCollectorWorkloadManagementWorkloads, err = pdh.NewCollector("MSExchange WorkloadManagement Workloads", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange WorkloadManagement Workloads collector: %w", err)
 	}

--- a/internal/collector/exchange/exchange_workload_management.go
+++ b/internal/collector/exchange/exchange_workload_management.go
@@ -42,7 +42,7 @@ func (c *Collector) buildWorkloadManagementWorkloads() error {
 
 	var err error
 
-	c.perfDataCollectorWorkloadManagementWorkloads, err = pdh.NewCollector("MSExchange WorkloadManagement Workloads", pdh.InstancesAll, counters)
+	c.perfDataCollectorWorkloadManagementWorkloads, err = pdh.NewCollector("MSExchange WorkloadManagement Workloads", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create MSExchange WorkloadManagement Workloads collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_datastore.go
+++ b/internal/collector/hyperv/hyperv_datastore.go
@@ -175,7 +175,7 @@ func (c *Collector) buildDataStore() error {
 		dataStoreQuerySizeOperationCount,
 		dataStoreSetOperationLatencyMicro,
 		dataStoreSetOperationCount,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V DataStore collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_datastore.go
+++ b/internal/collector/hyperv/hyperv_datastore.go
@@ -18,14 +18,14 @@ package hyperv
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // collectorDataStore Hyper-V DataStore metrics
 type collectorDataStore struct {
-	perfDataCollectorDataStore *perfdata.Collector
+	perfDataCollectorDataStore *pdh.Collector
 
 	dataStoreFragmentationRatio          *prometheus.Desc // \Hyper-V DataStore(*)\Fragmentation ratio
 	dataStoreSectorSize                  *prometheus.Desc // \Hyper-V DataStore(*)\Sector size
@@ -128,7 +128,7 @@ const (
 func (c *Collector) buildDataStore() error {
 	var err error
 
-	c.perfDataCollectorDataStore, err = perfdata.NewCollector("Hyper-V DataStore", perfdata.InstancesAll, []string{
+	c.perfDataCollectorDataStore, err = pdh.NewCollector("Hyper-V DataStore", pdh.InstancesAll, []string{
 		dataStoreFragmentationRatio,
 		dataStoreSectorSize,
 		dataStoreDataAlignment,

--- a/internal/collector/hyperv/hyperv_dynamic_memory_balancer.go
+++ b/internal/collector/hyperv/hyperv_dynamic_memory_balancer.go
@@ -50,7 +50,7 @@ func (c *Collector) buildDynamicMemoryBalancer() error {
 		vmDynamicMemoryBalancerAvailableMemoryForBalancing,
 		vmDynamicMemoryBalancerAveragePressure,
 		vmDynamicMemoryBalancerSystemCurrentPressure,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Virtual Machine Health Summary collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_dynamic_memory_balancer.go
+++ b/internal/collector/hyperv/hyperv_dynamic_memory_balancer.go
@@ -18,7 +18,7 @@ package hyperv
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,7 +26,7 @@ import (
 
 // collectorDynamicMemoryBalancer Hyper-V Dynamic Memory Balancer metrics
 type collectorDynamicMemoryBalancer struct {
-	perfDataCollectorDynamicMemoryBalancer             *perfdata.Collector
+	perfDataCollectorDynamicMemoryBalancer             *pdh.Collector
 	vmDynamicMemoryBalancerAvailableMemoryForBalancing *prometheus.Desc // \Hyper-V Dynamic Memory Balancer(*)\Available Memory For Balancing
 	vmDynamicMemoryBalancerSystemCurrentPressure       *prometheus.Desc // \Hyper-V Dynamic Memory Balancer(*)\System Current Pressure
 	vmDynamicMemoryBalancerAvailableMemory             *prometheus.Desc // \Hyper-V Dynamic Memory Balancer(*)\Available Memory
@@ -45,7 +45,7 @@ func (c *Collector) buildDynamicMemoryBalancer() error {
 	var err error
 
 	// https://learn.microsoft.com/en-us/archive/blogs/chrisavis/monitoring-dynamic-memory-in-windows-server-hyper-v-2012
-	c.perfDataCollectorDynamicMemoryBalancer, err = perfdata.NewCollector("Hyper-V Dynamic Memory Balancer", perfdata.InstancesAll, []string{
+	c.perfDataCollectorDynamicMemoryBalancer, err = pdh.NewCollector("Hyper-V Dynamic Memory Balancer", pdh.InstancesAll, []string{
 		vmDynamicMemoryBalancerAvailableMemory,
 		vmDynamicMemoryBalancerAvailableMemoryForBalancing,
 		vmDynamicMemoryBalancerAveragePressure,

--- a/internal/collector/hyperv/hyperv_dynamic_memory_vm.go
+++ b/internal/collector/hyperv/hyperv_dynamic_memory_vm.go
@@ -18,7 +18,7 @@ package hyperv
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,7 +26,7 @@ import (
 
 // collectorDynamicMemoryVM Hyper-V Dynamic Memory VM metrics
 type collectorDynamicMemoryVM struct {
-	perfDataCollectorDynamicMemoryVM   *perfdata.Collector
+	perfDataCollectorDynamicMemoryVM   *pdh.Collector
 	vmMemoryAddedMemory                *prometheus.Desc // \Hyper-V Dynamic Memory VM(*)\Added Memory
 	vmMemoryCurrentPressure            *prometheus.Desc // \Hyper-V Dynamic Memory VM(*)\Current Pressure
 	vmMemoryGuestVisiblePhysicalMemory *prometheus.Desc // \Hyper-V Dynamic Memory VM(*)\Guest Visible Physical Memory
@@ -56,7 +56,7 @@ const (
 func (c *Collector) buildDynamicMemoryVM() error {
 	var err error
 
-	c.perfDataCollectorDynamicMemoryVM, err = perfdata.NewCollector("Hyper-V Dynamic Memory VM", perfdata.InstancesAll, []string{
+	c.perfDataCollectorDynamicMemoryVM, err = pdh.NewCollector("Hyper-V Dynamic Memory VM", pdh.InstancesAll, []string{
 		vmMemoryAddedMemory,
 		vmMemoryCurrentPressure,
 		vmMemoryGuestVisiblePhysicalMemory,

--- a/internal/collector/hyperv/hyperv_dynamic_memory_vm.go
+++ b/internal/collector/hyperv/hyperv_dynamic_memory_vm.go
@@ -67,7 +67,7 @@ func (c *Collector) buildDynamicMemoryVM() error {
 		vmMemoryPhysicalMemory,
 		vmMemoryRemovedMemory,
 		vmMemoryGuestAvailableMemory,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Dynamic Memory VM collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_hypervisor_logical_processor.go
+++ b/internal/collector/hyperv/hyperv_hypervisor_logical_processor.go
@@ -53,7 +53,7 @@ func (c *Collector) buildHypervisorLogicalProcessor() error {
 		hypervisorLogicalProcessorTotalRunTimePercent,
 		hypervisorLogicalProcessorIdleRunTimePercent,
 		hypervisorLogicalProcessorContextSwitches,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Hypervisor Logical Processor collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_hypervisor_logical_processor.go
+++ b/internal/collector/hyperv/hyperv_hypervisor_logical_processor.go
@@ -19,14 +19,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // collectorHypervisorLogicalProcessor Hyper-V Hypervisor Logical Processor metrics
 type collectorHypervisorLogicalProcessor struct {
-	perfDataCollectorHypervisorLogicalProcessor *perfdata.Collector
+	perfDataCollectorHypervisorLogicalProcessor *pdh.Collector
 
 	// \Hyper-V Hypervisor Logical Processor(*)\% Guest Run Time
 	// \Hyper-V Hypervisor Logical Processor(*)\% Hypervisor Run Time
@@ -47,7 +47,7 @@ const (
 func (c *Collector) buildHypervisorLogicalProcessor() error {
 	var err error
 
-	c.perfDataCollectorHypervisorLogicalProcessor, err = perfdata.NewCollector("Hyper-V Hypervisor Logical Processor", perfdata.InstancesAll, []string{
+	c.perfDataCollectorHypervisorLogicalProcessor, err = pdh.NewCollector("Hyper-V Hypervisor Logical Processor", pdh.InstancesAll, []string{
 		hypervisorLogicalProcessorGuestRunTimePercent,
 		hypervisorLogicalProcessorHypervisorRunTimePercent,
 		hypervisorLogicalProcessorTotalRunTimePercent,

--- a/internal/collector/hyperv/hyperv_hypervisor_root_partition.go
+++ b/internal/collector/hyperv/hyperv_hypervisor_root_partition.go
@@ -99,7 +99,7 @@ func (c *Collector) buildHypervisorRootPartition() error {
 		hypervisorRootPartition4KGPAPages,
 		hypervisorRootPartitionVirtualTLBFlushEntries,
 		hypervisorRootPartitionVirtualTLBPages,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Hypervisor Root Partition collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_hypervisor_root_partition.go
+++ b/internal/collector/hyperv/hyperv_hypervisor_root_partition.go
@@ -19,14 +19,14 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // collectorHypervisorRootPartition Hyper-V Hypervisor Root Partition metrics
 type collectorHypervisorRootPartition struct {
-	perfDataCollectorHypervisorRootPartition             *perfdata.Collector
+	perfDataCollectorHypervisorRootPartition             *pdh.Collector
 	hypervisorRootPartitionAddressSpaces                 *prometheus.Desc // \Hyper-V Hypervisor Root Partition(*)\Address Spaces
 	hypervisorRootPartitionAttachedDevices               *prometheus.Desc // \Hyper-V Hypervisor Root Partition(*)\Attached Devices
 	hypervisorRootPartitionDepositedPages                *prometheus.Desc // \Hyper-V Hypervisor Root Partition(*)\Deposited Pages
@@ -77,7 +77,7 @@ const (
 func (c *Collector) buildHypervisorRootPartition() error {
 	var err error
 
-	c.perfDataCollectorHypervisorRootPartition, err = perfdata.NewCollector("Hyper-V Hypervisor Root Partition", []string{"Root"}, []string{
+	c.perfDataCollectorHypervisorRootPartition, err = pdh.NewCollector("Hyper-V Hypervisor Root Partition", []string{"Root"}, []string{
 		hypervisorRootPartitionAddressSpaces,
 		hypervisorRootPartitionAttachedDevices,
 		hypervisorRootPartitionDepositedPages,

--- a/internal/collector/hyperv/hyperv_hypervisor_root_virtual_processor.go
+++ b/internal/collector/hyperv/hyperv_hypervisor_root_virtual_processor.go
@@ -54,7 +54,7 @@ func (c *Collector) buildHypervisorRootVirtualProcessor() error {
 		hypervisorRootVirtualProcessorTotalRunTimePercent,
 		hypervisorRootVirtualProcessorRemoteRunTimePercent,
 		hypervisorRootVirtualProcessorCPUWaitTimePerDispatch,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Hypervisor Root Virtual Processor collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_hypervisor_root_virtual_processor.go
+++ b/internal/collector/hyperv/hyperv_hypervisor_root_virtual_processor.go
@@ -19,14 +19,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // collectorHypervisorRootVirtualProcessor Hyper-V Hypervisor Root Virtual Processor metrics
 type collectorHypervisorRootVirtualProcessor struct {
-	perfDataCollectorHypervisorRootVirtualProcessor *perfdata.Collector
+	perfDataCollectorHypervisorRootVirtualProcessor *pdh.Collector
 
 	// \Hyper-V Hypervisor Root Virtual Processor(*)\% Guest Run Time
 	// \Hyper-V Hypervisor Root Virtual Processor(*)\% Hypervisor Run Time
@@ -48,7 +48,7 @@ const (
 func (c *Collector) buildHypervisorRootVirtualProcessor() error {
 	var err error
 
-	c.perfDataCollectorHypervisorRootVirtualProcessor, err = perfdata.NewCollector("Hyper-V Hypervisor Root Virtual Processor", perfdata.InstancesAll, []string{
+	c.perfDataCollectorHypervisorRootVirtualProcessor, err = pdh.NewCollector("Hyper-V Hypervisor Root Virtual Processor", pdh.InstancesAll, []string{
 		hypervisorRootVirtualProcessorGuestRunTimePercent,
 		hypervisorRootVirtualProcessorHypervisorRunTimePercent,
 		hypervisorRootVirtualProcessorTotalRunTimePercent,

--- a/internal/collector/hyperv/hyperv_hypervisor_virtual_processor.go
+++ b/internal/collector/hyperv/hyperv_hypervisor_virtual_processor.go
@@ -53,7 +53,7 @@ func (c *Collector) buildHypervisorVirtualProcessor() error {
 		hypervisorVirtualProcessorTotalRunTimePercent,
 		hypervisorVirtualProcessorRemoteRunTimePercent,
 		hypervisorVirtualProcessorCPUWaitTimePerDispatch,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Hypervisor Virtual Processor collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_hypervisor_virtual_processor.go
+++ b/internal/collector/hyperv/hyperv_hypervisor_virtual_processor.go
@@ -19,14 +19,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // collectorHypervisorVirtualProcessor Hyper-V Hypervisor Virtual Processor metrics
 type collectorHypervisorVirtualProcessor struct {
-	perfDataCollectorHypervisorVirtualProcessor *perfdata.Collector
+	perfDataCollectorHypervisorVirtualProcessor *pdh.Collector
 
 	// \Hyper-V Hypervisor Virtual Processor(*)\% Guest Run Time
 	// \Hyper-V Hypervisor Virtual Processor(*)\% Hypervisor Run Time
@@ -47,7 +47,7 @@ const (
 func (c *Collector) buildHypervisorVirtualProcessor() error {
 	var err error
 
-	c.perfDataCollectorHypervisorVirtualProcessor, err = perfdata.NewCollector("Hyper-V Hypervisor Virtual Processor", perfdata.InstancesAll, []string{
+	c.perfDataCollectorHypervisorVirtualProcessor, err = pdh.NewCollector("Hyper-V Hypervisor Virtual Processor", pdh.InstancesAll, []string{
 		hypervisorVirtualProcessorGuestIdleTimePercent,
 		hypervisorVirtualProcessorHypervisorRunTimePercent,
 		hypervisorVirtualProcessorTotalRunTimePercent,

--- a/internal/collector/hyperv/hyperv_legacy_network_adapter.go
+++ b/internal/collector/hyperv/hyperv_legacy_network_adapter.go
@@ -18,14 +18,14 @@ package hyperv
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // collectorLegacyNetworkAdapter Hyper-V Legacy Network Adapter metrics
 type collectorLegacyNetworkAdapter struct {
-	perfDataCollectorLegacyNetworkAdapter *perfdata.Collector
+	perfDataCollectorLegacyNetworkAdapter *pdh.Collector
 
 	legacyNetworkAdapterBytesDropped   *prometheus.Desc // \Hyper-V Legacy Network Adapter(*)\Bytes Dropped
 	legacyNetworkAdapterBytesReceived  *prometheus.Desc // \Hyper-V Legacy Network Adapter(*)\Bytes Received/sec
@@ -47,7 +47,7 @@ const (
 func (c *Collector) buildLegacyNetworkAdapter() error {
 	var err error
 
-	c.perfDataCollectorLegacyNetworkAdapter, err = perfdata.NewCollector("Hyper-V Legacy Network Adapter", perfdata.InstancesAll, []string{
+	c.perfDataCollectorLegacyNetworkAdapter, err = pdh.NewCollector("Hyper-V Legacy Network Adapter", pdh.InstancesAll, []string{
 		legacyNetworkAdapterBytesDropped,
 		legacyNetworkAdapterBytesReceived,
 		legacyNetworkAdapterBytesSent,

--- a/internal/collector/hyperv/hyperv_legacy_network_adapter.go
+++ b/internal/collector/hyperv/hyperv_legacy_network_adapter.go
@@ -54,7 +54,7 @@ func (c *Collector) buildLegacyNetworkAdapter() error {
 		legacyNetworkAdapterFramesDropped,
 		legacyNetworkAdapterFramesReceived,
 		legacyNetworkAdapterFramesSent,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Legacy Network Adapter collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_virtual_machine_health_summary.go
+++ b/internal/collector/hyperv/hyperv_virtual_machine_health_summary.go
@@ -45,7 +45,7 @@ func (c *Collector) buildVirtualMachineHealthSummary() error {
 	c.perfDataCollectorVirtualMachineHealthSummary, err = pdh.NewCollector("Hyper-V Virtual Machine Health Summary", nil, []string{
 		healthCritical,
 		healthOk,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Virtual Machine Health Summary collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_virtual_machine_health_summary.go
+++ b/internal/collector/hyperv/hyperv_virtual_machine_health_summary.go
@@ -19,14 +19,14 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // collectorVirtualMachineHealthSummary Hyper-V Virtual Machine Health Summary metrics
 type collectorVirtualMachineHealthSummary struct {
-	perfDataCollectorVirtualMachineHealthSummary *perfdata.Collector
+	perfDataCollectorVirtualMachineHealthSummary *pdh.Collector
 
 	// \Hyper-V Virtual Machine Health Summary\Health Critical
 	// \Hyper-V Virtual Machine Health Summary\Health Ok
@@ -42,7 +42,7 @@ const (
 func (c *Collector) buildVirtualMachineHealthSummary() error {
 	var err error
 
-	c.perfDataCollectorVirtualMachineHealthSummary, err = perfdata.NewCollector("Hyper-V Virtual Machine Health Summary", nil, []string{
+	c.perfDataCollectorVirtualMachineHealthSummary, err = pdh.NewCollector("Hyper-V Virtual Machine Health Summary", nil, []string{
 		healthCritical,
 		healthOk,
 	})
@@ -66,7 +66,7 @@ func (c *Collector) collectVirtualMachineHealthSummary(ch chan<- prometheus.Metr
 		return fmt.Errorf("failed to collect Hyper-V Virtual Machine Health Summary metrics: %w", err)
 	}
 
-	healthData, ok := data[perfdata.InstanceEmpty]
+	healthData, ok := data[pdh.InstanceEmpty]
 	if !ok {
 		return errors.New("no data returned for Hyper-V Virtual Machine Health Summary")
 	}

--- a/internal/collector/hyperv/hyperv_virtual_machine_vid_partition.go
+++ b/internal/collector/hyperv/hyperv_virtual_machine_vid_partition.go
@@ -44,7 +44,7 @@ func (c *Collector) buildVirtualMachineVidPartition() error {
 		physicalPagesAllocated,
 		preferredNUMANodeIndex,
 		remotePhysicalPages,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V VM Vid Partition collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_virtual_machine_vid_partition.go
+++ b/internal/collector/hyperv/hyperv_virtual_machine_vid_partition.go
@@ -18,14 +18,14 @@ package hyperv
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // collectorVirtualMachineVidPartition Hyper-V VM Vid Partition metrics
 type collectorVirtualMachineVidPartition struct {
-	perfDataCollectorVirtualMachineVidPartition *perfdata.Collector
+	perfDataCollectorVirtualMachineVidPartition *pdh.Collector
 	physicalPagesAllocated                      *prometheus.Desc // \Hyper-V VM Vid Partition(*)\Physical Pages Allocated
 	preferredNUMANodeIndex                      *prometheus.Desc // \Hyper-V VM Vid Partition(*)\Preferred NUMA Node Index
 	remotePhysicalPages                         *prometheus.Desc // \Hyper-V VM Vid Partition(*)\Remote Physical Pages
@@ -40,7 +40,7 @@ const (
 func (c *Collector) buildVirtualMachineVidPartition() error {
 	var err error
 
-	c.perfDataCollectorVirtualMachineVidPartition, err = perfdata.NewCollector("Hyper-V VM Vid Partition", perfdata.InstancesAll, []string{
+	c.perfDataCollectorVirtualMachineVidPartition, err = pdh.NewCollector("Hyper-V VM Vid Partition", pdh.InstancesAll, []string{
 		physicalPagesAllocated,
 		preferredNUMANodeIndex,
 		remotePhysicalPages,

--- a/internal/collector/hyperv/hyperv_virtual_network_adapter.go
+++ b/internal/collector/hyperv/hyperv_virtual_network_adapter.go
@@ -54,7 +54,7 @@ func (c *Collector) buildVirtualNetworkAdapter() error {
 		virtualNetworkAdapterDroppedPacketsOutgoing,
 		virtualNetworkAdapterPacketsReceived,
 		virtualNetworkAdapterPacketsSent,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Virtual Network Adapter collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_virtual_network_adapter.go
+++ b/internal/collector/hyperv/hyperv_virtual_network_adapter.go
@@ -18,14 +18,14 @@ package hyperv
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // collectorVirtualNetworkAdapter Hyper-V Virtual Network Adapter metrics
 type collectorVirtualNetworkAdapter struct {
-	perfDataCollectorVirtualNetworkAdapter *perfdata.Collector
+	perfDataCollectorVirtualNetworkAdapter *pdh.Collector
 
 	virtualNetworkAdapterBytesReceived          *prometheus.Desc // \Hyper-V Virtual Network Adapter(*)\Bytes Received/sec
 	virtualNetworkAdapterBytesSent              *prometheus.Desc // \Hyper-V Virtual Network Adapter(*)\Bytes Sent/sec
@@ -47,7 +47,7 @@ const (
 func (c *Collector) buildVirtualNetworkAdapter() error {
 	var err error
 
-	c.perfDataCollectorVirtualNetworkAdapter, err = perfdata.NewCollector("Hyper-V Virtual Network Adapter", perfdata.InstancesAll, []string{
+	c.perfDataCollectorVirtualNetworkAdapter, err = pdh.NewCollector("Hyper-V Virtual Network Adapter", pdh.InstancesAll, []string{
 		virtualNetworkAdapterBytesReceived,
 		virtualNetworkAdapterBytesSent,
 		virtualNetworkAdapterDroppedPacketsIncoming,

--- a/internal/collector/hyperv/hyperv_virtual_network_adapter_drop_reasons.go
+++ b/internal/collector/hyperv/hyperv_virtual_network_adapter_drop_reasons.go
@@ -213,7 +213,7 @@ func (c *Collector) buildVirtualNetworkAdapterDropReasons() error {
 		virtualNetworkAdapterDropReasonsIncomingInvalidData,
 		virtualNetworkAdapterDropReasonsOutgoingUnknown,
 		virtualNetworkAdapterDropReasonsIncomingUnknown,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Virtual Network Adapter Drop Reasons collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_virtual_network_adapter_drop_reasons.go
+++ b/internal/collector/hyperv/hyperv_virtual_network_adapter_drop_reasons.go
@@ -18,14 +18,14 @@ package hyperv
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // collectorVirtualNetworkAdapterDropReasons Hyper-V Virtual Network Adapter Drop Reasons metrics
 type collectorVirtualNetworkAdapterDropReasons struct {
-	perfDataCollectorVirtualNetworkAdapterDropReasons *perfdata.Collector
+	perfDataCollectorVirtualNetworkAdapterDropReasons *pdh.Collector
 
 	// \Hyper-V Virtual Network Adapter Drop Reasons(*)\Outgoing LowPowerPacketFilter
 	// \Hyper-V Virtual Network Adapter Drop Reasons(*)\Incoming LowPowerPacketFilter
@@ -162,7 +162,7 @@ const (
 func (c *Collector) buildVirtualNetworkAdapterDropReasons() error {
 	var err error
 
-	c.perfDataCollectorVirtualNetworkAdapterDropReasons, err = perfdata.NewCollector("Hyper-V Virtual Network Adapter Drop Reasons", perfdata.InstancesAll, []string{
+	c.perfDataCollectorVirtualNetworkAdapterDropReasons, err = pdh.NewCollector("Hyper-V Virtual Network Adapter Drop Reasons", pdh.InstancesAll, []string{
 		virtualNetworkAdapterDropReasonsOutgoingNativeFwdingReq,
 		virtualNetworkAdapterDropReasonsIncomingNativeFwdingReq,
 		virtualNetworkAdapterDropReasonsOutgoingMTUMismatch,

--- a/internal/collector/hyperv/hyperv_virtual_smb.go
+++ b/internal/collector/hyperv/hyperv_virtual_smb.go
@@ -18,14 +18,14 @@ package hyperv
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // collectorVirtualSMB Hyper-V Virtual SMB metrics
 type collectorVirtualSMB struct {
-	perfDataCollectorVirtualSMB *perfdata.Collector
+	perfDataCollectorVirtualSMB *pdh.Collector
 
 	virtualSMBDirectMappedSections   *prometheus.Desc // \Hyper-V Virtual SMB(*)\Direct-Mapped Sections
 	virtualSMBDirectMappedPages      *prometheus.Desc // \Hyper-V Virtual SMB(*)\Direct-Mapped Pages
@@ -69,7 +69,7 @@ const (
 func (c *Collector) buildVirtualSMB() error {
 	var err error
 
-	c.perfDataCollectorVirtualSMB, err = perfdata.NewCollector("Hyper-V Virtual SMB", perfdata.InstancesAll, []string{
+	c.perfDataCollectorVirtualSMB, err = pdh.NewCollector("Hyper-V Virtual SMB", pdh.InstancesAll, []string{
 		virtualSMBDirectMappedSections,
 		virtualSMBDirectMappedPages,
 		virtualSMBWriteBytesRDMA,

--- a/internal/collector/hyperv/hyperv_virtual_smb.go
+++ b/internal/collector/hyperv/hyperv_virtual_smb.go
@@ -87,7 +87,7 @@ func (c *Collector) buildVirtualSMB() error {
 		virtualSMBRequests,
 		virtualSMBSentBytes,
 		virtualSMBReceivedBytes,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Virtual SMB collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_virtual_storage_device.go
+++ b/internal/collector/hyperv/hyperv_virtual_storage_device.go
@@ -18,14 +18,14 @@ package hyperv
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Hyper-V Virtual Storage Device metrics
 type collectorVirtualStorageDevice struct {
-	perfDataCollectorVirtualStorageDevice *perfdata.Collector
+	perfDataCollectorVirtualStorageDevice *pdh.Collector
 
 	virtualStorageDeviceErrorCount               *prometheus.Desc // \Hyper-V Virtual Storage Device(*)\Error Count
 	virtualStorageDeviceQueueLength              *prometheus.Desc // \Hyper-V Virtual Storage Device(*)\Queue Length
@@ -59,7 +59,7 @@ const (
 func (c *Collector) buildVirtualStorageDevice() error {
 	var err error
 
-	c.perfDataCollectorVirtualStorageDevice, err = perfdata.NewCollector("Hyper-V Virtual Storage Device", perfdata.InstancesAll, []string{
+	c.perfDataCollectorVirtualStorageDevice, err = pdh.NewCollector("Hyper-V Virtual Storage Device", pdh.InstancesAll, []string{
 		virtualStorageDeviceErrorCount,
 		virtualStorageDeviceQueueLength,
 		virtualStorageDeviceReadBytes,

--- a/internal/collector/hyperv/hyperv_virtual_storage_device.go
+++ b/internal/collector/hyperv/hyperv_virtual_storage_device.go
@@ -72,7 +72,7 @@ func (c *Collector) buildVirtualStorageDevice() error {
 		virtualStorageDeviceLowerQueueLength,
 		virtualStorageDeviceLowerLatency,
 		virtualStorageDeviceIOQuotaReplenishmentRate,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Virtual Storage Device collector: %w", err)
 	}

--- a/internal/collector/hyperv/hyperv_virtual_switch.go
+++ b/internal/collector/hyperv/hyperv_virtual_switch.go
@@ -18,14 +18,14 @@ package hyperv
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // collectorVirtualMachineHealthSummary Hyper-V Virtual Switch Summary metrics
 type collectorVirtualSwitch struct {
-	perfDataCollectorVirtualSwitch                *perfdata.Collector
+	perfDataCollectorVirtualSwitch                *pdh.Collector
 	virtualSwitchBroadcastPacketsReceived         *prometheus.Desc // \Hyper-V Virtual Switch(*)\Broadcast Packets Received/sec
 	virtualSwitchBroadcastPacketsSent             *prometheus.Desc // \Hyper-V Virtual Switch(*)\Broadcast Packets Sent/sec
 	virtualSwitchBytes                            *prometheus.Desc // \Hyper-V Virtual Switch(*)\Bytes/sec
@@ -76,7 +76,7 @@ const (
 func (c *Collector) buildVirtualSwitch() error {
 	var err error
 
-	c.perfDataCollectorVirtualSwitch, err = perfdata.NewCollector("Hyper-V Virtual Switch", perfdata.InstancesAll, []string{
+	c.perfDataCollectorVirtualSwitch, err = pdh.NewCollector("Hyper-V Virtual Switch", pdh.InstancesAll, []string{
 		virtualSwitchBroadcastPacketsReceived,
 		virtualSwitchBroadcastPacketsSent,
 		virtualSwitchBytes,

--- a/internal/collector/hyperv/hyperv_virtual_switch.go
+++ b/internal/collector/hyperv/hyperv_virtual_switch.go
@@ -98,7 +98,7 @@ func (c *Collector) buildVirtualSwitch() error {
 		virtualSwitchPacketsReceived,
 		virtualSwitchPacketsSent,
 		virtualSwitchPurgedMacAddresses,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Hyper-V Virtual Switch collector: %w", err)
 	}

--- a/internal/collector/iis/iis.go
+++ b/internal/collector/iis/iis.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/windows/registry"
@@ -276,7 +276,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 // discarded, and "Site_B#2" would be kept and presented as "Site_B" in the
 // Collector metrics.
 // [ "Site_A", "Site_B", "Site_C", "Site_B#2" ].
-func deduplicateIISNames(counterValues map[string]map[string]perfdata.CounterValue) {
+func deduplicateIISNames(counterValues map[string]map[string]pdh.CounterValue) {
 	services := slices.Collect(maps.Keys(counterValues))
 
 	// Ensure IIS entry with the highest suffix occurs last

--- a/internal/collector/iis/iis_app_pool_was.go
+++ b/internal/collector/iis/iis_app_pool_was.go
@@ -85,7 +85,7 @@ func (c *Collector) buildAppPoolWAS() error {
 		TotalWorkerProcessPingFailures,
 		TotalWorkerProcessShutdownFailures,
 		TotalWorkerProcessStartupFailures,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create APP_POOL_WAS collector: %w", err)
 	}

--- a/internal/collector/iis/iis_app_pool_was.go
+++ b/internal/collector/iis/iis_app_pool_was.go
@@ -18,13 +18,13 @@ package iis
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type collectorAppPoolWAS struct {
-	perfDataCollectorAppPoolWAS *perfdata.Collector
+	perfDataCollectorAppPoolWAS *pdh.Collector
 
 	currentApplicationPoolState        *prometheus.Desc
 	currentApplicationPoolUptime       *prometheus.Desc
@@ -71,7 +71,7 @@ var applicationStates = map[uint32]string{
 func (c *Collector) buildAppPoolWAS() error {
 	var err error
 
-	c.perfDataCollectorAppPoolWAS, err = perfdata.NewCollector("APP_POOL_WAS", perfdata.InstancesAll, []string{
+	c.perfDataCollectorAppPoolWAS, err = pdh.NewCollector("APP_POOL_WAS", pdh.InstancesAll, []string{
 		CurrentApplicationPoolState,
 		CurrentApplicationPoolUptime,
 		CurrentWorkerProcesses,

--- a/internal/collector/iis/iis_w3svc_w3wp.go
+++ b/internal/collector/iis/iis_w3svc_w3wp.go
@@ -181,7 +181,7 @@ func (c *Collector) buildW3SVCW3WP() error {
 
 	var err error
 
-	c.w3SVCW3WPPerfDataCollector, err = pdh.NewCollector("W3SVC_W3WP", pdh.InstancesAll, counters)
+	c.w3SVCW3WPPerfDataCollector, err = pdh.NewCollector("W3SVC_W3WP", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create W3SVC_W3WP collector: %w", err)
 	}

--- a/internal/collector/iis/iis_w3svc_w3wp.go
+++ b/internal/collector/iis/iis_w3svc_w3wp.go
@@ -20,13 +20,13 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type collectorW3SVCW3WP struct {
-	w3SVCW3WPPerfDataCollector *perfdata.Collector
+	w3SVCW3WPPerfDataCollector *pdh.Collector
 
 	// W3SVC_W3WP
 	w3SVCW3WPThreads        *prometheus.Desc
@@ -181,7 +181,7 @@ func (c *Collector) buildW3SVCW3WP() error {
 
 	var err error
 
-	c.w3SVCW3WPPerfDataCollector, err = perfdata.NewCollector("W3SVC_W3WP", perfdata.InstancesAll, counters)
+	c.w3SVCW3WPPerfDataCollector, err = pdh.NewCollector("W3SVC_W3WP", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create W3SVC_W3WP collector: %w", err)
 	}

--- a/internal/collector/iis/iis_web_service.go
+++ b/internal/collector/iis/iis_web_service.go
@@ -18,13 +18,13 @@ package iis
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type collectorWebService struct {
-	perfDataCollectorWebService *perfdata.Collector
+	perfDataCollectorWebService *pdh.Collector
 
 	webServiceCurrentAnonymousUsers               *prometheus.Desc
 	webServiceCurrentBlockedAsyncIORequests       *prometheus.Desc
@@ -93,7 +93,7 @@ const (
 func (c *Collector) buildWebService() error {
 	var err error
 
-	c.perfDataCollectorWebService, err = perfdata.NewCollector("Web Service", perfdata.InstancesAll, []string{
+	c.perfDataCollectorWebService, err = pdh.NewCollector("Web Service", pdh.InstancesAll, []string{
 		webServiceCurrentAnonymousUsers,
 		webServiceCurrentBlockedAsyncIORequests,
 		webServiceCurrentCGIRequests,

--- a/internal/collector/iis/iis_web_service.go
+++ b/internal/collector/iis/iis_web_service.go
@@ -131,7 +131,7 @@ func (c *Collector) buildWebService() error {
 		webServiceTotalSearchRequests,
 		webServiceTotalTraceRequests,
 		webServiceTotalUnlockRequests,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Web Service collector: %w", err)
 	}

--- a/internal/collector/iis/iis_web_service_cache.go
+++ b/internal/collector/iis/iis_web_service_cache.go
@@ -18,13 +18,13 @@ package iis
 import (
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type collectorWebServiceCache struct {
-	serviceCachePerfDataCollector *perfdata.Collector
+	serviceCachePerfDataCollector *pdh.Collector
 
 	serviceCacheActiveFlushedEntries *prometheus.Desc
 
@@ -100,7 +100,7 @@ const (
 func (c *Collector) buildWebServiceCache() error {
 	var err error
 
-	c.serviceCachePerfDataCollector, err = perfdata.NewCollector("Web Service Cache", perfdata.InstancesAll, []string{
+	c.serviceCachePerfDataCollector, err = pdh.NewCollector("Web Service Cache", pdh.InstancesAll, []string{
 		serviceCacheActiveFlushedEntries,
 		serviceCacheCurrentFileCacheMemoryUsage,
 		serviceCacheMaximumFileCacheMemoryUsage,

--- a/internal/collector/iis/iis_web_service_cache.go
+++ b/internal/collector/iis/iis_web_service_cache.go
@@ -135,7 +135,7 @@ func (c *Collector) buildWebServiceCache() error {
 		serviceCacheOutputCacheMissesTotal,
 		serviceCacheOutputCacheFlushedItemsTotal,
 		serviceCacheOutputCacheFlushesTotal,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Web Service Cache collector: %w", err)
 	}

--- a/internal/collector/logical_disk/logical_disk.go
+++ b/internal/collector/logical_disk/logical_disk.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/windows"
@@ -51,7 +51,7 @@ type Collector struct {
 	config Config
 	logger *slog.Logger
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	avgReadQueue     *prometheus.Desc
 	avgWriteQueue    *prometheus.Desc
@@ -151,7 +151,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("LogicalDisk", perfdata.InstancesAll, []string{
+	c.perfDataCollector, err = pdh.NewCollector("LogicalDisk", pdh.InstancesAll, []string{
 		currentDiskQueueLength,
 		avgDiskReadQueueLength,
 		avgDiskWriteQueueLength,
@@ -352,14 +352,14 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(
 			c.avgReadQueue,
 			prometheus.GaugeValue,
-			volume[avgDiskReadQueueLength].FirstValue*perfdata.TicksToSecondScaleFactor,
+			volume[avgDiskReadQueueLength].FirstValue*pdh.TicksToSecondScaleFactor,
 			name,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.avgWriteQueue,
 			prometheus.GaugeValue,
-			volume[avgDiskWriteQueueLength].FirstValue*perfdata.TicksToSecondScaleFactor,
+			volume[avgDiskWriteQueueLength].FirstValue*pdh.TicksToSecondScaleFactor,
 			name,
 		)
 
@@ -436,21 +436,21 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(
 			c.readLatency,
 			prometheus.CounterValue,
-			volume[avgDiskSecPerRead].FirstValue*perfdata.TicksToSecondScaleFactor,
+			volume[avgDiskSecPerRead].FirstValue*pdh.TicksToSecondScaleFactor,
 			name,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.writeLatency,
 			prometheus.CounterValue,
-			volume[avgDiskSecPerWrite].FirstValue*perfdata.TicksToSecondScaleFactor,
+			volume[avgDiskSecPerWrite].FirstValue*pdh.TicksToSecondScaleFactor,
 			name,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.readWriteLatency,
 			prometheus.CounterValue,
-			volume[avgDiskSecPerTransfer].FirstValue*perfdata.TicksToSecondScaleFactor,
+			volume[avgDiskSecPerTransfer].FirstValue*pdh.TicksToSecondScaleFactor,
 			name,
 		)
 	}

--- a/internal/collector/logical_disk/logical_disk.go
+++ b/internal/collector/logical_disk/logical_disk.go
@@ -168,7 +168,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 		avgDiskSecPerRead,
 		avgDiskSecPerWrite,
 		avgDiskSecPerTransfer,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create LogicalDisk collector: %w", err)
 	}

--- a/internal/collector/memory/memory.go
+++ b/internal/collector/memory/memory.go
@@ -26,7 +26,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/headers/sysinfoapi"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -42,7 +42,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	// Performance metrics
 	availableBytes                  *prometheus.Desc
@@ -148,7 +148,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("Memory", perfdata.InstancesAll, counters)
+	c.perfDataCollector, err = pdh.NewCollector("Memory", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create Memory collector: %w", err)
 	}
@@ -428,7 +428,7 @@ func (c *Collector) collectPDH(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("failed to collect Memory metrics: %w", err)
 	}
 
-	data, ok := perfData[perfdata.InstanceEmpty]
+	data, ok := perfData[pdh.InstanceEmpty]
 
 	if !ok {
 		return fmt.Errorf("failed to collect Memory metrics: %w", types.ErrNoData)

--- a/internal/collector/memory/memory.go
+++ b/internal/collector/memory/memory.go
@@ -148,7 +148,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 	var err error
 
-	c.perfDataCollector, err = pdh.NewCollector("Memory", pdh.InstancesAll, counters)
+	c.perfDataCollector, err = pdh.NewCollector("Memory", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Memory collector: %w", err)
 	}

--- a/internal/collector/msmq/msmq.go
+++ b/internal/collector/msmq/msmq.go
@@ -80,7 +80,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		bytesInQueue,
 		messagesInJournalQueue,
 		messagesInQueue,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create MSMQ Queue collector: %w", err)
 	}

--- a/internal/collector/msmq/msmq.go
+++ b/internal/collector/msmq/msmq.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -36,7 +36,7 @@ var ConfigDefaults = Config{}
 // A Collector is a Prometheus Collector for WMI Win32_PerfRawData_MSMQ_MSMQQueue metrics.
 type Collector struct {
 	config            Config
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	bytesInJournalQueue    *prometheus.Desc
 	bytesInQueue           *prometheus.Desc
@@ -75,7 +75,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("MSMQ Queue", perfdata.InstancesAll, []string{
+	c.perfDataCollector, err = pdh.NewCollector("MSMQ Queue", pdh.InstancesAll, []string{
 		bytesInJournalQueue,
 		bytesInQueue,
 		messagesInJournalQueue,

--- a/internal/collector/mssql/mssql.go
+++ b/internal/collector/mssql/mssql.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/windows/registry"
@@ -273,7 +273,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 // to the provided prometheus Metric channel.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 	if len(c.mssqlInstances) == 0 {
-		return fmt.Errorf("no SQL instances found: %w", perfdata.ErrNoData)
+		return fmt.Errorf("no SQL instances found: %w", pdh.ErrNoData)
 	}
 
 	errCh := make(chan error, len(c.collectorFns))
@@ -368,8 +368,8 @@ func (c *Collector) mssqlGetPerfObjectName(sqlInstance string, collector string)
 func (c *Collector) collect(
 	ch chan<- prometheus.Metric,
 	collector string,
-	perfDataCollectors map[string]*perfdata.Collector,
-	collectFn func(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *perfdata.Collector) error,
+	perfDataCollectors map[string]*pdh.Collector,
+	collectFn func(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *pdh.Collector) error,
 ) error {
 	errs := make([]error, 0, len(perfDataCollectors))
 
@@ -379,7 +379,7 @@ func (c *Collector) collect(
 		err := collectFn(ch, sqlInstance, perfDataCollector)
 		duration := time.Since(begin)
 
-		if err != nil && !errors.Is(err, perfdata.ErrNoData) {
+		if err != nil && !errors.Is(err, pdh.ErrNoData) {
 			errs = append(errs, err)
 			success = 0.0
 

--- a/internal/collector/mssql/mssql_access_methods.go
+++ b/internal/collector/mssql/mssql_access_methods.go
@@ -173,7 +173,7 @@ func (c *Collector) buildAccessMethods() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.accessMethodsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Access Methods"), nil, counters)
+		c.accessMethodsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Access Methods"), nil, counters, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create AccessMethods collector for instance %s: %w", sqlInstance.name, err))
 		}

--- a/internal/collector/mssql/mssql_availability_replica.go
+++ b/internal/collector/mssql/mssql_availability_replica.go
@@ -69,7 +69,7 @@ func (c *Collector) buildAvailabilityReplica() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.availabilityReplicaPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Availability Replica"), pdh.InstancesAll, counters)
+		c.availabilityReplicaPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Availability Replica"), pdh.InstancesAll, counters, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Availability Replica collector for instance %s: %w", sqlInstance.name, err))
 		}

--- a/internal/collector/mssql/mssql_availability_replica.go
+++ b/internal/collector/mssql/mssql_availability_replica.go
@@ -19,14 +19,14 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type collectorAvailabilityReplica struct {
-	availabilityReplicaPerfDataCollectors map[string]*perfdata.Collector
+	availabilityReplicaPerfDataCollectors map[string]*pdh.Collector
 
 	availReplicaBytesReceivedFromReplica *prometheus.Desc
 	availReplicaBytesSentToReplica       *prometheus.Desc
@@ -54,7 +54,7 @@ const (
 func (c *Collector) buildAvailabilityReplica() error {
 	var err error
 
-	c.availabilityReplicaPerfDataCollectors = make(map[string]*perfdata.Collector, len(c.mssqlInstances))
+	c.availabilityReplicaPerfDataCollectors = make(map[string]*pdh.Collector, len(c.mssqlInstances))
 	errs := make([]error, 0, len(c.mssqlInstances))
 	counters := []string{
 		availReplicaBytesReceivedFromReplicaPerSec,
@@ -69,7 +69,7 @@ func (c *Collector) buildAvailabilityReplica() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.availabilityReplicaPerfDataCollectors[sqlInstance.name], err = perfdata.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Availability Replica"), perfdata.InstancesAll, counters)
+		c.availabilityReplicaPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Availability Replica"), pdh.InstancesAll, counters)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Availability Replica collector for instance %s: %w", sqlInstance.name, err))
 		}
@@ -138,7 +138,7 @@ func (c *Collector) collectAvailabilityReplica(ch chan<- prometheus.Metric) erro
 	return c.collect(ch, subCollectorAvailabilityReplica, c.availabilityReplicaPerfDataCollectors, c.collectAvailabilityReplicaInstance)
 }
 
-func (c *Collector) collectAvailabilityReplicaInstance(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *perfdata.Collector) error {
+func (c *Collector) collectAvailabilityReplicaInstance(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *pdh.Collector) error {
 	if perfDataCollector == nil {
 		return types.ErrCollectorNotInitialized
 	}

--- a/internal/collector/mssql/mssql_buffer_manager.go
+++ b/internal/collector/mssql/mssql_buffer_manager.go
@@ -19,13 +19,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type collectorBufferManager struct {
-	bufManPerfDataCollectors map[string]*perfdata.Collector
+	bufManPerfDataCollectors map[string]*pdh.Collector
 
 	bufManBackgroundwriterpages         *prometheus.Desc
 	bufManBuffercachehits               *prometheus.Desc
@@ -81,7 +81,7 @@ const (
 func (c *Collector) buildBufferManager() error {
 	var err error
 
-	c.bufManPerfDataCollectors = make(map[string]*perfdata.Collector, len(c.mssqlInstances))
+	c.bufManPerfDataCollectors = make(map[string]*pdh.Collector, len(c.mssqlInstances))
 	errs := make([]error, 0, len(c.mssqlInstances))
 	counters := []string{
 		bufManBackgroundWriterPagesPerSec,
@@ -110,7 +110,7 @@ func (c *Collector) buildBufferManager() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.bufManPerfDataCollectors[sqlInstance.name], err = perfdata.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Buffer Manager"), nil, counters)
+		c.bufManPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Buffer Manager"), nil, counters)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Buffer Manager collector for instance %s: %w", sqlInstance.name, err))
 		}
@@ -262,7 +262,7 @@ func (c *Collector) collectBufferManager(ch chan<- prometheus.Metric) error {
 	return c.collect(ch, subCollectorBufferManager, c.bufManPerfDataCollectors, c.collectBufferManagerInstance)
 }
 
-func (c *Collector) collectBufferManagerInstance(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *perfdata.Collector) error {
+func (c *Collector) collectBufferManagerInstance(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *pdh.Collector) error {
 	if perfDataCollector == nil {
 		return types.ErrCollectorNotInitialized
 	}

--- a/internal/collector/mssql/mssql_buffer_manager.go
+++ b/internal/collector/mssql/mssql_buffer_manager.go
@@ -110,7 +110,7 @@ func (c *Collector) buildBufferManager() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.bufManPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Buffer Manager"), nil, counters)
+		c.bufManPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Buffer Manager"), nil, counters, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Buffer Manager collector for instance %s: %w", sqlInstance.name, err))
 		}

--- a/internal/collector/mssql/mssql_database.go
+++ b/internal/collector/mssql/mssql_database.go
@@ -19,13 +19,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type collectorDatabases struct {
-	databasesPerfDataCollectors map[string]*perfdata.Collector
+	databasesPerfDataCollectors map[string]*pdh.Collector
 
 	databasesActiveParallelRedoThreads       *prometheus.Desc
 	databasesActiveTransactions              *prometheus.Desc
@@ -131,7 +131,7 @@ const (
 func (c *Collector) buildDatabases() error {
 	var err error
 
-	c.databasesPerfDataCollectors = make(map[string]*perfdata.Collector, len(c.mssqlInstances))
+	c.databasesPerfDataCollectors = make(map[string]*pdh.Collector, len(c.mssqlInstances))
 	errs := make([]error, 0, len(c.mssqlInstances))
 	counters := []string{
 		databasesActiveTransactions,
@@ -188,7 +188,7 @@ func (c *Collector) buildDatabases() error {
 			counters = append(counters, databasesActiveParallelRedoThreads)
 		}
 
-		c.databasesPerfDataCollectors[sqlInstance.name], err = perfdata.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Databases"), perfdata.InstancesAll, counters)
+		c.databasesPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Databases"), pdh.InstancesAll, counters)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Databases collector for instance %s: %w", sqlInstance.name, err))
 		}
@@ -490,7 +490,7 @@ func (c *Collector) collectDatabases(ch chan<- prometheus.Metric) error {
 	return c.collect(ch, subCollectorDatabases, c.databasesPerfDataCollectors, c.collectDatabasesInstance)
 }
 
-func (c *Collector) collectDatabasesInstance(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *perfdata.Collector) error {
+func (c *Collector) collectDatabasesInstance(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *pdh.Collector) error {
 	if perfDataCollector == nil {
 		return types.ErrCollectorNotInitialized
 	}

--- a/internal/collector/mssql/mssql_database.go
+++ b/internal/collector/mssql/mssql_database.go
@@ -188,7 +188,7 @@ func (c *Collector) buildDatabases() error {
 			counters = append(counters, databasesActiveParallelRedoThreads)
 		}
 
-		c.databasesPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Databases"), pdh.InstancesAll, counters)
+		c.databasesPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Databases"), pdh.InstancesAll, counters, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Databases collector for instance %s: %w", sqlInstance.name, err))
 		}

--- a/internal/collector/mssql/mssql_database_replica.go
+++ b/internal/collector/mssql/mssql_database_replica.go
@@ -113,7 +113,7 @@ func (c *Collector) buildDatabaseReplica() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.dbReplicaPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Database Replica"), pdh.InstancesAll, counters)
+		c.dbReplicaPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Database Replica"), pdh.InstancesAll, counters, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Database Replica collector for instance %s: %w", sqlInstance.name, err))
 		}

--- a/internal/collector/mssql/mssql_database_replica.go
+++ b/internal/collector/mssql/mssql_database_replica.go
@@ -19,13 +19,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type collectorDatabaseReplica struct {
-	dbReplicaPerfDataCollectors map[string]*perfdata.Collector
+	dbReplicaPerfDataCollectors map[string]*pdh.Collector
 
 	dbReplicaDatabaseFlowControlDelay  *prometheus.Desc
 	dbReplicaDatabaseFlowControls      *prometheus.Desc
@@ -83,7 +83,7 @@ const (
 func (c *Collector) buildDatabaseReplica() error {
 	var err error
 
-	c.dbReplicaPerfDataCollectors = make(map[string]*perfdata.Collector, len(c.mssqlInstances))
+	c.dbReplicaPerfDataCollectors = make(map[string]*pdh.Collector, len(c.mssqlInstances))
 	errs := make([]error, 0, len(c.mssqlInstances))
 	counters := []string{
 		dbReplicaDatabaseFlowControlDelay,
@@ -113,7 +113,7 @@ func (c *Collector) buildDatabaseReplica() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.dbReplicaPerfDataCollectors[sqlInstance.name], err = perfdata.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Database Replica"), perfdata.InstancesAll, counters)
+		c.dbReplicaPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Database Replica"), pdh.InstancesAll, counters)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Database Replica collector for instance %s: %w", sqlInstance.name, err))
 		}
@@ -272,7 +272,7 @@ func (c *Collector) collectDatabaseReplica(ch chan<- prometheus.Metric) error {
 	return c.collect(ch, subCollectorDatabaseReplica, c.dbReplicaPerfDataCollectors, c.collectDatabaseReplicaInstance)
 }
 
-func (c *Collector) collectDatabaseReplicaInstance(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *perfdata.Collector) error {
+func (c *Collector) collectDatabaseReplicaInstance(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *pdh.Collector) error {
 	if perfDataCollector == nil {
 		return types.ErrCollectorNotInitialized
 	}

--- a/internal/collector/mssql/mssql_general_statistics.go
+++ b/internal/collector/mssql/mssql_general_statistics.go
@@ -113,7 +113,7 @@ func (c *Collector) buildGeneralStatistics() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.genStatsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "General Statistics"), nil, counters)
+		c.genStatsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "General Statistics"), nil, counters, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create General Statistics collector for instance %s: %w", sqlInstance.name, err))
 		}

--- a/internal/collector/mssql/mssql_locks.go
+++ b/internal/collector/mssql/mssql_locks.go
@@ -66,7 +66,7 @@ func (c *Collector) buildLocks() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.locksPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Locks"), pdh.InstancesAll, counters)
+		c.locksPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Locks"), pdh.InstancesAll, counters, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Locks collector for instance %s: %w", sqlInstance.name, err))
 		}

--- a/internal/collector/mssql/mssql_memory_manager.go
+++ b/internal/collector/mssql/mssql_memory_manager.go
@@ -101,7 +101,7 @@ func (c *Collector) buildMemoryManager() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.memMgrPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Memory Manager"), pdh.InstancesAll, counters)
+		c.memMgrPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Memory Manager"), pdh.InstancesAll, counters, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Memory Manager collector for instance %s: %w", sqlInstance.name, err))
 		}

--- a/internal/collector/mssql/mssql_sql_errors.go
+++ b/internal/collector/mssql/mssql_sql_errors.go
@@ -19,13 +19,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type collectorSQLErrors struct {
-	sqlErrorsPerfDataCollectors map[string]*perfdata.Collector
+	sqlErrorsPerfDataCollectors map[string]*pdh.Collector
 
 	// Win32_PerfRawData_{instance}_SQLServerSQLErrors
 	sqlErrorsTotal *prometheus.Desc
@@ -38,14 +38,14 @@ const (
 func (c *Collector) buildSQLErrors() error {
 	var err error
 
-	c.sqlErrorsPerfDataCollectors = make(map[string]*perfdata.Collector, len(c.mssqlInstances))
+	c.sqlErrorsPerfDataCollectors = make(map[string]*pdh.Collector, len(c.mssqlInstances))
 	errs := make([]error, 0, len(c.mssqlInstances))
 	counters := []string{
 		sqlErrorsErrorsPerSec,
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.sqlErrorsPerfDataCollectors[sqlInstance.name], err = perfdata.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "SQL Errors"), perfdata.InstancesAll, counters)
+		c.sqlErrorsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "SQL Errors"), pdh.InstancesAll, counters)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create SQL Errors collector for instance %s: %w", sqlInstance.name, err))
 		}
@@ -66,7 +66,7 @@ func (c *Collector) collectSQLErrors(ch chan<- prometheus.Metric) error {
 	return c.collect(ch, subCollectorSQLErrors, c.sqlErrorsPerfDataCollectors, c.collectSQLErrorsInstance)
 }
 
-func (c *Collector) collectSQLErrorsInstance(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *perfdata.Collector) error {
+func (c *Collector) collectSQLErrorsInstance(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *pdh.Collector) error {
 	if perfDataCollector == nil {
 		return types.ErrCollectorNotInitialized
 	}

--- a/internal/collector/mssql/mssql_sql_errors.go
+++ b/internal/collector/mssql/mssql_sql_errors.go
@@ -45,7 +45,7 @@ func (c *Collector) buildSQLErrors() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.sqlErrorsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "SQL Errors"), pdh.InstancesAll, counters)
+		c.sqlErrorsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "SQL Errors"), pdh.InstancesAll, counters, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create SQL Errors collector for instance %s: %w", sqlInstance.name, err))
 		}

--- a/internal/collector/mssql/mssql_sql_stats.go
+++ b/internal/collector/mssql/mssql_sql_stats.go
@@ -74,7 +74,7 @@ func (c *Collector) buildSQLStats() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.sqlStatsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "SQL Statistics"), nil, counters)
+		c.sqlStatsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "SQL Statistics"), nil, counters, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create SQL Statistics collector for instance %s: %w", sqlInstance.name, err))
 		}

--- a/internal/collector/mssql/mssql_transactions.go
+++ b/internal/collector/mssql/mssql_transactions.go
@@ -80,7 +80,7 @@ func (c *Collector) buildTransactions() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.transactionsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Transactions"), nil, counters)
+		c.transactionsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Transactions"), nil, counters, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Transactions collector for instance %s: %w", sqlInstance.name, err))
 		}

--- a/internal/collector/mssql/mssql_wait_stats.go
+++ b/internal/collector/mssql/mssql_wait_stats.go
@@ -19,13 +19,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type collectorWaitStats struct {
-	waitStatsPerfDataCollectors map[string]*perfdata.Collector
+	waitStatsPerfDataCollectors map[string]*pdh.Collector
 
 	waitStatsLockWaits                     *prometheus.Desc
 	waitStatsMemoryGrantQueueWaits         *prometheus.Desc
@@ -59,7 +59,7 @@ const (
 func (c *Collector) buildWaitStats() error {
 	var err error
 
-	c.waitStatsPerfDataCollectors = make(map[string]*perfdata.Collector, len(c.mssqlInstances))
+	c.waitStatsPerfDataCollectors = make(map[string]*pdh.Collector, len(c.mssqlInstances))
 	errs := make([]error, 0, len(c.mssqlInstances))
 	counters := []string{
 		waitStatsLockWaits,
@@ -77,7 +77,7 @@ func (c *Collector) buildWaitStats() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.waitStatsPerfDataCollectors[sqlInstance.name], err = perfdata.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Wait Statistics"), perfdata.InstancesAll, counters)
+		c.waitStatsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Wait Statistics"), pdh.InstancesAll, counters)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Wait Statistics collector for instance %s: %w", sqlInstance.name, err))
 		}
@@ -164,7 +164,7 @@ func (c *Collector) collectWaitStats(ch chan<- prometheus.Metric) error {
 	return c.collect(ch, subCollectorWaitStats, c.waitStatsPerfDataCollectors, c.collectWaitStatsInstance)
 }
 
-func (c *Collector) collectWaitStatsInstance(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *perfdata.Collector) error {
+func (c *Collector) collectWaitStatsInstance(ch chan<- prometheus.Metric, sqlInstance string, perfDataCollector *pdh.Collector) error {
 	if perfDataCollector == nil {
 		return types.ErrCollectorNotInitialized
 	}

--- a/internal/collector/mssql/mssql_wait_stats.go
+++ b/internal/collector/mssql/mssql_wait_stats.go
@@ -77,7 +77,7 @@ func (c *Collector) buildWaitStats() error {
 	}
 
 	for _, sqlInstance := range c.mssqlInstances {
-		c.waitStatsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Wait Statistics"), pdh.InstancesAll, counters)
+		c.waitStatsPerfDataCollectors[sqlInstance.name], err = pdh.NewCollector(c.mssqlGetPerfObjectName(sqlInstance.name, "Wait Statistics"), pdh.InstancesAll, counters, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create Wait Statistics collector for instance %s: %w", sqlInstance.name, err))
 		}

--- a/internal/collector/net/net.go
+++ b/internal/collector/net/net.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/windows"
@@ -55,7 +55,7 @@ var ConfigDefaults = Config{
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	bytesReceivedTotal       *prometheus.Desc
 	bytesSentTotal           *prometheus.Desc
@@ -158,7 +158,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("Network Interface", perfdata.InstancesAll, []string{
+	c.perfDataCollector, err = pdh.NewCollector("Network Interface", pdh.InstancesAll, []string{
 		bytesReceivedPerSec,
 		bytesSentPerSec,
 		bytesTotalPerSec,

--- a/internal/collector/net/net.go
+++ b/internal/collector/net/net.go
@@ -172,7 +172,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 		packetsReceivedUnknown,
 		packetsSentPerSec,
 		currentBandwidth,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Processor Information collector: %w", err)
 	}

--- a/internal/collector/nps/nps.go
+++ b/internal/collector/nps/nps.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -37,7 +37,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	accessPerfDataCollector *perfdata.Collector
+	accessPerfDataCollector *pdh.Collector
 	accessAccepts           *prometheus.Desc
 	accessChallenges        *prometheus.Desc
 	accessRejects           *prometheus.Desc
@@ -52,7 +52,7 @@ type Collector struct {
 	accessServerUpTime      *prometheus.Desc
 	accessUnknownType       *prometheus.Desc
 
-	accountingPerfDataCollector *perfdata.Collector
+	accountingPerfDataCollector *pdh.Collector
 	accountingRequests          *prometheus.Desc
 	accountingResponses         *prometheus.Desc
 	accountingBadAuthenticators *prometheus.Desc
@@ -96,7 +96,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 	errs := make([]error, 0, 2)
 
-	c.accessPerfDataCollector, err = perfdata.NewCollector("NPS Authentication Server", nil, []string{
+	c.accessPerfDataCollector, err = pdh.NewCollector("NPS Authentication Server", nil, []string{
 		accessAccepts,
 		accessChallenges,
 		accessRejects,
@@ -115,7 +115,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		errs = append(errs, fmt.Errorf("failed to create NPS Authentication Server collector: %w", err))
 	}
 
-	c.accountingPerfDataCollector, err = perfdata.NewCollector("NPS Accounting Server", nil, []string{
+	c.accountingPerfDataCollector, err = pdh.NewCollector("NPS Accounting Server", nil, []string{
 		accountingRequests,
 		accountingResponses,
 		accountingBadAuthenticators,
@@ -312,7 +312,7 @@ func (c *Collector) collectAccept(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("failed to collect NPS Authentication Server metrics: %w", err)
 	}
 
-	data, ok := perfData[perfdata.InstanceEmpty]
+	data, ok := perfData[pdh.InstanceEmpty]
 	if !ok {
 		return fmt.Errorf("failed to collect NPS Authentication Server metrics: %w", types.ErrNoData)
 	}
@@ -404,7 +404,7 @@ func (c *Collector) collectAccounting(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("failed to collect NPS Accounting Server metrics: %w", err)
 	}
 
-	data, ok := perfData[perfdata.InstanceEmpty]
+	data, ok := perfData[pdh.InstanceEmpty]
 	if !ok {
 		return fmt.Errorf("failed to collect NPS Accounting Server metrics: %w", types.ErrNoData)
 	}

--- a/internal/collector/nps/nps.go
+++ b/internal/collector/nps/nps.go
@@ -110,7 +110,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		accessServerResetTime,
 		accessServerUpTime,
 		accessUnknownType,
-	})
+	}, false)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to create NPS Authentication Server collector: %w", err))
 	}
@@ -128,7 +128,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		accountingServerResetTime,
 		accountingServerUpTime,
 		accountingUnknownType,
-	})
+	}, false)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to create NPS Accounting Server collector: %w", err))
 	}

--- a/internal/collector/pagefile/pagefile.go
+++ b/internal/collector/pagefile/pagefile.go
@@ -77,7 +77,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 	c.perfDataCollector, err = pdh.NewCollector("Paging File", pdh.InstancesAll, []string{
 		usage,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Paging File collector: %w", err)
 	}

--- a/internal/collector/pagefile/pagefile.go
+++ b/internal/collector/pagefile/pagefile.go
@@ -24,7 +24,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/headers/psapi"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -40,7 +40,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	pagingFreeBytes  *prometheus.Desc
 	pagingLimitBytes *prometheus.Desc
@@ -75,7 +75,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("Paging File", perfdata.InstancesAll, []string{
+	c.perfDataCollector, err = pdh.NewCollector("Paging File", pdh.InstancesAll, []string{
 		usage,
 	})
 	if err != nil {

--- a/internal/collector/performancecounter/performancecounter.go
+++ b/internal/collector/performancecounter/performancecounter.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -114,7 +114,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 			}
 		}
 
-		collector, err := perfdata.NewCollector(object.Object, object.Instances, counters)
+		collector, err := pdh.NewCollector(object.Object, object.Instances, counters)
 		if err != nil {
 			return fmt.Errorf("failed to create v2 collector: %w", err)
 		}
@@ -148,7 +148,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 				}
 
 				labels := make(prometheus.Labels, len(counter.Labels)+1)
-				if collectedInstance != perfdata.InstanceEmpty {
+				if collectedInstance != pdh.InstanceEmpty {
 					labels[perfDataObject.InstanceLabel] = collectedInstance
 				}
 

--- a/internal/collector/performancecounter/performancecounter.go
+++ b/internal/collector/performancecounter/performancecounter.go
@@ -114,7 +114,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 			}
 		}
 
-		collector, err := pdh.NewCollector(object.Object, object.Instances, counters)
+		collector, err := pdh.NewCollector(object.Object, object.Instances, counters, false)
 		if err != nil {
 			return fmt.Errorf("failed to create v2 collector: %w", err)
 		}

--- a/internal/collector/performancecounter/types.go
+++ b/internal/collector/performancecounter/types.go
@@ -15,7 +15,7 @@
 
 package performancecounter
 
-import "github.com/prometheus-community/windows_exporter/internal/perfdata"
+import "github.com/prometheus-community/windows_exporter/internal/pdh"
 
 type Object struct {
 	Object        string    `json:"object"         yaml:"object"`
@@ -23,7 +23,7 @@ type Object struct {
 	Counters      []Counter `json:"counters"       yaml:"counters"`
 	InstanceLabel string    `json:"instance_label" yaml:"instance_label"` //nolint:tagliatelle
 
-	collector *perfdata.Collector
+	collector *pdh.Collector
 }
 
 type Counter struct {

--- a/internal/collector/physical_disk/physical_disk.go
+++ b/internal/collector/physical_disk/physical_disk.go
@@ -143,7 +143,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 	var err error
 
-	c.perfDataCollector, err = pdh.NewCollector("PhysicalDisk", pdh.InstancesAll, counters)
+	c.perfDataCollector, err = pdh.NewCollector("PhysicalDisk", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create PhysicalDisk collector: %w", err)
 	}

--- a/internal/collector/physical_disk/physical_disk.go
+++ b/internal/collector/physical_disk/physical_disk.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -45,7 +45,7 @@ var ConfigDefaults = Config{
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	idleTime         *prometheus.Desc
 	readBytesTotal   *prometheus.Desc
@@ -143,7 +143,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("PhysicalDisk", perfdata.InstancesAll, counters)
+	c.perfDataCollector, err = pdh.NewCollector("PhysicalDisk", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create PhysicalDisk collector: %w", err)
 	}
@@ -319,21 +319,21 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(
 			c.readLatency,
 			prometheus.CounterValue,
-			disk[AvgDiskSecPerRead].FirstValue*perfdata.TicksToSecondScaleFactor,
+			disk[AvgDiskSecPerRead].FirstValue*pdh.TicksToSecondScaleFactor,
 			disk_number,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.writeLatency,
 			prometheus.CounterValue,
-			disk[AvgDiskSecPerWrite].FirstValue*perfdata.TicksToSecondScaleFactor,
+			disk[AvgDiskSecPerWrite].FirstValue*pdh.TicksToSecondScaleFactor,
 			disk_number,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.readWriteLatency,
 			prometheus.CounterValue,
-			disk[AvgDiskSecPerTransfer].FirstValue*perfdata.TicksToSecondScaleFactor,
+			disk[AvgDiskSecPerTransfer].FirstValue*pdh.TicksToSecondScaleFactor,
 			disk_number,
 		)
 	}

--- a/internal/collector/process/process.go
+++ b/internal/collector/process/process.go
@@ -29,7 +29,6 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
 	"github.com/prometheus-community/windows_exporter/internal/pdh"
-	"github.com/prometheus-community/windows_exporter/internal/pdh/registry"
 	pdhtypes "github.com/prometheus-community/windows_exporter/internal/pdh/types"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
@@ -214,12 +213,12 @@ func (c *Collector) Build(logger *slog.Logger, miSession *mi.Session) error {
 		workingSet,
 	}
 
-	c.perfDataCollector, err = pdh.NewCollector("Process V2", pdh.InstancesAll, counters)
+	c.perfDataCollector, err = pdh.NewCollector("Process V2", pdh.InstancesAll, counters, false)
 	if true {
 		counters[0] = idProcess
 
 		//c.perfDataCollector, err = pdh.NewCollector("Process", pdh.InstancesAll, counters)
-		c.perfDataCollector, err = registry.NewCollector("Process", pdh.InstancesAll, counters)
+		c.perfDataCollector, err = pdh.NewCollector("Process", pdh.InstancesAll, counters, true)
 	}
 
 	if err != nil {

--- a/internal/collector/process/process.go
+++ b/internal/collector/process/process.go
@@ -28,7 +28,9 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
+	"github.com/prometheus-community/windows_exporter/internal/pdh/registry"
+	pdhtypes "github.com/prometheus-community/windows_exporter/internal/pdh/types"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/windows"
@@ -57,7 +59,7 @@ type Collector struct {
 	miSession                 *mi.Session
 	workerProcessMIQueryQuery mi.Query
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector pdhtypes.Collector
 
 	lookupCache sync.Map
 
@@ -85,7 +87,7 @@ type Collector struct {
 type processWorkerRequest struct {
 	ch                       chan<- prometheus.Metric
 	name                     string
-	performanceCounterValues map[string]perfdata.CounterValue
+	performanceCounterValues map[string]pdh.CounterValue
 	waitGroup                *sync.WaitGroup
 	workerProcesses          []WorkerProcess
 }
@@ -212,11 +214,11 @@ func (c *Collector) Build(logger *slog.Logger, miSession *mi.Session) error {
 		workingSet,
 	}
 
-	c.perfDataCollector, err = perfdata.NewCollector("Process V2", perfdata.InstancesAll, counters)
-	if errors.Is(err, perfdata.NewPdhError(perfdata.PdhCstatusNoObject)) {
+	c.perfDataCollector, err = pdh.NewCollector("Process V2", pdh.InstancesAll, counters)
+	if true {
 		counters[0] = idProcess
 
-		c.perfDataCollector, err = perfdata.NewCollector("Process", perfdata.InstancesAll, counters)
+		c.perfDataCollector, err = registry.NewCollector("Process", pdh.InstancesAll, counters)
 	}
 
 	if err != nil {

--- a/internal/collector/process/process.go
+++ b/internal/collector/process/process.go
@@ -218,6 +218,7 @@ func (c *Collector) Build(logger *slog.Logger, miSession *mi.Session) error {
 	if true {
 		counters[0] = idProcess
 
+		//c.perfDataCollector, err = pdh.NewCollector("Process", pdh.InstancesAll, counters)
 		c.perfDataCollector, err = registry.NewCollector("Process", pdh.InstancesAll, counters)
 	}
 

--- a/internal/collector/remote_fx/remote_fx.go
+++ b/internal/collector/remote_fx/remote_fx.go
@@ -116,7 +116,7 @@ func (c *Collector) Build(*slog.Logger, *mi.Session) error {
 		FECRate,
 		LossRate,
 		RetransmissionRate,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create RemoteFX Network collector: %w", err)
 	}
@@ -131,7 +131,7 @@ func (c *Collector) Build(*slog.Logger, *mi.Session) error {
 		InputFramesPerSecond,
 		OutputFramesPerSecond,
 		SourceFramesPerSecond,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create RemoteFX Graphics collector: %w", err)
 	}

--- a/internal/collector/remote_fx/remote_fx.go
+++ b/internal/collector/remote_fx/remote_fx.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,8 +44,8 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollectorNetwork  *perfdata.Collector
-	perfDataCollectorGraphics *perfdata.Collector
+	perfDataCollectorNetwork  *pdh.Collector
+	perfDataCollectorGraphics *pdh.Collector
 
 	// net
 	baseTCPRTT               *prometheus.Desc
@@ -102,7 +102,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(*slog.Logger, *mi.Session) error {
 	var err error
 
-	c.perfDataCollectorNetwork, err = perfdata.NewCollector("RemoteFX Network", perfdata.InstancesAll, []string{
+	c.perfDataCollectorNetwork, err = pdh.NewCollector("RemoteFX Network", pdh.InstancesAll, []string{
 		BaseTCPRTT,
 		BaseUDPRTT,
 		CurrentTCPBandwidth,
@@ -121,7 +121,7 @@ func (c *Collector) Build(*slog.Logger, *mi.Session) error {
 		return fmt.Errorf("failed to create RemoteFX Network collector: %w", err)
 	}
 
-	c.perfDataCollectorGraphics, err = perfdata.NewCollector("RemoteFX Graphics", perfdata.InstancesAll, []string{
+	c.perfDataCollectorGraphics, err = pdh.NewCollector("RemoteFX Graphics", pdh.InstancesAll, []string{
 		AverageEncodingTime,
 		FrameQuality,
 		FramesSkippedPerSecondInsufficientClientResources,

--- a/internal/collector/smb/smb.go
+++ b/internal/collector/smb/smb.go
@@ -86,7 +86,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		metadataRequests,
 		sentBytes,
 		filesOpened,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create SMB Server Shares collector: %w", err)
 	}

--- a/internal/collector/smb/smb.go
+++ b/internal/collector/smb/smb.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -36,7 +36,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	treeConnectCount     *prometheus.Desc
 	currentOpenFileCount *prometheus.Desc
@@ -77,7 +77,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("SMB Server Shares", perfdata.InstancesAll, []string{
+	c.perfDataCollector, err = pdh.NewCollector("SMB Server Shares", pdh.InstancesAll, []string{
 		currentOpenFileCount,
 		treeConnectCount,
 		receivedBytes,

--- a/internal/collector/smbclient/smbclient.go
+++ b/internal/collector/smbclient/smbclient.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -39,7 +39,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	readBytesTotal                            *prometheus.Desc
 	readBytesTransmittedViaSMBDirectTotal     *prometheus.Desc
@@ -92,7 +92,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("SMB Client Shares", perfdata.InstancesAll, []string{
+	c.perfDataCollector, err = pdh.NewCollector("SMB Client Shares", pdh.InstancesAll, []string{
 		AvgDataQueueLength,
 		AvgReadQueueLength,
 		AvgSecPerRead,
@@ -233,7 +233,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(
 			c.requestQueueSecsTotal,
 			prometheus.CounterValue,
-			data[AvgDataQueueLength].FirstValue*perfdata.TicksToSecondScaleFactor,
+			data[AvgDataQueueLength].FirstValue*pdh.TicksToSecondScaleFactor,
 			serverValue, shareValue,
 		)
 
@@ -241,28 +241,28 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(
 			c.readRequestQueueSecsTotal,
 			prometheus.CounterValue,
-			data[AvgReadQueueLength].FirstValue*perfdata.TicksToSecondScaleFactor,
+			data[AvgReadQueueLength].FirstValue*pdh.TicksToSecondScaleFactor,
 			serverValue, shareValue,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.readSecsTotal,
 			prometheus.CounterValue,
-			data[AvgSecPerRead].FirstValue*perfdata.TicksToSecondScaleFactor,
+			data[AvgSecPerRead].FirstValue*pdh.TicksToSecondScaleFactor,
 			serverValue, shareValue,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.writeSecsTotal,
 			prometheus.CounterValue,
-			data[AvgSecPerWrite].FirstValue*perfdata.TicksToSecondScaleFactor,
+			data[AvgSecPerWrite].FirstValue*pdh.TicksToSecondScaleFactor,
 			serverValue, shareValue,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.requestSecs,
 			prometheus.CounterValue,
-			data[AvgSecPerDataRequest].FirstValue*perfdata.TicksToSecondScaleFactor,
+			data[AvgSecPerDataRequest].FirstValue*pdh.TicksToSecondScaleFactor,
 			serverValue, shareValue,
 		)
 
@@ -270,7 +270,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(
 			c.writeRequestQueueSecsTotal,
 			prometheus.CounterValue,
-			data[AvgWriteQueueLength].FirstValue*perfdata.TicksToSecondScaleFactor,
+			data[AvgWriteQueueLength].FirstValue*pdh.TicksToSecondScaleFactor,
 			serverValue, shareValue,
 		)
 

--- a/internal/collector/smbclient/smbclient.go
+++ b/internal/collector/smbclient/smbclient.go
@@ -114,7 +114,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		WriteBytesPerSec,
 		WriteRequestsTransmittedViaSMBDirectPerSec,
 		WriteRequestsPerSec,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create SMB Client Shares collector: %w", err)
 	}

--- a/internal/collector/smtp/smtp.go
+++ b/internal/collector/smtp/smtp.go
@@ -201,7 +201,7 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 		remoteQueueLength,
 		remoteRetryQueueLength,
 		routingTableLookupsTotal,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create SMTP Server collector: %w", err)
 	}

--- a/internal/collector/smtp/smtp.go
+++ b/internal/collector/smtp/smtp.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -43,7 +43,7 @@ var ConfigDefaults = Config{
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	badMailedMessagesBadPickupFileTotal     *prometheus.Desc
 	badMailedMessagesGeneralFailureTotal    *prometheus.Desc
@@ -158,7 +158,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("SMTP Server", perfdata.InstancesAll, []string{
+	c.perfDataCollector, err = pdh.NewCollector("SMTP Server", pdh.InstancesAll, []string{
 		badmailedMessagesBadPickupFileTotal,
 		badmailedMessagesGeneralFailureTotal,
 		badmailedMessagesHopCountExceededTotal,

--- a/internal/collector/system/system.go
+++ b/internal/collector/system/system.go
@@ -87,7 +87,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		systemUpTime,
 		processes,
 		threads,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create System collector: %w", err)
 	}

--- a/internal/collector/system/system.go
+++ b/internal/collector/system/system.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -38,7 +38,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	contextSwitchesTotal     *prometheus.Desc
 	exceptionDispatchesTotal *prometheus.Desc
@@ -79,7 +79,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("System", nil, []string{
+	c.perfDataCollector, err = pdh.NewCollector("System", nil, []string{
 		contextSwitchesPersec,
 		exceptionDispatchesPersec,
 		processorQueueLength,
@@ -153,7 +153,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("failed to collect System metrics: %w", err)
 	}
 
-	data, ok := perfData[perfdata.InstanceEmpty]
+	data, ok := perfData[pdh.InstanceEmpty]
 	if !ok {
 		return errors.New("query for System returned empty result set")
 	}

--- a/internal/collector/tcp/tcp.go
+++ b/internal/collector/tcp/tcp.go
@@ -130,12 +130,12 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 	var err error
 
-	c.perfDataCollector4, err = pdh.NewCollector("TCPv4", nil, counters)
+	c.perfDataCollector4, err = pdh.NewCollector("TCPv4", nil, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create TCPv4 collector: %w", err)
 	}
 
-	c.perfDataCollector6, err = pdh.NewCollector("TCPv6", nil, counters)
+	c.perfDataCollector6, err = pdh.NewCollector("TCPv6", nil, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create TCPv6 collector: %w", err)
 	}

--- a/internal/collector/terminal_services/terminal_services.go
+++ b/internal/collector/terminal_services/terminal_services.go
@@ -156,7 +156,7 @@ func (c *Collector) Build(logger *slog.Logger, miSession *mi.Session) error {
 
 	var err error
 
-	c.perfDataCollectorTerminalServicesSession, err = pdh.NewCollector("Terminal Services Session", pdh.InstancesAll, counters)
+	c.perfDataCollectorTerminalServicesSession, err = pdh.NewCollector("Terminal Services Session", pdh.InstancesAll, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Terminal Services Session collector: %w", err)
 	}
@@ -172,7 +172,7 @@ func (c *Collector) Build(logger *slog.Logger, miSession *mi.Session) error {
 
 		var err error
 
-		c.perfDataCollectorBroker, err = pdh.NewCollector("Remote Desktop Connection Broker Counterset", pdh.InstancesAll, counters)
+		c.perfDataCollectorBroker, err = pdh.NewCollector("Remote Desktop Connection Broker Counterset", pdh.InstancesAll, counters, false)
 		if err != nil {
 			return fmt.Errorf("failed to create Remote Desktop Connection Broker Counterset collector: %w", err)
 		}

--- a/internal/collector/terminal_services/terminal_services.go
+++ b/internal/collector/terminal_services/terminal_services.go
@@ -25,7 +25,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/headers/wtsapi32"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -72,8 +72,8 @@ type Collector struct {
 
 	connectionBrokerEnabled bool
 
-	perfDataCollectorTerminalServicesSession *perfdata.Collector
-	perfDataCollectorBroker                  *perfdata.Collector
+	perfDataCollectorTerminalServicesSession *pdh.Collector
+	perfDataCollectorBroker                  *pdh.Collector
 
 	hServer windows.Handle
 
@@ -156,7 +156,7 @@ func (c *Collector) Build(logger *slog.Logger, miSession *mi.Session) error {
 
 	var err error
 
-	c.perfDataCollectorTerminalServicesSession, err = perfdata.NewCollector("Terminal Services Session", perfdata.InstancesAll, counters)
+	c.perfDataCollectorTerminalServicesSession, err = pdh.NewCollector("Terminal Services Session", pdh.InstancesAll, counters)
 	if err != nil {
 		return fmt.Errorf("failed to create Terminal Services Session collector: %w", err)
 	}
@@ -172,7 +172,7 @@ func (c *Collector) Build(logger *slog.Logger, miSession *mi.Session) error {
 
 		var err error
 
-		c.perfDataCollectorBroker, err = perfdata.NewCollector("Remote Desktop Connection Broker Counterset", perfdata.InstancesAll, counters)
+		c.perfDataCollectorBroker, err = pdh.NewCollector("Remote Desktop Connection Broker Counterset", pdh.InstancesAll, counters)
 		if err != nil {
 			return fmt.Errorf("failed to create Remote Desktop Connection Broker Counterset collector: %w", err)
 		}
@@ -427,7 +427,7 @@ func (c *Collector) collectCollectionBrokerPerformanceCounter(ch chan<- promethe
 		return fmt.Errorf("failed to collect Remote Desktop Connection Broker Counterset metrics: %w", err)
 	}
 
-	data, ok := perfData[perfdata.InstanceEmpty]
+	data, ok := perfData[pdh.InstanceEmpty]
 	if !ok {
 		return errors.New("query for Remote Desktop Connection Broker Counterset returned empty result set")
 	}

--- a/internal/collector/thermalzone/thermalzone.go
+++ b/internal/collector/thermalzone/thermalzone.go
@@ -75,7 +75,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		highPrecisionTemperature,
 		percentPassiveLimit,
 		throttleReasons,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Thermal Zone Information collector: %w", err)
 	}

--- a/internal/collector/thermalzone/thermalzone.go
+++ b/internal/collector/thermalzone/thermalzone.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -37,7 +37,7 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	percentPassiveLimit *prometheus.Desc
 	temperature         *prometheus.Desc
@@ -71,7 +71,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("Thermal Zone Information", perfdata.InstancesAll, []string{
+	c.perfDataCollector, err = pdh.NewCollector("Thermal Zone Information", pdh.InstancesAll, []string{
 		highPrecisionTemperature,
 		percentPassiveLimit,
 		throttleReasons,

--- a/internal/collector/time/time.go
+++ b/internal/collector/time/time.go
@@ -26,7 +26,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/headers/kernel32"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/windows"
@@ -55,7 +55,7 @@ var ConfigDefaults = Config{
 type Collector struct {
 	config Config
 
-	perfDataCollector *perfdata.Collector
+	perfDataCollector *pdh.Collector
 
 	currentTime                      *prometheus.Desc
 	timezone                         *prometheus.Desc
@@ -126,7 +126,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 	var err error
 
-	c.perfDataCollector, err = perfdata.NewCollector("Windows Time Service", nil, []string{
+	c.perfDataCollector, err = pdh.NewCollector("Windows Time Service", nil, []string{
 		ClockFrequencyAdjustmentPPBTotal,
 		ComputedTimeOffset,
 		NTPClientTimeSourceCount,
@@ -241,7 +241,7 @@ func (c *Collector) collectNTP(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("failed to collect VM Memory metrics: %w", err)
 	}
 
-	data, ok := perfData[perfdata.InstanceEmpty]
+	data, ok := perfData[pdh.InstanceEmpty]
 	if !ok {
 		return fmt.Errorf("failed to collect VM Memory metrics: %w", err)
 	}

--- a/internal/collector/time/time.go
+++ b/internal/collector/time/time.go
@@ -133,7 +133,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		NTPRoundTripDelay,
 		NTPServerIncomingRequestsTotal,
 		NTPServerOutgoingResponsesTotal,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create Windows Time Service collector: %w", err)
 	}

--- a/internal/collector/udp/udp.go
+++ b/internal/collector/udp/udp.go
@@ -88,12 +88,12 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 	var err error
 
-	c.perfDataCollector4, err = pdh.NewCollector("UDPv4", nil, counters)
+	c.perfDataCollector4, err = pdh.NewCollector("UDPv4", nil, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create UDPv4 collector: %w", err)
 	}
 
-	c.perfDataCollector6, err = pdh.NewCollector("UDPv6", nil, counters)
+	c.perfDataCollector6, err = pdh.NewCollector("UDPv6", nil, counters, false)
 	if err != nil {
 		return fmt.Errorf("failed to create UDPv6 collector: %w", err)
 	}

--- a/internal/collector/vmware/vmware.go
+++ b/internal/collector/vmware/vmware.go
@@ -101,7 +101,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		cpuTimePercents,
 		couEffectiveVMSpeedMHz,
 		cpuHostProcessorSpeedMHz,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create VM Processor collector: %w", err)
 	}
@@ -162,7 +162,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		memSwappedMB,
 		memTargetSizeMB,
 		memUsedMB,
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to create VM Memory collector: %w", err)
 	}

--- a/internal/collector/vmware/vmware.go
+++ b/internal/collector/vmware/vmware.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus-community/windows_exporter/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -38,8 +38,8 @@ var ConfigDefaults = Config{}
 // A Collector is a Prometheus Collector for WMI Win32_PerfRawData_vmGuestLib_VMem/Win32_PerfRawData_vmGuestLib_VCPU metrics.
 type Collector struct {
 	config                  Config
-	perfDataCollectorCPU    *perfdata.Collector
-	perfDataCollectorMemory *perfdata.Collector
+	perfDataCollectorCPU    *pdh.Collector
+	perfDataCollectorMemory *pdh.Collector
 
 	memActive      *prometheus.Desc
 	memBallooned   *prometheus.Desc
@@ -93,7 +93,7 @@ func (c *Collector) Close() error {
 func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	var err error
 
-	c.perfDataCollectorCPU, err = perfdata.NewCollector("VM Processor", perfdata.InstancesTotal, []string{
+	c.perfDataCollectorCPU, err = pdh.NewCollector("VM Processor", pdh.InstancesTotal, []string{
 		cpuLimitMHz,
 		cpuReservationMHz,
 		cpuShares,
@@ -149,7 +149,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 		nil,
 	)
 
-	c.perfDataCollectorMemory, err = perfdata.NewCollector("VM Memory", nil, []string{
+	c.perfDataCollectorMemory, err = pdh.NewCollector("VM Memory", nil, []string{
 		memActiveMB,
 		memBalloonedMB,
 		memLimitMB,
@@ -265,7 +265,7 @@ func (c *Collector) collectMem(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("failed to collect VM Memory metrics: %w", err)
 	}
 
-	data, ok := perfData[perfdata.InstanceEmpty]
+	data, ok := perfData[pdh.InstanceEmpty]
 	if !ok {
 		return fmt.Errorf("failed to collect VM Memory metrics: %w", types.ErrNoData)
 	}
@@ -351,7 +351,7 @@ func (c *Collector) collectCpu(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("failed to collect VM CPU metrics: %w", err)
 	}
 
-	data, ok := perfData[perfdata.InstanceTotal]
+	data, ok := perfData[pdh.InstanceTotal]
 	if !ok {
 		return fmt.Errorf("failed to collect VM CPU metrics: %w", types.ErrNoData)
 	}

--- a/internal/pdh/collector.go
+++ b/internal/pdh/collector.go
@@ -13,7 +13,7 @@
 
 //go:build windows
 
-package perfdata
+package pdh
 
 import (
 	"errors"
@@ -241,7 +241,7 @@ func (c *Collector) collectRoutine() {
 					}
 
 					var metricType prometheus.ValueType
-					if val, ok := supportedCounterTypes[counter.Type]; ok {
+					if val, ok := SupportedCounterTypes[counter.Type]; ok {
 						metricType = val
 					} else {
 						metricType = prometheus.GaugeValue

--- a/internal/pdh/collector.go
+++ b/internal/pdh/collector.go
@@ -243,7 +243,7 @@ func (c *Collector) collectRoutine() {
 					for _, instance := range expandedInstances {
 						var counterHandle PDHCounterHandle
 						if ret := PdhAddCounter(handle, instance, 0, &counterHandle); ret != ErrorSuccess {
-							return nil, fmt.Errorf("failed to add counter %s: %w", NewPdhError(ret))
+							return nil, fmt.Errorf("failed to add counter %w", NewPdhError(ret))
 						}
 
 						instances[instance] = counterHandle

--- a/internal/pdh/collector_bench_test.go
+++ b/internal/pdh/collector_bench_test.go
@@ -53,7 +53,7 @@ func BenchmarkTestCollector(b *testing.B) {
 		"Working Set Peak",
 		"Working Set",
 	}
-	performanceData, err := v2.NewCollector("Process", []string{"*"}, counters)
+	performanceData, err := v2.NewCollector("Process", []string{"*"}, counters, false)
 	require.NoError(b, err)
 
 	for i := 0; i < b.N; i++ {

--- a/internal/pdh/collector_bench_test.go
+++ b/internal/pdh/collector_bench_test.go
@@ -13,12 +13,12 @@
 
 //go:build windows
 
-package perfdata_test
+package pdh_test
 
 import (
 	"testing"
 
-	v2 "github.com/prometheus-community/windows_exporter/internal/perfdata"
+	v2 "github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/pdh/collector_test.go
+++ b/internal/pdh/collector_test.go
@@ -13,13 +13,13 @@
 
 //go:build windows
 
-package perfdata_test
+package pdh_test
 
 import (
 	"testing"
 	"time"
 
-	v2 "github.com/prometheus-community/windows_exporter/internal/perfdata"
+	v2 "github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/pdh/collector_test.go
+++ b/internal/pdh/collector_test.go
@@ -74,7 +74,7 @@ func TestCollector(t *testing.T) {
 		t.Run(tc.object, func(t *testing.T) {
 			t.Parallel()
 
-			performanceData, err := v2.NewCollector(tc.object, tc.instances, tc.counters)
+			performanceData, err := v2.NewCollector(tc.object, tc.instances, tc.counters, false)
 			require.NoError(t, err)
 
 			time.Sleep(100 * time.Millisecond)

--- a/internal/pdh/const.go
+++ b/internal/pdh/const.go
@@ -13,7 +13,7 @@
 
 //go:build windows
 
-package perfdata
+package pdh
 
 import "github.com/prometheus/client_golang/prometheus"
 
@@ -71,7 +71,7 @@ const (
 )
 
 //nolint:gochecknoglobals
-var supportedCounterTypes = map[uint32]prometheus.ValueType{
+var SupportedCounterTypes = map[uint32]prometheus.ValueType{
 	PERF_COUNTER_RAWCOUNT_HEX:       prometheus.GaugeValue,
 	PERF_COUNTER_LARGE_RAWCOUNT_HEX: prometheus.GaugeValue,
 	PERF_COUNTER_RAWCOUNT:           prometheus.GaugeValue,

--- a/internal/pdh/error.go
+++ b/internal/pdh/error.go
@@ -13,7 +13,7 @@
 
 //go:build windows
 
-package perfdata
+package pdh
 
 import "errors"
 

--- a/internal/pdh/pdh.go
+++ b/internal/pdh/pdh.go
@@ -31,7 +31,7 @@
 
 //go:build windows
 
-package perfdata
+package pdh
 
 import (
 	"fmt"

--- a/internal/pdh/pdh.go
+++ b/internal/pdh/pdh.go
@@ -253,8 +253,8 @@ const (
 )
 
 type (
-	pdhQueryHandle   HANDLE // query handle
-	pdhCounterHandle HANDLE // counter handle
+	PDHQueryHandle   HANDLE // query handle
+	PDHCounterHandle HANDLE // counter handle
 )
 
 //nolint:gochecknoglobals
@@ -315,7 +315,7 @@ var (
 // The typeperf command may also be pretty easy. To find all performance counters, simply execute:
 //
 //	typeperf -qx
-func PdhAddCounter(hQuery pdhQueryHandle, szFullCounterPath string, dwUserData uintptr, phCounter *pdhCounterHandle) uint32 {
+func PdhAddCounter(hQuery PDHQueryHandle, szFullCounterPath string, dwUserData uintptr, phCounter *PDHCounterHandle) uint32 {
 	ptxt, _ := windows.UTF16PtrFromString(szFullCounterPath)
 	ret, _, _ := pdhAddCounterW.Call(
 		uintptr(hQuery),
@@ -328,7 +328,7 @@ func PdhAddCounter(hQuery pdhQueryHandle, szFullCounterPath string, dwUserData u
 
 // PdhAddEnglishCounter adds the specified language-neutral counter to the query. See the PdhAddCounter function. This function only exists on
 // Windows versions higher than Vista.
-func PdhAddEnglishCounter(hQuery pdhQueryHandle, szFullCounterPath string, dwUserData uintptr, phCounter *pdhCounterHandle) uint32 {
+func PdhAddEnglishCounter(hQuery PDHQueryHandle, szFullCounterPath string, dwUserData uintptr, phCounter *PDHCounterHandle) uint32 {
 	if pdhAddEnglishCounterW == nil {
 		return ErrorInvalidFunction
 	}
@@ -345,7 +345,7 @@ func PdhAddEnglishCounter(hQuery pdhQueryHandle, szFullCounterPath string, dwUse
 
 // PdhCloseQuery closes all counters contained in the specified query, closes all handles related to the query,
 // and frees all memory associated with the query.
-func PdhCloseQuery(hQuery pdhQueryHandle) uint32 {
+func PdhCloseQuery(hQuery PDHQueryHandle) uint32 {
 	ret, _, _ := pdhCloseQuery.Call(uintptr(hQuery))
 
 	return uint32(ret)
@@ -372,7 +372,7 @@ func PdhCloseQuery(hQuery pdhQueryHandle) uint32 {
 //
 // The PdhCollectQueryData will return an error in the first call because it needs two values for
 // displaying the correct data for the processor idle time. The second call will have a 0 return code.
-func PdhCollectQueryData(hQuery pdhQueryHandle) uint32 {
+func PdhCollectQueryData(hQuery PDHQueryHandle) uint32 {
 	ret, _, _ := pdhCollectQueryData.Call(uintptr(hQuery))
 
 	return uint32(ret)
@@ -380,7 +380,7 @@ func PdhCollectQueryData(hQuery pdhQueryHandle) uint32 {
 
 // PdhCollectQueryDataWithTime queries data from perfmon, retrieving the device/windows timestamp from the node it was collected on.
 // Converts the filetime structure to a GO time class and returns the native time.
-func PdhCollectQueryDataWithTime(hQuery pdhQueryHandle) (uint32, time.Time) {
+func PdhCollectQueryDataWithTime(hQuery PDHQueryHandle) (uint32, time.Time) {
 	var localFileTime windows.Filetime
 
 	ret, _, _ := pdhCollectQueryDataWithTime.Call(uintptr(hQuery), uintptr(unsafe.Pointer(&localFileTime)))
@@ -402,7 +402,7 @@ func PdhCollectQueryDataWithTime(hQuery pdhQueryHandle) (uint32, time.Time) {
 
 // PdhGetFormattedCounterValueDouble formats the given hCounter using a 'double'. The result is set into the specialized union struct pValue.
 // This function does not directly translate to a Windows counterpart due to union specialization tricks.
-func PdhGetFormattedCounterValueDouble(hCounter pdhCounterHandle, lpdwType *uint32, pValue *PdhFmtCountervalueDouble) uint32 {
+func PdhGetFormattedCounterValueDouble(hCounter PDHCounterHandle, lpdwType *uint32, pValue *PdhFmtCountervalueDouble) uint32 {
 	ret, _, _ := pdhGetFormattedCounterValue.Call(
 		uintptr(hCounter),
 		uintptr(PdhFmtDouble|PdhFmtNocap100),
@@ -449,7 +449,7 @@ func PdhGetFormattedCounterValueDouble(hCounter pdhCounterHandle, lpdwType *uint
 //			time.Sleep(2000 * time.Millisecond)
 //		}
 //	}
-func PdhGetFormattedCounterArrayDouble(hCounter pdhCounterHandle, lpdwBufferSize *uint32, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
+func PdhGetFormattedCounterArrayDouble(hCounter PDHCounterHandle, lpdwBufferSize *uint32, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
 	ret, _, _ := pdhGetFormattedCounterArrayW.Call(
 		uintptr(hCounter),
 		uintptr(PdhFmtDouble|PdhFmtNocap100),
@@ -467,7 +467,7 @@ func PdhGetFormattedCounterArrayDouble(hCounter pdhCounterHandle, lpdwBufferSize
 // call PdhGetCounterInfo and access dwQueryUserData of the PdhCounterInfo structure. phQuery is
 // the handle to the query, and must be used in subsequent calls. This function returns a PDH_
 // constant error code, or ErrorSuccess if the call succeeded.
-func PdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *pdhQueryHandle) uint32 {
+func PdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *PDHQueryHandle) uint32 {
 	ret, _, _ := pdhOpenQuery.Call(
 		szDataSource,
 		dwUserData,
@@ -560,7 +560,7 @@ func PdhFormatError(msgID uint32) string {
 // Caller-allocated buffer that receives a PdhCounterInfo structure.
 // The structure is variable-length, because the string data is appended to the end of the fixed-format portion of the structure.
 // This is done so that all data is returned in a single buffer allocated by the caller. Set to NULL if pdwBufferSize is zero.
-func PdhGetCounterInfo(hCounter pdhCounterHandle, bRetrieveExplainText int, pdwBufferSize *uint32, lpBuffer *byte) uint32 {
+func PdhGetCounterInfo(hCounter PDHCounterHandle, bRetrieveExplainText int, pdwBufferSize *uint32, lpBuffer *byte) uint32 {
 	ret, _, _ := pdhGetCounterInfoW.Call(
 		uintptr(hCounter),
 		uintptr(bRetrieveExplainText),
@@ -583,7 +583,7 @@ func PdhGetCounterInfo(hCounter pdhCounterHandle, bRetrieveExplainText int, pdwB
 //
 // pValue [out]
 // A PdhRawCounter structure that receives the counter value.
-func PdhGetRawCounterValue(hCounter pdhCounterHandle, lpdwType *uint32, pValue *PdhRawCounter) uint32 {
+func PdhGetRawCounterValue(hCounter PDHCounterHandle, lpdwType *uint32, pValue *PdhRawCounter) uint32 {
 	ret, _, _ := pdhGetRawCounterValue.Call(
 		uintptr(hCounter),
 		uintptr(unsafe.Pointer(lpdwType)),
@@ -608,7 +608,7 @@ func PdhGetRawCounterValue(hCounter pdhCounterHandle, lpdwType *uint32, pValue *
 // ItemBuffer
 // Caller-allocated buffer that receives the array of PdhRawCounterItem structures; the structures contain the raw instance counter values.
 // Set to NULL if lpdwBufferSize is zero.
-func PdhGetRawCounterArray(hCounter pdhCounterHandle, lpdwBufferSize *uint32, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
+func PdhGetRawCounterArray(hCounter PDHCounterHandle, lpdwBufferSize *uint32, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
 	ret, _, _ := pdhGetRawCounterArrayW.Call(
 		uintptr(hCounter),
 		uintptr(unsafe.Pointer(lpdwBufferSize)),
@@ -624,10 +624,24 @@ func PdhGetRawCounterArray(hCounter pdhCounterHandle, lpdwBufferSize *uint32, lp
 //
 // lpdwItemCount
 // Time base that specifies the number of performance values a counter samples per second.
-func PdhGetCounterTimeBase(hCounter pdhCounterHandle, pTimeBase *int64) uint32 {
+func PdhGetCounterTimeBase(hCounter PDHCounterHandle, pTimeBase *int64) uint32 {
 	ret, _, _ := pdhPdhGetCounterTimeBase.Call(
 		uintptr(hCounter),
 		uintptr(unsafe.Pointer(pTimeBase)))
 
 	return uint32(ret)
+}
+
+// UTF16ToStringArray converts list of Windows API NULL terminated strings  to go string array
+func UTF16ToStringArray(buf []uint16) []string {
+	var strings []string
+	nextLineStart := 0
+	stringLine := windows.UTF16PtrToString(&buf[0])
+	for stringLine != "" {
+		strings = append(strings, stringLine)
+		nextLineStart += len([]rune(stringLine)) + 1
+		remainingBuf := buf[nextLineStart:]
+		stringLine = windows.UTF16PtrToString(&remainingBuf[0])
+	}
+	return strings
 }

--- a/internal/pdh/pdh_amd64.go
+++ b/internal/pdh/pdh_amd64.go
@@ -31,7 +31,7 @@
 
 //go:build windows
 
-package perfdata
+package pdh
 
 import "golang.org/x/sys/windows"
 
@@ -42,41 +42,42 @@ type PdhFmtCountervalueDouble struct {
 }
 
 // PdhFmtCounterValueLarge is a union specialization for 64-bit integer values.
-type PdhFmtCountervalueLarge struct {
+type PdhFmtCounterValueLarge struct {
 	CStatus    uint32
 	LargeValue int64
 }
 
 // PdhFmtCounterValueLong is a union specialization for long values.
-type PdhFmtCountervalueLong struct {
+type PdhFmtCounterValueLong struct {
 	CStatus   uint32
 	LongValue int32
 	padding   [4]byte //nolint:unused // Memory reservation
 }
 
+// PdhFmtCountervalueItemDouble is a union specialization for double values, used by PdhGetFormattedCounterArrayDouble.
 type PdhFmtCountervalueItemDouble struct {
 	SzName   *uint16
 	FmtValue PdhFmtCountervalueDouble
 }
 
 // PdhFmtCounterValueItemLarge is a union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge().
-type PdhFmtCountervalueItemLarge struct {
+type PdhFmtCounterValueItemLarge struct {
 	SzName   *uint16 // pointer to a string
-	FmtValue PdhFmtCountervalueLarge
+	FmtValue PdhFmtCounterValueLarge
 }
 
 // PdhFmtCounterValueItemLong is a union specialization for long values, used by PdhGetFormattedCounterArrayLong().
-type PdhFmtCountervalueItemLong struct {
+type PdhFmtCounterValueItemLong struct {
 	SzName   *uint16 // pointer to a string
-	FmtValue PdhFmtCountervalueLong
+	FmtValue PdhFmtCounterValueLong
 }
 
 // PdhCounterInfo structure contains information describing the properties of a counter. This information also includes the counter path.
 type PdhCounterInfo struct {
 	// Size of the structure, including the appended strings, in bytes.
 	DwLength uint32
-	// Counter type. For a list of counter types, see the Counter Types section
-	// of the Windows Server 2003 Deployment Kit (http://go.microsoft.com/fwlink/p/?linkid=84422).
+	// Counter type. For a list of counter types,
+	// see the Counter Types section of the <a "href=http://go.microsoft.com/fwlink/p/?linkid=84422">Windows Server 2003 Deployment Kit</a>.
 	// The counter type constants are defined in Winperf.h.
 	DwType uint32
 	// Counter version information. Not used.
@@ -105,8 +106,7 @@ type PdhCounterInfo struct {
 	// The string follows this structure in memory.
 	SzInstanceName *uint16 // pointer to a string
 	// Null-terminated string that contains the name of the parent instance specified in the counter path.
-	// Is NULL, if the path does not specify a parent instance.
-	// The string follows this structure in memory.
+	// Is NULL, if the path does not specify a parent instance. The string follows this structure in memory.
 	SzParentInstance *uint16 // pointer to a string
 	// Instance index specified in the counter path. Is 0, if the path does not specify an instance index.
 	DwInstanceIndex uint32 // pointer to a string

--- a/internal/pdh/pdh_arm64.go
+++ b/internal/pdh/pdh_arm64.go
@@ -31,7 +31,7 @@
 
 //go:build windows
 
-package perfdata
+package pdh
 
 import "golang.org/x/sys/windows"
 
@@ -42,42 +42,41 @@ type PdhFmtCountervalueDouble struct {
 }
 
 // PdhFmtCounterValueLarge is a union specialization for 64-bit integer values.
-type PdhFmtCounterValueLarge struct {
+type PdhFmtCountervalueLarge struct {
 	CStatus    uint32
 	LargeValue int64
 }
 
 // PdhFmtCounterValueLong is a union specialization for long values.
-type PdhFmtCounterValueLong struct {
+type PdhFmtCountervalueLong struct {
 	CStatus   uint32
 	LongValue int32
 	padding   [4]byte //nolint:unused // Memory reservation
 }
 
-// PdhFmtCountervalueItemDouble is a union specialization for double values, used by PdhGetFormattedCounterArrayDouble.
 type PdhFmtCountervalueItemDouble struct {
 	SzName   *uint16
 	FmtValue PdhFmtCountervalueDouble
 }
 
 // PdhFmtCounterValueItemLarge is a union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge().
-type PdhFmtCounterValueItemLarge struct {
+type PdhFmtCountervalueItemLarge struct {
 	SzName   *uint16 // pointer to a string
-	FmtValue PdhFmtCounterValueLarge
+	FmtValue PdhFmtCountervalueLarge
 }
 
 // PdhFmtCounterValueItemLong is a union specialization for long values, used by PdhGetFormattedCounterArrayLong().
-type PdhFmtCounterValueItemLong struct {
+type PdhFmtCountervalueItemLong struct {
 	SzName   *uint16 // pointer to a string
-	FmtValue PdhFmtCounterValueLong
+	FmtValue PdhFmtCountervalueLong
 }
 
 // PdhCounterInfo structure contains information describing the properties of a counter. This information also includes the counter path.
 type PdhCounterInfo struct {
 	// Size of the structure, including the appended strings, in bytes.
 	DwLength uint32
-	// Counter type. For a list of counter types,
-	// see the Counter Types section of the <a "href=http://go.microsoft.com/fwlink/p/?linkid=84422">Windows Server 2003 Deployment Kit</a>.
+	// Counter type. For a list of counter types, see the Counter Types section
+	// of the Windows Server 2003 Deployment Kit (http://go.microsoft.com/fwlink/p/?linkid=84422).
 	// The counter type constants are defined in Winperf.h.
 	DwType uint32
 	// Counter version information. Not used.
@@ -106,7 +105,8 @@ type PdhCounterInfo struct {
 	// The string follows this structure in memory.
 	SzInstanceName *uint16 // pointer to a string
 	// Null-terminated string that contains the name of the parent instance specified in the counter path.
-	// Is NULL, if the path does not specify a parent instance. The string follows this structure in memory.
+	// Is NULL, if the path does not specify a parent instance.
+	// The string follows this structure in memory.
 	SzParentInstance *uint16 // pointer to a string
 	// Instance index specified in the counter path. Is 0, if the path does not specify an instance index.
 	DwInstanceIndex uint32 // pointer to a string

--- a/internal/pdh/registry/LICENSE
+++ b/internal/pdh/registry/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Leopold Schabel / The perflib_exporter authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/internal/pdh/registry/collector.go
+++ b/internal/pdh/registry/collector.go
@@ -1,0 +1,119 @@
+package registry
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Collector struct {
+	object string
+	query  string
+}
+
+type Counter struct {
+	Name      string
+	Desc      string
+	Instances map[string]uint32
+	Type      uint32
+	Frequency float64
+}
+
+func NewCollector(object string, _ []string, _ []string) (*Collector, error) {
+	collector := &Collector{
+		object: object,
+		query:  MapCounterToIndex(object),
+	}
+
+	if _, err := collector.Collect(); err != nil {
+		return nil, fmt.Errorf("failed to collect initial data: %w", err)
+	}
+
+	return collector, nil
+}
+
+func (c *Collector) Describe() map[string]string {
+	return map[string]string{}
+}
+
+func (c *Collector) Collect() (pdh.CounterValues, error) {
+	perfObjects, err := QueryPerformanceData(c.query, c.object)
+	if err != nil {
+		return nil, fmt.Errorf("QueryPerformanceData: %w", err)
+	}
+
+	if len(perfObjects) == 0 || perfObjects[0] == nil || len(perfObjects[0].Instances) == 0 {
+		return pdh.CounterValues{}, nil
+	}
+
+	data := make(pdh.CounterValues, len(perfObjects[0].Instances))
+
+	for _, perfObject := range perfObjects {
+		if perfObject.Name != c.object {
+			continue
+		}
+
+		for _, perfInstance := range perfObject.Instances {
+			instanceName := perfInstance.Name
+			if strings.HasSuffix(instanceName, "_Total") {
+				continue
+			}
+
+			if instanceName == "" || instanceName == "*" {
+				instanceName = pdh.InstanceEmpty
+			}
+
+			if _, ok := data[instanceName]; !ok {
+				if _, ok := data[instanceName]; !ok {
+					data[instanceName] = make(map[string]pdh.CounterValue, len(perfInstance.Counters))
+				}
+			}
+
+			for _, perfCounter := range perfInstance.Counters {
+				if perfCounter.Def.IsBaseValue && !perfCounter.Def.IsNanosecondCounter {
+					continue
+				}
+
+				if _, ok := data[instanceName][perfCounter.Def.Name]; !ok {
+					data[instanceName][perfCounter.Def.Name] = pdh.CounterValue{
+						Type: prometheus.GaugeValue,
+					}
+				}
+
+				var metricType prometheus.ValueType
+				if val, ok := pdh.SupportedCounterTypes[perfCounter.Def.CounterType]; ok {
+					metricType = val
+				} else {
+					metricType = prometheus.GaugeValue
+				}
+
+				values := pdh.CounterValue{
+					Type: metricType,
+				}
+
+				switch perfCounter.Def.CounterType {
+				case pdh.PERF_ELAPSED_TIME:
+					values.FirstValue = float64(perfCounter.Value-pdh.WindowsEpoch) / float64(perfObject.Frequency)
+					values.SecondValue = float64(perfCounter.SecondValue-pdh.WindowsEpoch) / float64(perfObject.Frequency)
+				case pdh.PERF_100NSEC_TIMER, pdh.PERF_PRECISION_100NS_TIMER:
+					values.FirstValue = float64(perfCounter.Value) * pdh.TicksToSecondScaleFactor
+					values.SecondValue = float64(perfCounter.SecondValue) * pdh.TicksToSecondScaleFactor
+				case pdh.PERF_AVERAGE_BULK, pdh.PERF_RAW_FRACTION:
+					values.FirstValue = float64(perfCounter.Value)
+					values.SecondValue = float64(perfCounter.SecondValue)
+				default:
+					values.FirstValue = float64(perfCounter.Value)
+				}
+
+				data[instanceName][perfCounter.Def.Name] = values
+			}
+		}
+	}
+
+	return data, nil
+}
+
+func (c *Collector) Close() {
+}

--- a/internal/pdh/registry/nametable.go
+++ b/internal/pdh/registry/nametable.go
@@ -1,0 +1,85 @@
+package registry
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+// Initialize global name tables
+// TODO: profiling, add option to disable name tables if necessary
+// Not sure if we should resolve the names at all or just have the caller do it on demand
+// (for many use cases the index is sufficient)
+
+var CounterNameTable = *QueryNameTable("Counter 009")
+
+func (p *perfObjectType) LookupName() string {
+	return CounterNameTable.LookupString(p.ObjectNameTitleIndex)
+}
+
+type NameTable struct {
+	once sync.Once
+
+	name string
+
+	table struct {
+		index  map[uint32]string
+		string map[string]uint32
+	}
+}
+
+func (t *NameTable) LookupString(index uint32) string {
+	t.initialize()
+
+	return t.table.index[index]
+}
+
+func (t *NameTable) LookupIndex(str string) uint32 {
+	t.initialize()
+
+	return t.table.string[str]
+}
+
+// QueryNameTable Query a perflib name table from the v1. Specify the type and the language
+// code (i.e. "Counter 009" or "Help 009") for English language.
+func QueryNameTable(tableName string) *NameTable {
+	return &NameTable{
+		name: tableName,
+	}
+}
+
+func (t *NameTable) initialize() {
+	t.once.Do(func() {
+		t.table.index = make(map[uint32]string)
+		t.table.string = make(map[string]uint32)
+
+		buffer, err := queryRawData(t.name)
+		if err != nil {
+			panic(err)
+		}
+
+		r := bytes.NewReader(buffer)
+
+		for {
+			index, err := readUTF16String(r)
+			if err != nil {
+				break
+			}
+
+			desc, err := readUTF16String(r)
+			if err != nil {
+				break
+			}
+
+			if err != nil {
+				panic(fmt.Sprint("Invalid index ", index))
+			}
+
+			indexInt, _ := strconv.Atoi(index)
+
+			t.table.index[uint32(indexInt)] = desc
+			t.table.string[desc] = uint32(indexInt)
+		}
+	})
+}

--- a/internal/pdh/registry/perflib.go
+++ b/internal/pdh/registry/perflib.go
@@ -120,7 +120,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/prometheus-community/windows_exporter/internal/pdh/perftypes"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"golang.org/x/sys/windows"
 )
 
@@ -364,7 +364,7 @@ func QueryPerformanceData(query string, counterName string) ([]*PerfObject, erro
 				IsCounter:           def.CounterType&0x400 == 0x400,
 				IsBaseValue:         def.CounterType&0x00030000 == 0x00030000,
 				IsNanosecondCounter: def.CounterType&0x00100000 == 0x00100000,
-				HasSecondValue:      def.CounterType == perftypes.PERF_AVERAGE_BULK,
+				HasSecondValue:      def.CounterType == pdh.PERF_AVERAGE_BULK,
 			}
 		}
 

--- a/internal/pdh/registry/perflib.go
+++ b/internal/pdh/registry/perflib.go
@@ -1,0 +1,490 @@
+package registry
+
+/*
+Go bindings for the HKEY_PERFORMANCE_DATA perflib / Performance Counters interface.
+
+# Overview
+
+HKEY_PERFORMANCE_DATA is a low-level alternative to the higher-level PDH library and WMI.
+It operates on blocks of counters and only returns raw values without calculating rates
+or formatting them, which is exactly what you want for, say, a Prometheus exporter
+(not so much for a GUI like Windows Performance Monitor).
+
+Its overhead is much lower than the high-level libraries.
+
+It operates on the same set of perflib providers as PDH and WMI. See this document
+for more details on the relationship between the different libraries:
+https://msdn.microsoft.com/en-us/library/windows/desktop/aa371643(v=vs.85).aspx
+
+Example C++ source code:
+https://msdn.microsoft.com/de-de/library/windows/desktop/aa372138(v=vs.85).aspx
+
+For now, the API is not stable and is probably going to change in future
+perflib_exporter releases. If you want to use this library, send the author an email
+so we can discuss your requirements and stabilize the API.
+
+# Names
+
+Counter names and help texts are resolved by looking up an index in a name table.
+Since Microsoft loves internalization, both names and help texts can be requested
+any locally available language.
+
+The library automatically loads the name tables and resolves all identifiers
+in English ("Name" and "HelpText" struct members). You can manually resolve
+identifiers in a different language by using the NameTable API.
+
+# Performance Counters intro
+
+Windows has a system-wide performance counter mechanism. Most performance counters
+are stored as actual counters, not gauges (with some exceptions).
+There's additional metadata which defines how the counter should be presented to the user
+(for example, as a calculated rate). This library disregards all of the display metadata.
+
+At the top level, there's a number of performance counter objects.
+Each object has counter definitions, which contain the metadata for a particular
+counter, and either zero or multiple instances. We hide the fact that there are
+objects with no instances, and simply return a single null instance.
+
+There's one counter per counter definition and instance (or the object itself, if
+there are no instances).
+
+Behind the scenes, every perflib DLL provides one or more objects.
+Perflib has a v1 where DLLs are dynamically registered and
+unregistered. Some third party applications like VMWare provide their own counters,
+but this is, sadly, a rare occurrence.
+
+Different Windows releases have different numbers of counters.
+
+Objects and counters are identified by well-known indices.
+
+Here's an example object with one instance:
+
+	4320 WSMan Quota Statistics [7 counters, 1 instance(s)]
+	`-- "WinRMService"
+		`-- Total Requests/Second [4322] = 59
+		`-- User Quota Violations/Second [4324] = 0
+		`-- System Quota Violations/Second [4326] = 0
+		`-- Active Shells [4328] = 0
+		`-- Active Operations [4330] = 0
+		`-- Active Users [4332] = 0
+		`-- Process ID [4334] = 928
+
+All "per second" metrics are counters, the rest are gauges.
+
+Another example, with no instance:
+
+	4600 Network QoS Policy [6 counters, 1 instance(s)]
+	`-- (default)
+		`-- Packets transmitted [4602] = 1744
+		`-- Packets transmitted/sec [4604] = 4852
+		`-- Bytes transmitted [4606] = 4853
+		`-- Bytes transmitted/sec [4608] = 180388626632
+		`-- Packets dropped [4610] = 0
+		`-- Packets dropped/sec [4612] = 0
+
+You can access the same values using PowerShell's Get-Counter cmdlet
+or the Performance Monitor.
+
+	> Get-Counter '\WSMan Quota Statistics(WinRMService)\Process ID'
+
+	Timestamp                 CounterSamples
+	---------                 --------------
+	1/28/2018 10:18:00 PM     \\DEV\wsman quota statistics(winrmservice)\process id :
+							  928
+
+	>  (Get-Counter '\Process(Idle)\% Processor Time').CounterSamples[0] | Format-List *
+	[..detailed output...]
+
+Data for some of the objects is also available through WMI:
+
+	> Get-CimInstance Win32_PerfRawData_Counters_WSManQuotaStatistics
+
+	Name                           : WinRMService
+	[...]
+	ActiveOperations               : 0
+	ActiveShells                   : 0
+	ActiveUsers                    : 0
+	ProcessID                      : 928
+	SystemQuotaViolationsPerSecond : 0
+	TotalRequestsPerSecond         : 59
+	UserQuotaViolationsPerSecond   : 0
+*/
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/prometheus-community/windows_exporter/internal/pdh/perftypes"
+	"golang.org/x/sys/windows"
+)
+
+// TODO: There's a LittleEndian field in the PERF header - we ought to check it.
+var bo = binary.LittleEndian
+
+// PerfObject Top-level performance object (like "Process").
+type PerfObject struct {
+	Name string
+	// NameIndex Same index you pass to QueryPerformanceData
+	NameIndex   uint
+	Instances   []*PerfInstance
+	CounterDefs []*PerfCounterDef
+
+	Frequency int64
+
+	rawData *perfObjectType
+}
+
+// PerfInstance Each object can have multiple instances. For example,
+// In case the object has no instances, we return one single PerfInstance with an empty name.
+type PerfInstance struct {
+	// *not* resolved using a name table
+	Name     string
+	Counters []*PerfCounter
+
+	rawData         *perfInstanceDefinition
+	rawCounterBlock *perfCounterBlock
+}
+
+type PerfCounterDef struct {
+	Name      string
+	NameIndex uint
+
+	// For debugging - subject to removal. CounterType is a perflib
+	// implementation detail (see perflib.h) and should not be used outside
+	// of this package. We export it so we can show it on /dump.
+	CounterType uint32
+
+	// PERF_TYPE_COUNTER (otherwise, it's a gauge)
+	IsCounter bool
+	// PERF_COUNTER_BASE (base value of a multi-value fraction)
+	IsBaseValue bool
+	// PERF_TIMER_100NS
+	IsNanosecondCounter bool
+	HasSecondValue      bool
+
+	rawData *perfCounterDefinition
+}
+
+type PerfCounter struct {
+	Value       int64
+	Def         *PerfCounterDef
+	SecondValue int64
+}
+
+var (
+	bufLenGlobal = uint32(400000)
+	bufLenCostly = uint32(2000000)
+)
+
+// queryRawData Queries the performance counter buffer using RegQueryValueEx, returning raw bytes. See:
+// https://msdn.microsoft.com/de-de/library/windows/desktop/aa373219(v=vs.85).aspx
+func queryRawData(query string) ([]byte, error) {
+	var (
+		valType uint32
+		buffer  []byte
+		bufLen  uint32
+	)
+
+	switch query {
+	case "Global":
+		bufLen = bufLenGlobal
+	case "Costly":
+		bufLen = bufLenCostly
+	default:
+		// TODO: depends on the number of values requested
+		// need make an educated guess
+		numCounters := len(strings.Split(query, " "))
+		bufLen = uint32(150000 * numCounters)
+	}
+
+	buffer = make([]byte, bufLen)
+
+	name, err := windows.UTF16PtrFromString(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode query string: %w", err)
+	}
+
+	for {
+		bufLen := uint32(len(buffer))
+
+		err := windows.RegQueryValueEx(
+			windows.HKEY_PERFORMANCE_DATA,
+			name,
+			nil,
+			&valType,
+			(*byte)(unsafe.Pointer(&buffer[0])),
+			&bufLen)
+
+		switch {
+		case errors.Is(err, error(windows.ERROR_MORE_DATA)):
+			newBuffer := make([]byte, len(buffer)+16384)
+			copy(newBuffer, buffer)
+			buffer = newBuffer
+
+			continue
+		case errors.Is(err, error(windows.ERROR_BUSY)):
+			time.Sleep(50 * time.Millisecond)
+
+			continue
+		case err != nil:
+			var errNo windows.Errno
+			if errors.As(err, &errNo) {
+				return nil, fmt.Errorf("ReqQueryValueEx failed: %w errno %d", err, uint(errNo))
+			}
+
+			return nil, err
+		}
+
+		buffer = buffer[:bufLen]
+
+		switch query {
+		case "Global":
+			if bufLen > bufLenGlobal {
+				bufLenGlobal = bufLen
+			}
+		case "Costly":
+			if bufLen > bufLenCostly {
+				bufLenCostly = bufLen
+			}
+		}
+
+		return buffer, nil
+	}
+}
+
+/*
+QueryPerformanceData Query all performance counters that match a given query.
+
+The query can be any of the following:
+
+- "Global" (all performance counters except those Windows marked as costly)
+
+- "Costly" (only the costly ones)
+
+- One or more object indices, separated by spaces ("238 2 5")
+
+Many objects have dependencies - if you query one of them, you often get back
+more than you asked for.
+*/
+func QueryPerformanceData(query string, counterName string) ([]*PerfObject, error) {
+	buffer, err := queryRawData(query)
+	if err != nil {
+		return nil, err
+	}
+
+	r := bytes.NewReader(buffer)
+
+	// Read global header
+
+	header := new(perfDataBlock)
+
+	err = header.BinaryReadFrom(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read performance data block for %q with: %w", query, err)
+	}
+
+	// Check for "PERF" signature
+	if header.Signature != [4]uint16{80, 69, 82, 70} {
+		panic("Invalid performance block header")
+	}
+
+	// Parse the performance data
+
+	numObjects := int(header.NumObjectTypes)
+	numFilteredObjects := 0
+
+	objects := make([]*PerfObject, numObjects)
+
+	objOffset := int64(header.HeaderLength)
+
+	for i := range numObjects {
+		_, err := r.Seek(objOffset, io.SeekStart)
+		if err != nil {
+			return nil, err
+		}
+
+		obj := new(perfObjectType)
+
+		err = obj.BinaryReadFrom(r)
+		if err != nil {
+			return nil, err
+		}
+
+		perfCounterName := obj.LookupName()
+
+		if counterName != "" && perfCounterName != counterName {
+			objOffset += int64(obj.TotalByteLength)
+
+			continue
+		}
+
+		numCounterDefs := int(obj.NumCounters)
+		numInstances := int(obj.NumInstances)
+
+		// Perf objects can have no instances. The perflib differentiates
+		// between objects with instances and without, but we just create
+		// an empty instance in order to simplify the interface.
+		if numInstances <= 0 {
+			numInstances = 1
+		}
+
+		instances := make([]*PerfInstance, numInstances)
+		counterDefs := make([]*PerfCounterDef, numCounterDefs)
+
+		objects[i] = &PerfObject{
+			Name:        perfCounterName,
+			NameIndex:   uint(obj.ObjectNameTitleIndex),
+			Instances:   instances,
+			CounterDefs: counterDefs,
+			Frequency:   obj.PerfFreq,
+			rawData:     obj,
+		}
+
+		for i := range numCounterDefs {
+			def := new(perfCounterDefinition)
+
+			err := def.BinaryReadFrom(r)
+			if err != nil {
+				return nil, err
+			}
+
+			counterDefs[i] = &PerfCounterDef{
+				Name:      def.LookupName(),
+				NameIndex: uint(def.CounterNameTitleIndex),
+				rawData:   def,
+
+				CounterType: def.CounterType,
+
+				IsCounter:           def.CounterType&0x400 == 0x400,
+				IsBaseValue:         def.CounterType&0x00030000 == 0x00030000,
+				IsNanosecondCounter: def.CounterType&0x00100000 == 0x00100000,
+				HasSecondValue:      def.CounterType == perftypes.PERF_AVERAGE_BULK,
+			}
+		}
+
+		if obj.NumInstances <= 0 { //nolint:nestif
+			blockOffset := objOffset + int64(obj.DefinitionLength)
+
+			if _, err := r.Seek(blockOffset, io.SeekStart); err != nil {
+				return nil, err
+			}
+
+			_, counters, err := parseCounterBlock(buffer, r, blockOffset, counterDefs)
+			if err != nil {
+				return nil, err
+			}
+
+			instances[0] = &PerfInstance{
+				Name:            "",
+				Counters:        counters,
+				rawData:         nil,
+				rawCounterBlock: nil,
+			}
+		} else {
+			instOffset := objOffset + int64(obj.DefinitionLength)
+
+			for i := range numInstances {
+				if _, err := r.Seek(instOffset, io.SeekStart); err != nil {
+					return nil, err
+				}
+
+				inst := new(perfInstanceDefinition)
+
+				if err = inst.BinaryReadFrom(r); err != nil {
+					return nil, err
+				}
+
+				name, _ := readUTF16StringAtPos(r, instOffset+int64(inst.NameOffset), inst.NameLength)
+				pos := instOffset + int64(inst.ByteLength)
+
+				offset, counters, err := parseCounterBlock(buffer, r, pos, counterDefs)
+				if err != nil {
+					return nil, err
+				}
+
+				instances[i] = &PerfInstance{
+					Name:     name,
+					Counters: counters,
+					rawData:  inst,
+				}
+
+				instOffset = pos + offset
+			}
+		}
+
+		if counterName != "" {
+			return objects[i : i+1], nil
+		}
+
+		// Next perfObjectType
+		objOffset += int64(obj.TotalByteLength)
+		numFilteredObjects++
+	}
+
+	return objects[:numFilteredObjects], nil
+}
+
+func parseCounterBlock(b []byte, r io.ReadSeeker, pos int64, defs []*PerfCounterDef) (int64, []*PerfCounter, error) {
+	_, err := r.Seek(pos, io.SeekStart)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	block := new(perfCounterBlock)
+
+	err = block.BinaryReadFrom(r)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	counters := make([]*PerfCounter, len(defs))
+
+	for i, def := range defs {
+		valueOffset := pos + int64(def.rawData.CounterOffset)
+		value := convertCounterValue(def.rawData, b, valueOffset)
+		secondValue := int64(0)
+
+		if def.HasSecondValue {
+			secondValue = convertCounterValue(def.rawData, b, valueOffset+8)
+		}
+
+		counters[i] = &PerfCounter{
+			Value:       value,
+			Def:         def,
+			SecondValue: secondValue,
+		}
+	}
+
+	return int64(block.ByteLength), counters, nil
+}
+
+func convertCounterValue(counterDef *perfCounterDefinition, buffer []byte, valueOffset int64) int64 {
+	/*
+		We can safely ignore the type since we're not interested in anything except the raw value.
+		We also ignore all of the other attributes (timestamp, presentation, multi counter values...)
+
+		See also: winperf.h.
+
+		Here's the most common value for CounterType:
+
+			65536	32bit counter
+			65792	64bit counter
+			272696320	32bit rate
+			272696576	64bit rate
+
+	*/
+	switch counterDef.CounterSize {
+	case 4:
+		return int64(bo.Uint32(buffer[valueOffset:(valueOffset + 4)]))
+	case 8:
+		return int64(bo.Uint64(buffer[valueOffset:(valueOffset + 8)]))
+	default:
+		return int64(bo.Uint32(buffer[valueOffset:(valueOffset + 4)]))
+	}
+}

--- a/internal/pdh/registry/perflib_test.go
+++ b/internal/pdh/registry/perflib_test.go
@@ -1,0 +1,11 @@
+package registry
+
+import (
+	"testing"
+)
+
+func BenchmarkQueryPerformanceData(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, _ = QueryPerformanceData("Global", "")
+	}
+}

--- a/internal/pdh/registry/raw_types.go
+++ b/internal/pdh/registry/raw_types.go
@@ -1,0 +1,173 @@
+package registry
+
+import (
+	"encoding/binary"
+	"io"
+
+	"golang.org/x/sys/windows"
+)
+
+/*
+perfDataBlock
+See: https://msdn.microsoft.com/de-de/library/windows/desktop/aa373157(v=vs.85).aspx
+
+	typedef struct _PERF_DATA_BLOCK {
+	  WCHAR         Signature[4];
+	  DWORD         LittleEndian;
+	  DWORD         Version;
+	  DWORD         Revision;
+	  DWORD         TotalByteLength;
+	  DWORD         HeaderLength;
+	  DWORD         NumObjectTypes;
+	  DWORD         DefaultObject;
+	  SYSTEMTIME    SystemTime;
+	  LARGE_INTEGER PerfTime;
+	  LARGE_INTEGER PerfFreq;
+	  LARGE_INTEGER PerfTime100nSec;
+	  DWORD         SystemNameLength;
+	  DWORD         SystemNameOffset;
+	} PERF_DATA_BLOCK;
+*/
+type perfDataBlock struct {
+	Signature        [4]uint16
+	LittleEndian     uint32
+	Version          uint32
+	Revision         uint32
+	TotalByteLength  uint32
+	HeaderLength     uint32
+	NumObjectTypes   uint32
+	DefaultObject    int32
+	SystemTime       windows.Systemtime
+	_                uint32 // TODO
+	PerfTime         int64
+	PerfFreq         int64
+	PerfTime100nSec  int64
+	SystemNameLength uint32
+	SystemNameOffset uint32
+}
+
+func (p *perfDataBlock) BinaryReadFrom(r io.Reader) error {
+	return binary.Read(r, bo, p)
+}
+
+/*
+perfObjectType
+See: https://msdn.microsoft.com/en-us/library/windows/desktop/aa373160(v=vs.85).aspx
+
+	typedef struct _PERF_OBJECT_TYPE {
+	  DWORD         TotalByteLength;
+	  DWORD         DefinitionLength;
+	  DWORD         HeaderLength;
+	  DWORD         ObjectNameTitleIndex;
+	  LPWSTR        ObjectNameTitle;
+	  DWORD         ObjectHelpTitleIndex;
+	  LPWSTR        ObjectHelpTitle;
+	  DWORD         DetailLevel;
+	  DWORD         NumCounters;
+	  DWORD         DefaultCounter;
+	  DWORD         NumInstances;
+	  DWORD         CodePage;
+	  LARGE_INTEGER PerfTime;
+	  LARGE_INTEGER PerfFreq;
+	} PERF_OBJECT_TYPE;
+*/
+type perfObjectType struct {
+	TotalByteLength      uint32
+	DefinitionLength     uint32
+	HeaderLength         uint32
+	ObjectNameTitleIndex uint32
+	ObjectNameTitle      uint32
+	ObjectHelpTitleIndex uint32
+	ObjectHelpTitle      uint32
+	DetailLevel          uint32
+	NumCounters          uint32
+	DefaultCounter       int32
+	NumInstances         int32
+	CodePage             uint32
+	PerfTime             int64
+	PerfFreq             int64
+}
+
+func (p *perfObjectType) BinaryReadFrom(r io.Reader) error {
+	return binary.Read(r, bo, p)
+}
+
+/*
+perfCounterDefinition
+See: https://msdn.microsoft.com/en-us/library/windows/desktop/aa373150(v=vs.85).aspx
+
+	typedef struct _PERF_COUNTER_DEFINITION {
+	  DWORD  ByteLength;
+	  DWORD  CounterNameTitleIndex;
+	  LPWSTR CounterNameTitle;
+	  DWORD  CounterHelpTitleIndex;
+	  LPWSTR CounterHelpTitle;
+	  LONG   DefaultScale;
+	  DWORD  DetailLevel;
+	  DWORD  CounterType;
+	  DWORD  CounterSize;
+	  DWORD  CounterOffset;
+	} PERF_COUNTER_DEFINITION;
+*/
+type perfCounterDefinition struct {
+	ByteLength            uint32
+	CounterNameTitleIndex uint32
+	CounterNameTitle      uint32
+	CounterHelpTitleIndex uint32
+	CounterHelpTitle      uint32
+	DefaultScale          int32
+	DetailLevel           uint32
+	CounterType           uint32
+	CounterSize           uint32
+	CounterOffset         uint32
+}
+
+func (p *perfCounterDefinition) BinaryReadFrom(r io.Reader) error {
+	return binary.Read(r, bo, p)
+}
+
+func (p *perfCounterDefinition) LookupName() string {
+	return CounterNameTable.LookupString(p.CounterNameTitleIndex)
+}
+
+/*
+perfCounterBlock
+See: https://msdn.microsoft.com/en-us/library/windows/desktop/aa373147(v=vs.85).aspx
+
+	typedef struct _PERF_COUNTER_BLOCK {
+	  DWORD ByteLength;
+	} PERF_COUNTER_BLOCK;
+*/
+type perfCounterBlock struct {
+	ByteLength uint32
+}
+
+func (p *perfCounterBlock) BinaryReadFrom(r io.Reader) error {
+	return binary.Read(r, bo, p)
+}
+
+/*
+perfInstanceDefinition
+See: https://msdn.microsoft.com/en-us/library/windows/desktop/aa373159(v=vs.85).aspx
+
+	typedef struct _PERF_INSTANCE_DEFINITION {
+	  DWORD ByteLength;
+	  DWORD ParentObjectTitleIndex;
+	  DWORD ParentObjectInstance;
+	  DWORD UniqueID;
+	  DWORD NameOffset;
+	  DWORD NameLength;
+	} PERF_INSTANCE_DEFINITION;
+*/
+type perfInstanceDefinition struct {
+	ByteLength             uint32
+	ParentObjectTitleIndex uint32
+	ParentObjectInstance   uint32
+	UniqueID               uint32
+	NameOffset             uint32
+	NameLength             uint32
+}
+
+func (p *perfInstanceDefinition) BinaryReadFrom(r io.Reader) error {
+	return binary.Read(r, bo, p)
+}

--- a/internal/pdh/registry/unmarshal.go
+++ b/internal/pdh/registry/unmarshal.go
@@ -1,0 +1,117 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"strings"
+
+	"github.com/prometheus-community/windows_exporter/internal/pdh/perftypes"
+)
+
+func UnmarshalObject(obj *PerfObject, vs interface{}, logger *slog.Logger) error {
+	if obj == nil {
+		return errors.New("counter not found")
+	}
+
+	rv := reflect.ValueOf(vs)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return fmt.Errorf("%v is nil or not a pointer to slice", reflect.TypeOf(vs))
+	}
+
+	ev := rv.Elem()
+	if ev.Kind() != reflect.Slice {
+		return fmt.Errorf("%v is not slice", reflect.TypeOf(vs))
+	}
+
+	// Ensure sufficient length
+	if ev.Cap() < len(obj.Instances) {
+		nvs := reflect.MakeSlice(ev.Type(), len(obj.Instances), len(obj.Instances))
+		ev.Set(nvs)
+	}
+
+	for idx, instance := range obj.Instances {
+		target := ev.Index(idx)
+		rt := target.Type()
+
+		counters := make(map[string]*PerfCounter, len(instance.Counters))
+
+		for _, ctr := range instance.Counters {
+			if ctr.Def.IsBaseValue && !ctr.Def.IsNanosecondCounter {
+				counters[ctr.Def.Name+"_Base"] = ctr
+			} else {
+				counters[ctr.Def.Name] = ctr
+			}
+		}
+
+		for i := range target.NumField() {
+			f := rt.Field(i)
+
+			tag := f.Tag.Get("perflib")
+			if tag == "" {
+				continue
+			}
+
+			secondValue := false
+
+			st := strings.Split(tag, ",")
+			tag = st[0]
+
+			for _, t := range st {
+				if t == "secondvalue" {
+					secondValue = true
+				}
+			}
+
+			ctr, found := counters[tag]
+			if !found {
+				logger.Debug(fmt.Sprintf("missing counter %q, have %v", tag, counterMapKeys(counters)))
+
+				continue
+			}
+
+			if !target.Field(i).CanSet() {
+				return fmt.Errorf("tagged field %v cannot be written to", f.Name)
+			}
+
+			if fieldType := target.Field(i).Type(); fieldType != reflect.TypeOf((*float64)(nil)).Elem() {
+				return fmt.Errorf("tagged field %v has wrong type %v, must be float64", f.Name, fieldType)
+			}
+
+			if secondValue {
+				if !ctr.Def.HasSecondValue {
+					return fmt.Errorf("tagged field %v expected a SecondValue, which was not present", f.Name)
+				}
+
+				target.Field(i).SetFloat(float64(ctr.SecondValue))
+
+				continue
+			}
+
+			switch ctr.Def.CounterType {
+			case perftypes.PERF_ELAPSED_TIME:
+				target.Field(i).SetFloat(float64(ctr.Value-perftypes.WindowsEpoch) / float64(obj.Frequency))
+			case perftypes.PERF_100NSEC_TIMER, perftypes.PERF_PRECISION_100NS_TIMER:
+				target.Field(i).SetFloat(float64(ctr.Value) * perftypes.TicksToSecondScaleFactor)
+			default:
+				target.Field(i).SetFloat(float64(ctr.Value))
+			}
+		}
+
+		if instance.Name != "" && target.FieldByName("Name").CanSet() {
+			target.FieldByName("Name").SetString(instance.Name)
+		}
+	}
+
+	return nil
+}
+
+func counterMapKeys(m map[string]*PerfCounter) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	return keys
+}

--- a/internal/pdh/registry/unmarshal.go
+++ b/internal/pdh/registry/unmarshal.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/prometheus-community/windows_exporter/internal/pdh/perftypes"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 )
 
 func UnmarshalObject(obj *PerfObject, vs interface{}, logger *slog.Logger) error {
@@ -90,10 +90,10 @@ func UnmarshalObject(obj *PerfObject, vs interface{}, logger *slog.Logger) error
 			}
 
 			switch ctr.Def.CounterType {
-			case perftypes.PERF_ELAPSED_TIME:
-				target.Field(i).SetFloat(float64(ctr.Value-perftypes.WindowsEpoch) / float64(obj.Frequency))
-			case perftypes.PERF_100NSEC_TIMER, perftypes.PERF_PRECISION_100NS_TIMER:
-				target.Field(i).SetFloat(float64(ctr.Value) * perftypes.TicksToSecondScaleFactor)
+			case pdh.PERF_ELAPSED_TIME:
+				target.Field(i).SetFloat(float64(ctr.Value-pdh.WindowsEpoch) / float64(obj.Frequency))
+			case pdh.PERF_100NSEC_TIMER, pdh.PERF_PRECISION_100NS_TIMER:
+				target.Field(i).SetFloat(float64(ctr.Value) * pdh.TicksToSecondScaleFactor)
 			default:
 				target.Field(i).SetFloat(float64(ctr.Value))
 			}

--- a/internal/pdh/registry/utf16.go
+++ b/internal/pdh/registry/utf16.go
@@ -1,0 +1,49 @@
+package registry
+
+import (
+	"encoding/binary"
+	"io"
+
+	"golang.org/x/sys/windows"
+)
+
+// readUTF16StringAtPos Read an unterminated UTF16 string at a given position, specifying its length.
+func readUTF16StringAtPos(r io.ReadSeeker, absPos int64, length uint32) (string, error) {
+	value := make([]uint16, length/2)
+
+	_, err := r.Seek(absPos, io.SeekStart)
+	if err != nil {
+		return "", err
+	}
+
+	err = binary.Read(r, bo, value)
+	if err != nil {
+		return "", err
+	}
+
+	return windows.UTF16ToString(value), nil
+}
+
+// readUTF16String Reads a null-terminated UTF16 string at the current offset.
+func readUTF16String(r io.Reader) (string, error) {
+	var err error
+
+	b := make([]byte, 2)
+	out := make([]uint16, 0, 100)
+
+	for i := 0; err == nil; i += 2 {
+		_, err = r.Read(b)
+
+		if b[0] == 0 && b[1] == 0 {
+			break
+		}
+
+		out = append(out, bo.Uint16(b))
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return windows.UTF16ToString(out), nil
+}

--- a/internal/pdh/registry/utils.go
+++ b/internal/pdh/registry/utils.go
@@ -1,0 +1,23 @@
+package registry
+
+import (
+	"strconv"
+)
+
+func MapCounterToIndex(name string) string {
+	return strconv.Itoa(int(CounterNameTable.LookupIndex(name)))
+}
+
+func GetPerflibSnapshot(objNames string) (map[string]*PerfObject, error) {
+	objects, err := QueryPerformanceData(objNames, "")
+	if err != nil {
+		return nil, err
+	}
+
+	indexed := make(map[string]*PerfObject)
+	for _, obj := range objects {
+		indexed[obj.Name] = obj
+	}
+
+	return indexed, nil
+}

--- a/internal/pdh/registry/utils_test.go
+++ b/internal/pdh/registry/utils_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/prometheus-community/windows_exporter/internal/pdh/perftypes"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 )
 
 type simple struct {
@@ -40,7 +40,7 @@ func TestUnmarshalPerflib(t *testing.T) {
 							{
 								Def: &PerfCounterDef{
 									Name:        "Something",
-									CounterType: perftypes.PERF_COUNTER_COUNTER,
+									CounterType: pdh.PERF_COUNTER_COUNTER,
 								},
 								Value: 123,
 							},
@@ -60,14 +60,14 @@ func TestUnmarshalPerflib(t *testing.T) {
 							{
 								Def: &PerfCounterDef{
 									Name:        "Something",
-									CounterType: perftypes.PERF_COUNTER_COUNTER,
+									CounterType: pdh.PERF_COUNTER_COUNTER,
 								},
 								Value: 123,
 							},
 							{
 								Def: &PerfCounterDef{
 									Name:           "Something Else",
-									CounterType:    perftypes.PERF_COUNTER_COUNTER,
+									CounterType:    pdh.PERF_COUNTER_COUNTER,
 									HasSecondValue: true,
 								},
 								Value:       256,
@@ -89,7 +89,7 @@ func TestUnmarshalPerflib(t *testing.T) {
 							{
 								Def: &PerfCounterDef{
 									Name:        "Something",
-									CounterType: perftypes.PERF_COUNTER_COUNTER,
+									CounterType: pdh.PERF_COUNTER_COUNTER,
 								},
 								Value: 321,
 							},
@@ -100,7 +100,7 @@ func TestUnmarshalPerflib(t *testing.T) {
 							{
 								Def: &PerfCounterDef{
 									Name:        "Something",
-									CounterType: perftypes.PERF_COUNTER_COUNTER,
+									CounterType: pdh.PERF_COUNTER_COUNTER,
 								},
 								Value: 231,
 							},

--- a/internal/pdh/registry/utils_test.go
+++ b/internal/pdh/registry/utils_test.go
@@ -1,0 +1,136 @@
+package registry
+
+import (
+	"io"
+	"log/slog"
+	"reflect"
+	"testing"
+
+	"github.com/prometheus-community/windows_exporter/internal/pdh/perftypes"
+)
+
+type simple struct {
+	ValA float64 `perflib:"Something"`
+	ValB float64 `perflib:"Something Else"`
+	ValC float64 `perflib:"Something Else,secondvalue"`
+}
+
+func TestUnmarshalPerflib(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		obj  *PerfObject
+
+		expectedOutput []simple
+		expectError    bool
+	}{
+		{
+			name:           "nil check",
+			obj:            nil,
+			expectedOutput: []simple{},
+			expectError:    true,
+		},
+		{
+			name: "Simple",
+			obj: &PerfObject{
+				Instances: []*PerfInstance{
+					{
+						Counters: []*PerfCounter{
+							{
+								Def: &PerfCounterDef{
+									Name:        "Something",
+									CounterType: perftypes.PERF_COUNTER_COUNTER,
+								},
+								Value: 123,
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: []simple{{ValA: 123}},
+			expectError:    false,
+		},
+		{
+			name: "Multiple properties",
+			obj: &PerfObject{
+				Instances: []*PerfInstance{
+					{
+						Counters: []*PerfCounter{
+							{
+								Def: &PerfCounterDef{
+									Name:        "Something",
+									CounterType: perftypes.PERF_COUNTER_COUNTER,
+								},
+								Value: 123,
+							},
+							{
+								Def: &PerfCounterDef{
+									Name:           "Something Else",
+									CounterType:    perftypes.PERF_COUNTER_COUNTER,
+									HasSecondValue: true,
+								},
+								Value:       256,
+								SecondValue: 222,
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: []simple{{ValA: 123, ValB: 256, ValC: 222}},
+			expectError:    false,
+		},
+		{
+			name: "Multiple instances",
+			obj: &PerfObject{
+				Instances: []*PerfInstance{
+					{
+						Counters: []*PerfCounter{
+							{
+								Def: &PerfCounterDef{
+									Name:        "Something",
+									CounterType: perftypes.PERF_COUNTER_COUNTER,
+								},
+								Value: 321,
+							},
+						},
+					},
+					{
+						Counters: []*PerfCounter{
+							{
+								Def: &PerfCounterDef{
+									Name:        "Something",
+									CounterType: perftypes.PERF_COUNTER_COUNTER,
+								},
+								Value: 231,
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: []simple{{ValA: 321}, {ValA: 231}},
+			expectError:    false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			output := make([]simple, 0)
+
+			err := UnmarshalObject(c.obj, &output, logger)
+			if err != nil && !c.expectError {
+				t.Errorf("Did not expect error, got %q", err)
+			}
+
+			if err == nil && c.expectError {
+				t.Errorf("Expected an error, but got ok")
+			}
+
+			if err == nil && !reflect.DeepEqual(output, c.expectedOutput) {
+				t.Errorf("Output mismatch, expected %+v, got %+v", c.expectedOutput, output)
+			}
+		})
+	}
+}

--- a/internal/pdh/types.go
+++ b/internal/pdh/types.go
@@ -13,7 +13,7 @@
 
 //go:build windows
 
-package perfdata
+package pdh
 
 import "github.com/prometheus/client_golang/prometheus"
 

--- a/internal/pdh/types/types.go
+++ b/internal/pdh/types/types.go
@@ -1,0 +1,8 @@
+package types
+
+import "github.com/prometheus-community/windows_exporter/internal/pdh"
+
+type Collector interface {
+	Collect() (pdh.CounterValues, error)
+	Close()
+}

--- a/internal/utils/testutils/testutils.go
+++ b/internal/utils/testutils/testutils.go
@@ -27,7 +27,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/windows_exporter/internal/collector/update"
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/pkg/collector"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -96,8 +96,8 @@ func TestCollector[C collector.Collector, V interface{}](t *testing.T, fn func(*
 	switch {
 	case err == nil:
 	case errors.Is(err, mi.MI_RESULT_INVALID_NAMESPACE),
-		errors.Is(err, perfdata.NewPdhError(perfdata.PdhCstatusNoCounter)),
-		errors.Is(err, perfdata.NewPdhError(perfdata.PdhCstatusNoObject)),
+		errors.Is(err, pdh.NewPdhError(pdh.PdhCstatusNoCounter)),
+		errors.Is(err, pdh.NewPdhError(pdh.PdhCstatusNoObject)),
 		errors.Is(err, update.ErrUpdateServiceDisabled),
 		errors.Is(err, os.ErrNotExist):
 	default:
@@ -111,8 +111,8 @@ func TestCollector[C collector.Collector, V interface{}](t *testing.T, fn func(*
 	switch {
 	// container collector
 	case errors.Is(err, windows.Errno(2151088411)),
-		errors.Is(err, perfdata.ErrPerformanceCounterNotInitialized),
-		errors.Is(err, perfdata.ErrNoData),
+		errors.Is(err, pdh.ErrPerformanceCounterNotInitialized),
+		errors.Is(err, pdh.ErrNoData),
 		errors.Is(err, mi.MI_RESULT_INVALID_NAMESPACE),
 		errors.Is(err, mi.MI_RESULT_INVALID_QUERY),
 		errors.Is(err, update.ErrNoUpdates):

--- a/pkg/collector/collect.go
+++ b/pkg/collector/collect.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/prometheus-community/windows_exporter/internal/mi"
-	"github.com/prometheus-community/windows_exporter/internal/perfdata"
+	"github.com/prometheus-community/windows_exporter/internal/pdh"
 	"github.com/prometheus-community/windows_exporter/internal/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -204,9 +204,9 @@ func (c *Collection) collectCollector(ch chan<- prometheus.Metric, logger *slog.
 		return pending
 	}
 
-	if err != nil && !errors.Is(err, perfdata.ErrNoData) && !errors.Is(err, types.ErrNoData) {
+	if err != nil && !errors.Is(err, pdh.ErrNoData) && !errors.Is(err, types.ErrNoData) {
 		loggerFn := logger.Warn
-		if errors.Is(err, perfdata.ErrPerformanceCounterNotInitialized) || errors.Is(err, mi.MI_RESULT_INVALID_NAMESPACE) {
+		if errors.Is(err, pdh.ErrPerformanceCounterNotInitialized) || errors.Is(err, mi.MI_RESULT_INVALID_NAMESPACE) {
 			loggerFn = logger.Debug
 		}
 


### PR DESCRIPTION
The PDH API doesn't support the instance index. Thats current results a situation, where process based counters are returned with the same name.

Refs:

* https://github.com/oshi/oshi/issues/505#issuecomment-395235285_
* https://stackoverflow.com/questions/36217734/pdh-performance-counter-instance-names

Until a solution is found, the old registry based collector will be included again to mitigate the issue.