### PR TITLE
Draft dhcp scope stats

### DIFF
--- a/internal/mi/callbacks.go
+++ b/internal/mi/callbacks.go
@@ -162,6 +162,8 @@ func (o *OperationUnmarshalCallbacks) InstanceResult(
 			field.SetString(stringValue)
 		case ValueTypeREAL32, ValueTypeREAL64:
 			field.SetFloat(float64(element.value))
+		case ValueTypeINSTANCEA:
+			// todo
 		default:
 			o.errCh <- fmt.Errorf("unsupported value type: %d", element.valueType)
 

--- a/internal/mi/callbacks.go
+++ b/internal/mi/callbacks.go
@@ -164,6 +164,7 @@ func (o *OperationUnmarshalCallbacks) InstanceResult(
 			field.SetFloat(float64(element.value))
 		case ValueTypeINSTANCEA:
 			// todo
+			// https://learn.microsoft.com/en-us/windows/win32/api/mi/ns-mi-mi_constinstancea
 		default:
 			o.errCh <- fmt.Errorf("unsupported value type: %d", element.valueType)
 

--- a/internal/mi/types.go
+++ b/internal/mi/types.go
@@ -49,9 +49,22 @@ func NewNamespace(namespace string) (Namespace, error) {
 var (
 	NamespaceRootCIMv2             = utils.Must(NewNamespace("root/CIMv2"))
 	NamespaceRootWindowsFSRM       = utils.Must(NewNamespace("root/microsoft/windows/fsrm"))
+	NamespaceRootWindowsDHCP       = utils.Must(NewNamespace("root/microsoft/windows/dhcp"))
 	NamespaceRootWebAdministration = utils.Must(NewNamespace("root/WebAdministration"))
 	NamespaceRootMSCluster         = utils.Must(NewNamespace("root/MSCluster"))
 )
+
+type Method *uint16
+
+func NewMethod(methodName string) (Method, error) {
+	return windows.UTF16PtrFromString(methodName)
+}
+
+type Class *uint16
+
+func NewClass(ClassName string) (Class, error) {
+	return windows.UTF16PtrFromString(ClassName)
+}
 
 type Query *uint16
 


### PR DESCRIPTION
#### What this PR does / why we need it
This PR is about including DHCP scope statistic metrics in windows_exporter:
- AddressesFree
- AddressesFreeOnPartnerServer
- AddressesFreeOnThisServer
- AddressesInUse
- AddressesInUseOnPartnerServer
- AddressesInUseOnThisServer
- PendingOffers
- ReservedAddress

Example output
```
# HELP windows_dhcp_scope_addresses_free Number of addresses free on given scope on the DHCP server (AddressesFree)
# TYPE windows_dhcp_scope_addresses_free gauge
windows_dhcp_scope_addresses_free{scope_id="192.168.102.0",superscope_name=""} 50
# HELP windows_dhcp_scope_addresses_free_partner_server Number of addresses free on partner server based on the ownership assignment of the free address pool. Applies to a failover scope. (AddressesFreeOnPartnerServer)
# TYPE windows_dhcp_scope_addresses_free_partner_server gauge
windows_dhcp_scope_addresses_free_partner_server{scope_id="192.168.102.0",superscope_name=""} 20
# HELP windows_dhcp_scope_addresses_free_this_server Number of addresses free on this server based on the ownership assignment of the free address pool. Applies to a failover scope. (AddressesFreeOnThisServer)
# TYPE windows_dhcp_scope_addresses_free_this_server gauge
windows_dhcp_scope_addresses_free_this_server{scope_id="192.168.102.0",superscope_name=""} 30
# HELP windows_dhcp_scope_addresses_in_use Number of addresses in use on given scope on the DHCP server (AddressesInUse)
# TYPE windows_dhcp_scope_addresses_in_use gauge
windows_dhcp_scope_addresses_in_use{scope_id="192.168.102.0",superscope_name=""} 5
# HELP windows_dhcp_scope_addresses_in_use_partner_server Number of addresses leased/renewed by partner server. Applies to a failover scope. (AddressesInUseOnPartnerServer)
# TYPE windows_dhcp_scope_addresses_in_use_partner_server gauge
windows_dhcp_scope_addresses_in_use_partner_server{scope_id="192.168.102.0",superscope_name=""} 2
# HELP windows_dhcp_scope_addresses_in_use_this_server Number of addresses leased/renewed by this server. Applies to a failover scope. (AddressesInUseOnThisServer)
# TYPE windows_dhcp_scope_addresses_in_use_this_server gauge
windows_dhcp_scope_addresses_in_use_this_server{scope_id="192.168.102.0",superscope_name=""} 3
# HELP windows_dhcp_scope_pending_offers Number of pending offers on given scope on the DHCP server (PendingOffers)
# TYPE windows_dhcp_scope_pending_offers gauge
windows_dhcp_scope_pending_offers{scope_id="192.168.102.0",superscope_name=""} 0
# HELP windows_dhcp_scope_reserved_address Number of reserved addresses on given scope on the DHCP server (ReservedAddress)
# TYPE windows_dhcp_scope_reserved_address gauge
windows_dhcp_scope_reserved_address{scope_id="192.168.102.0",superscope_name=""} 1
```

#### Which issue this PR fixes
- fixes #1836 
- fixes #880 

#### Special notes for your reviewer
Unmarshal of the get method's result has to be completed.
OperationUnmarshalCallbacks.InstanceResult does not support ValueTypeINSTANCEA at the moment.