### PR TITLE
Update MSI Installer main.wxs to include exclusion for web URL config files

### DIFF
--- a/installer/main.wxs
+++ b/installer/main.wxs
@@ -59,7 +59,7 @@
             Value="&quot;[%ComSpec]&quot; /c TYPE NUL >>&quot;[ConfigFile_NonDefault][ConfigFile_Default]&quot;"
             Before="CreateConfigFile"
             Sequence="execute"
-            Condition="ConfigFile_NonDefault OR ConfigFile_Default"
+            Condition="(ConfigFile_NonDefault OR ConfigFile_Default) AND NOT CONFIG_FILE ~ http*"
         />
         <CustomAction
             Id="CreateConfigFile"


### PR DESCRIPTION
Signed-off-by: Michael B <michaelb081988@gmail.com>



<!--
    Please give your PR a title in the form "area: short description".  For example "cpu: reduce usage by 95%" or "docs: fix typo in installation.md".

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Performance improvements would need a benchmark test to prove it.

    - All comments should start with a capital letter and end with a full stop.
 -->


#### What this PR does / why we need it

Adds a condition to "CreateConfigFile" to skip if the config file starts with http.

Fixes an issue where the MSI installer would try to create a blank config.yaml file when given a web URL and exits the install early.

#### Which issue this PR fixes

- fixes #1842

#### Special notes for your reviewer

#### Particularly user-facing changes

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes and the area they affect
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
