### PR TITLE
docs: Fix incorrect metric prefix in update collector documentation

### DIFF
--- a/docs/collector.update.md
+++ b/docs/collector.update.md
@@ -11,7 +11,11 @@ The Windows Update service is responsible for managing the installation of updat
 | Data source         | Windows Update service |
 | Enabled by default? | No                     |
 
+
 ## Flags
+
+> [!NOTE]
+> The collector name used in the CLI flags is `updates`, while the metric prefix is `update`. This naming mismatch is known and intentional for compatibility reasons.
 
 ### `--collector.updates.online`
 Whether to search for updates online. If set to `false`, the collector will only list updates that are already found by the Windows Update service.
@@ -22,23 +26,23 @@ Define the interval of scraping Windows Update information
 
 ## Metrics
 
-| Name                           | Description                                   | Type  | Labels                        |
-|--------------------------------|-----------------------------------------------|-------|-------------------------------|
-| `windows_updates_pending_info` | Expose information single pending update item | gauge | `category`,`severity`,`title` |
-| `windows_updates_scrape_query_duration_seconds` | Duration of the last scrape query to the Windows Update API | gauge |  |
-| `windows_updates_scrape_timestamp_seconds` | Timestamp of the last scrape | gauge |  |
+| Name                           | Description                                                 | Type  | Labels                        |
+|--------------------------------|-------------------------------------------------------------|-------|-------------------------------|
+| `windows_update_pending_info` | Expose information for a single pending update item         | gauge | `category`,`severity`,`title` |
+| `windows_update_scrape_query_duration_seconds` | Duration of the last scrape query to the Windows Update API | gauge |  |
+| `windows_update_scrape_timestamp_seconds` | Timestamp of the last scrape                                | gauge |  |
 
 ### Example metrics
 ```
-# HELP windows_updates_pending Pending Windows Updates
-# TYPE windows_updates_pending gauge
-windows_updates_pending{category="Drivers",severity="",title="Intel Corporation - Bluetooth - 23.60.5.10"} 1
-# HELP windows_updates_scrape_query_duration_seconds Duration of the last scrape query to the Windows Update API
-# TYPE windows_updates_scrape_query_duration_seconds gauge
-windows_updates_scrape_query_duration_seconds 2.8161838
-# HELP windows_updates_scrape_timestamp_seconds Timestamp of the last scrape
-# TYPE windows_updates_scrape_timestamp_seconds gauge
-windows_updates_scrape_timestamp_seconds 1.727539734e+09
+# HELP windows_update_pending Pending Windows Updates
+# TYPE windows_update_pending gauge
+windows_update_pending{category="Drivers",severity="",title="Intel Corporation - Bluetooth - 23.60.5.10"} 1
+# HELP windows_update_scrape_query_duration_seconds Duration of the last scrape query to the Windows Update API
+# TYPE windows_update_scrape_query_duration_seconds gauge
+windows_update_scrape_query_duration_seconds 2.8161838
+# HELP windows_update_scrape_timestamp_seconds Timestamp of the last scrape
+# TYPE windows_update_scrape_timestamp_seconds gauge
+windows_update_scrape_timestamp_seconds 1.727539734e+09
 ```
 
 ## Useful queries


### PR DESCRIPTION
## Summary

This PR fixes the metric names in the `docs/collector.update.md` file. The documentation previously used the prefix `updates`, which doesn't match the actual exported metrics. This update aligns the docs with the current code.

## Changes

- Corrected metric names:
  - `windows_updates_pending_info` ➝ `windows_update_pending_info`
  - `windows_updates_scrape_query_duration_seconds` ➝ `windows_update_scrape_query_duration_seconds`
  - `windows_updates_scrape_timestamp_seconds` ➝ `windows_update_scrape_timestamp_seconds`
- Updated example output
- Updated `windows_update_pending_info` description (grammar)
- Added a note to clarify the mismatch between CLI flags and metric prefix

## Notes

Flag names (e.g., `--collector.updates.online`) were intentionally left unchanged to match the collector name in the CLI interface.

Closes #1983

