### PR TITLE
logical_disk: skip unmounted volumes

### DIFF
--- a/internal/collector/logical_disk/logical_disk.go
+++ b/internal/collector/logical_disk/logical_disk.go
@@ -701,6 +701,11 @@ func getAllMountedVolumes() (map[string]string, error) {
 				break
 			}
 
+			if errors.Is(err, windows.ERROR_FILE_NOT_FOUND) {
+				// the volume is not mounted
+				break
+			}
+
 			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
 				rootPathBuf = make([]uint16, (rootPathLen+1)/2)
 


### PR DESCRIPTION
#### What this PR does / why we need it

The `logical_disk` collector may fail if a volume is recognized by Windows but not mounted.  All `logical_disk` metrics will then not be emitted.

In this case, the error logged is something like:

```
source=collect.go:212 msg="collector logical_disk failed after 42.6338ms, resulting in 0 metrics"
  err="failed to get volumes: GetVolumePathNamesForVolumeName: The system cannot find the file specified."
```

This change makes it so the failure from `GetVolumePathNamesForVolumeName` of `ERROR_FILE_NOT_FOUND` is not a hard-stop (will just be skipped), and the gathering of metrics for other volumes will continue.

This scenario can happen when e.g. an uninitialized volume is plugged into the computer.

![image](https://github.com/user-attachments/assets/2e546b56-5515-4683-8f6e-2048c9018aa0)

#### Which issue this PR fixes

n/a

#### Special notes for your reviewer

n/a

#### Particularly user-facing changes

n/a

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes and the area they affect
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
