### PR TITLE
mssql: fix incorrect patch version in windows_mssql_instance_info

### DIFF
--- a/internal/collector/mssql/types.go
+++ b/internal/collector/mssql/types.go
@@ -44,7 +44,7 @@ func newMssqlInstance(key, name string) (mssqlInstance, error) {
 		_ = key.Close()
 	}(k)
 
-	patchVersion, _, err := k.GetStringValue("Version")
+	patchVersion, _, err := k.GetStringValue("PatchLevel")
 	if err != nil {
 		return mssqlInstance{}, fmt.Errorf("couldn't get version from registry: %w", err)
 	}


### PR DESCRIPTION

<!--
    Please give your PR a title in the form "area: short description".  For example "cpu: reduce usage by 95%" or "docs: fix typo in installation.md".

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Performance improvements would need a benchmark test to prove it.

    - All comments should start with a capital letter and end with a full stop.
 -->


#### What this PR does / why we need it
PR changes the key from `Value` to `PatchLevel`, from which it reads in the `mssql` collector.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #2107 

#### Special notes for your reviewer

#### Particularly user-facing changes
Change the value of the `patch` label in `windows_mssql_instance_info`.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes and the area they affect
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
