### PR TITLE
iis: metric collector fix for align metric types with Prometheus conventions Correct 9 metric type misclassifications in IIS collectors: - Changed 8 metrics from Counter to Gauge (timestamps, maximums, active counts, rates) - Changed 1 metric from Gauge to Counter (cumulative rejection total)

### DIFF
--- a/internal/collector/iis/iis_app_pool_was.go
+++ b/internal/collector/iis/iis_app_pool_was.go
@@ -168,6 +168,10 @@ func (c *Collector) buildAppPoolWAS() error {
 }
 
 func (c *Collector) collectAppPoolWAS(ch chan<- prometheus.Metric) error {
+	if c.perfDataCollectorAppPoolWAS == nil {
+		return nil
+	}
+
 	err := c.perfDataCollectorAppPoolWAS.Collect(&c.perfDataObjectAppPoolWAS)
 	if err != nil {
 		return fmt.Errorf("failed to collect APP_POOL_WAS metrics: %w", err)
@@ -239,7 +243,7 @@ func (c *Collector) collectAppPoolWAS(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.totalApplicationPoolUptime,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.TotalApplicationPoolUptime,
 			data.Name,
 		)

--- a/internal/collector/iis/iis_http_service_request_queues.go
+++ b/internal/collector/iis/iis_http_service_request_queues.go
@@ -88,6 +88,10 @@ func (c *Collector) buildHttpServiceRequestQueues() error {
 }
 
 func (c *Collector) collectHttpServiceRequestQueues(ch chan<- prometheus.Metric) error {
+	if c.perfDataCollectorHttpServiceRequestQueues == nil {
+		return nil
+	}
+
 	err := c.perfDataCollectorHttpServiceRequestQueues.Collect(&c.perfDataObjectHttpServiceRequestQueues)
 	if err != nil {
 		return fmt.Errorf("failed to collect Http Service Request Queues metrics: %w", err)
@@ -113,7 +117,7 @@ func (c *Collector) collectHttpServiceRequestQueues(ch chan<- prometheus.Metric)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.httpRequestQueuesTotalRejectedRequest,
-			prometheus.GaugeValue,
+			prometheus.CounterValue,
 			data.HttpRequestQueuesTotalRejectedRequests,
 			data.Name,
 		)

--- a/internal/collector/iis/iis_w3svc_w3wp.go
+++ b/internal/collector/iis/iis_w3svc_w3wp.go
@@ -366,25 +366,25 @@ func (c *Collector) buildW3SVCW3WP() error {
 	)
 	c.w3SVCW3WPWebSocketRequestsActive = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, Name, "worker_current_websocket_requests"),
-		"",
+		"Current number of active WebSocket requests in the worker process",
 		[]string{"app", "pid"},
 		nil,
 	)
 	c.w3SVCW3WPWebSocketConnectionAttempts = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "worker_websocket_connection_attempts_total"),
-		"",
+		prometheus.BuildFQName(types.Namespace, Name, "worker_websocket_connection_attempts_per_sec"),
+		"WebSocket connection attempts per second",
 		[]string{"app", "pid"},
 		nil,
 	)
 	c.w3SVCW3WPWebSocketConnectionsAccepted = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "worker_websocket_connection_accepted_total"),
-		"",
+		prometheus.BuildFQName(types.Namespace, Name, "worker_websocket_connection_accepted_per_sec"),
+		"WebSocket connections accepted per second",
 		[]string{"app", "pid"},
 		nil,
 	)
 	c.w3SVCW3WPWebSocketConnectionsRejected = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "worker_websocket_connection_rejected_total"),
-		"",
+		prometheus.BuildFQName(types.Namespace, Name, "worker_websocket_connection_rejected_per_sec"),
+		"WebSocket connections rejected per second",
 		[]string{"app", "pid"},
 		nil,
 	)
@@ -407,6 +407,10 @@ func (c *Collector) collectW3SVCW3WP(ch chan<- prometheus.Metric) error {
 }
 
 func (c *Collector) collectW3SVCW3WPv8(ch chan<- prometheus.Metric) error {
+	if c.w3SVCW3WPPerfDataCollectorV8 == nil {
+		return nil
+	}
+
 	err := c.w3SVCW3WPPerfDataCollectorV8.Collect(&c.perfDataObjectW3SVCW3WPV8)
 	if err != nil {
 		return fmt.Errorf("failed to collect APP_POOL_WAS metrics: %w", err)
@@ -471,7 +475,7 @@ func (c *Collector) collectW3SVCW3WPv8(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPWebSocketRequestsActive,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPWebSocketRequestsActive,
 			name,
 			pid,
@@ -479,7 +483,7 @@ func (c *Collector) collectW3SVCW3WPv8(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPWebSocketConnectionAttempts,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPWebSocketConnectionAttempts,
 			name,
 			pid,
@@ -487,7 +491,7 @@ func (c *Collector) collectW3SVCW3WPv8(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPWebSocketConnectionsAccepted,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPWebSocketConnectionsAccepted,
 			name,
 			pid,
@@ -495,7 +499,7 @@ func (c *Collector) collectW3SVCW3WPv8(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPWebSocketConnectionsRejected,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPWebSocketConnectionsRejected,
 			name,
 			pid,
@@ -506,6 +510,10 @@ func (c *Collector) collectW3SVCW3WPv8(ch chan<- prometheus.Metric) error {
 }
 
 func (c *Collector) collectW3SVCW3WPv7(ch chan<- prometheus.Metric) error {
+	if c.w3SVCW3WPPerfDataCollector == nil {
+		return nil
+	}
+
 	err := c.w3SVCW3WPPerfDataCollector.Collect(&c.perfDataObjectW3SVCW3WP)
 	if err != nil {
 		return fmt.Errorf("failed to collect APP_POOL_WAS metrics: %w", err)
@@ -539,7 +547,7 @@ func (c *Collector) collectW3SVCW3WPv7(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPMaximumThreads,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPMaximumThreads,
 			name,
 			pid,
@@ -555,7 +563,7 @@ func (c *Collector) collectW3SVCW3WPv7(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPRequestsActive,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPRequestsActive,
 			name,
 			pid,
@@ -579,7 +587,7 @@ func (c *Collector) collectW3SVCW3WPv7(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPMaximumFileCacheMemoryUsage,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPMaximumFileCacheMemoryUsage,
 			name,
 			pid,

--- a/internal/collector/iis/iis_web_service.go
+++ b/internal/collector/iis/iis_web_service.go
@@ -244,6 +244,10 @@ func (c *Collector) buildWebService() error {
 }
 
 func (c *Collector) collectWebService(ch chan<- prometheus.Metric) error {
+	if c.perfDataCollectorWebService == nil {
+		return nil
+	}
+
 	err := c.perfDataCollectorWebService.Collect(&c.perfDataObjectWebService)
 	if err != nil {
 		return fmt.Errorf("failed to collect Web Service metrics: %w", err)

--- a/internal/collector/iis/iis_web_service_cache.go
+++ b/internal/collector/iis/iis_web_service_cache.go
@@ -282,6 +282,10 @@ func (c *Collector) buildWebServiceCache() error {
 }
 
 func (c *Collector) collectWebServiceCache(ch chan<- prometheus.Metric) error {
+	if c.serviceCachePerfDataCollector == nil {
+		return nil
+	}
+
 	err := c.serviceCachePerfDataCollector.Collect(&c.perfDataObjectServiceCache)
 	if err != nil {
 		return fmt.Errorf("failed to collect Web Service Cache metrics: %w", err)


### PR DESCRIPTION
…tric type misclassifications in IIS collectors: - Changed 8 metrics from Counter to Gauge (timestamps, maximums, active counts, rates) - Changed 1 metric from Gauge to Counter (cumulative rejection total)
