### PR TITLE
iis: metric collector fix for align metric types with Prometheus conventions Correct 9 metric type misclassifications in IIS collectors: - Changed 8 metrics from Counter to Gauge (timestamps, maximums, active counts, rates) - Changed 1 metric from Gauge to Counter (cumulative rejection total)

### DIFF
--- a/internal/collector/iis/iis_app_pool_was.go
+++ b/internal/collector/iis/iis_app_pool_was.go
@@ -239,7 +239,7 @@ func (c *Collector) collectAppPoolWAS(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.totalApplicationPoolUptime,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.TotalApplicationPoolUptime,
 			data.Name,
 		)

--- a/internal/collector/iis/iis_http_service_request_queues.go
+++ b/internal/collector/iis/iis_http_service_request_queues.go
@@ -113,7 +113,7 @@ func (c *Collector) collectHttpServiceRequestQueues(ch chan<- prometheus.Metric)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.httpRequestQueuesTotalRejectedRequest,
-			prometheus.GaugeValue,
+			prometheus.CounterValue,
 			data.HttpRequestQueuesTotalRejectedRequests,
 			data.Name,
 		)

--- a/internal/collector/iis/iis_w3svc_w3wp.go
+++ b/internal/collector/iis/iis_w3svc_w3wp.go
@@ -366,25 +366,25 @@ func (c *Collector) buildW3SVCW3WP() error {
 	)
 	c.w3SVCW3WPWebSocketRequestsActive = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, Name, "worker_current_websocket_requests"),
-		"",
+		"Current number of active WebSocket requests in the worker process",
 		[]string{"app", "pid"},
 		nil,
 	)
 	c.w3SVCW3WPWebSocketConnectionAttempts = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "worker_websocket_connection_attempts_total"),
-		"",
+		prometheus.BuildFQName(types.Namespace, Name, "worker_websocket_connection_attempts_per_sec"),
+		"WebSocket connection attempts per second",
 		[]string{"app", "pid"},
 		nil,
 	)
 	c.w3SVCW3WPWebSocketConnectionsAccepted = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "worker_websocket_connection_accepted_total"),
-		"",
+		prometheus.BuildFQName(types.Namespace, Name, "worker_websocket_connection_accepted_per_sec"),
+		"WebSocket connections accepted per second",
 		[]string{"app", "pid"},
 		nil,
 	)
 	c.w3SVCW3WPWebSocketConnectionsRejected = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "worker_websocket_connection_rejected_total"),
-		"",
+		prometheus.BuildFQName(types.Namespace, Name, "worker_websocket_connection_rejected_per_sec"),
+		"WebSocket connections rejected per second",
 		[]string{"app", "pid"},
 		nil,
 	)
@@ -471,7 +471,7 @@ func (c *Collector) collectW3SVCW3WPv8(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPWebSocketRequestsActive,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPWebSocketRequestsActive,
 			name,
 			pid,
@@ -479,7 +479,7 @@ func (c *Collector) collectW3SVCW3WPv8(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPWebSocketConnectionAttempts,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPWebSocketConnectionAttempts,
 			name,
 			pid,
@@ -487,7 +487,7 @@ func (c *Collector) collectW3SVCW3WPv8(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPWebSocketConnectionsAccepted,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPWebSocketConnectionsAccepted,
 			name,
 			pid,
@@ -495,7 +495,7 @@ func (c *Collector) collectW3SVCW3WPv8(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPWebSocketConnectionsRejected,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPWebSocketConnectionsRejected,
 			name,
 			pid,
@@ -539,7 +539,7 @@ func (c *Collector) collectW3SVCW3WPv7(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPMaximumThreads,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPMaximumThreads,
 			name,
 			pid,
@@ -555,7 +555,7 @@ func (c *Collector) collectW3SVCW3WPv7(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPRequestsActive,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPRequestsActive,
 			name,
 			pid,
@@ -579,7 +579,7 @@ func (c *Collector) collectW3SVCW3WPv7(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.w3SVCW3WPMaximumFileCacheMemoryUsage,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			data.W3SVCW3WPMaximumFileCacheMemoryUsage,
 			name,
 			pid,


### PR DESCRIPTION
iis: metric collector fix for align metric types with Prometheus conventions Correct 9 metric type misclassifications in IIS collectors: - Changed 8 metrics from Counter to Gauge (timestamps, maximums, active counts, rates) - Changed 1 metric from Gauge to Counter (cumulative rejection total)