### PR TITLE
os: add system installation date to metrics

### DIFF
--- a/docs/collector.os.md
+++ b/docs/collector.os.md
@@ -14,10 +14,11 @@ None
 
 ## Metrics
 
-| Name                  | Description                                                                                                                                                    | Type  | Labels                                                                 |
-|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|------------------------------------------------------------------------|
-| `windows_os_hostname` | Labelled system hostname information as provided by ComputerSystem.DNSHostName and ComputerSystem.Domain                                                       | gauge | `domain`, `fqdn`, `hostname`                                           |
-| `windows_os_info`     | Contains full product name & version in labels. Note that the `major_version` for Windows 11 is "10"; a build number greater than 22000 represents Windows 11. | gauge | `product`, `version`, `major_version`, `minor_version`, `build_number`, `revision`, `installation_type`, `install_date`|
+| Name                                 | Description                                                                                                                                                    | Type  | Labels                                                                                                          |
+|--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|-----------------------------------------------------------------------------------------------------------------|
+| `windows_os_hostname`                | Labelled system hostname information as provided by ComputerSystem.DNSHostName and ComputerSystem.Domain                                                       | gauge | `domain`, `fqdn`, `hostname`                                                                                    |
+| `windows_os_info`                    | Contains full product name & version in labels. Note that the `major_version` for Windows 11 is "10"; a build number greater than 22000 represents Windows 11. | gauge | `product`, `version`, `major_version`, `minor_version`, `build_number`, `revision`, `installation_type`         |
+| `windows_os_install_time_timestamp`  | Unix timestamp of OS installation time                                                                                                                         | gauge | None                                                                                                            |
 
 ### Example metric
 
@@ -27,7 +28,10 @@ None
 windows_os_hostname{domain="",fqdn="PC",hostname="PC"} 1
 # HELP windows_os_info Contains full product name & version in labels. Note that the "major_version" for Windows 11 is \\"10\\"; a build number greater than 22000 represents Windows 11.
 # TYPE windows_os_info gauge
-windows_os_info{build_number="19045",install_date="1672531200",installation_type="Client",major_version="10",minor_version="0",product="Windows 10 Pro",revision="4842",version="10.0.19045"} 1
+windows_os_info{build_number="19045",installation_type="Client",major_version="10",minor_version="0",product="Windows 10 Pro",revision="4842",version="10.0.19045"} 1
+# HELP windows_os_install_time_timestamp Unix timestamp of OS installation time
+# TYPE windows_os_install_time_timestamp gauge
+windows_os_install_time_timestamp 1.6725312e+09
 ```
 
 ## Useful queries

--- a/tools/e2e-output.txt
+++ b/tools/e2e-output.txt
@@ -287,6 +287,8 @@ windows_exporter_collector_timeout{collector="udp"} 0
 # TYPE windows_os_hostname gauge
 # HELP windows_os_info Contains full product name & version in labels. Note that the "major_version" for Windows 11 is \\"10\\"; a build number greater than 22000 represents Windows 11.
 # TYPE windows_os_info gauge
+# HELP windows_os_install_time_timestamp Unix timestamp of OS installation time
+# TYPE windows_os_install_time_timestamp gauge
 # HELP windows_pagefile_free_bytes Number of bytes that can be mapped into the operating system paging files without causing any other pages to be swapped out
 # TYPE windows_pagefile_free_bytes gauge
 # HELP windows_pagefile_limit_bytes Number of bytes that can be stored in the operating system paging files. 0 (zero) indicates that there are no paging files


### PR DESCRIPTION
## What this PR does / why we need it

Adds the Windows installation date to the `windows_os_info` metric, providing visibility into when the operating system was originally installed. This can be useful for tracking system age, maintenance schedules, and compliance reporting.


## Which issue this PR fixes
- #2280

## Special notes for your reviewer

- The implementation follows the same pattern as the existing `revision` (UBR) registry read
- Installation date is stored as a Unix timestamp in the registry and exposed as a string in the metric label
- Missing registry values are handled gracefully with a default value of "0"
- No breaking changes to existing metrics

## Particularly user-facing changes

- New `install_date` label added to `windows_os_info` metric containing the Unix timestamp of the Windows installation
- Documentation updated to reflect the new label
- Example metric output updated

## Checklist

Complete these before marking the PR as ready to review:

- [x] DCO signed
- [x] The PR title has a summary of the changes and the area they affect
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
