### PR TITLE
cpu: add example query for Task Manager-style CPU utilization

### DIFF
--- a/docs/collector.cpu.md
+++ b/docs/collector.cpu.md
@@ -48,6 +48,27 @@ Show per-cpu utilisation using the processor utility metrics
 ```
 rate(windows_cpu_processor_utility_total{instance="localhost"}[5m]) / rate(windows_cpu_processor_rtc_total{instance="localhost"}[5m])
 ```
+Show average CPU utilization percentage (like Windows Task Manager)
+```
+sum by (instance) (
+  clamp_max(
+    (
+      rate(windows_cpu_processor_utility_total{
+        job=~"$job",
+      }[1m])
+      /
+      rate(windows_cpu_processor_rtc_total{
+        job=~"$job",
+      }[1m])
+    ), 100
+  )
+) /
+count by (instance) (
+  windows_cpu_processor_utility_total{
+    job=~"$job"
+  }
+)
+```
 Show actual average CPU frequency in Hz
 ```
 avg by(instance) (


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds a practical query example to the CPU collector documentation that calculates average CPU utilization percentage across all cores, matching what users see in Windows Task Manager.

The query demonstrates how to properly use the `windows_cpu_processor_utility_total` and `windows_cpu_processor_rtc_total` metrics together with `clamp_max` to get accurate CPU utilization percentages on modern systems with dynamic CPU frequencies.

## Which issue this PR fixes

N/A - This is a documentation enhancement

## Special notes for your reviewer

This query uses `clamp_max` to ensure values don't exceed 100% and divides by the number of cores to get the overall system average, which matches the Task Manager behavior.

## Particularly user-facing changes

Adds a new example query to the CPU collector documentation that helps users calculate CPU utilization in a way that matches Windows Task Manager's display.

## Checklist

- [x] DCO signed
- [x] The PR title has a summary of the changes and the area they affect
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR