### PR TITLE
docs: add alerting examples for CPU and CSV

### DIFF
--- a/docs/collector.mscluster.md
+++ b/docs/collector.mscluster.md
@@ -12,7 +12,7 @@ Enabled by default? | No
 
 ### `--collectors.mscluster.enabled`
 Comma-separated list of collectors to use, for example:
-`--collectors.mscluster.enabled=cluster,network,node,resource,resouregroup`. 
+`--collectors.mscluster.enabled=cluster,network,node,resource,resouregroup`.
 Matching is case-sensitive.
 
 ## Metrics
@@ -183,4 +183,21 @@ count(windows_mscluster_resource_state{type="Network Name"})
 ```
 
 ## Alerting examples
-_This collector does not yet have alerting examples, we would appreciate your help adding them!_
+#### Low free space on cluster shared volume
+```yaml
+# Alerts if volume has less then 20% free space
+- alert: LowCSVFreeSpace
+    expr: |
+        (
+        max by (name, cluster) (windows_mscluster_shared_volumes_free_bytes{name!="ClusterPerformanceHistory"})
+        /
+        max by (name, cluster) (windows_mscluster_shared_volumes_total_bytes{name!="ClusterPerformanceHistory"})
+        ) * 100 < 20
+    for: 10m
+    labels:
+        severity: warning
+    annotations:
+        summary: "Low CSV free space on {{ $labels.name }}"
+        description: |
+        Cluster Shared Volume {{ $labels.name }} on cluster {{ $labels.cluster }} has less than 20% free space (current: {{ printf "%.2f" $value }}%)
+```

--- a/docs/collector.os.md
+++ b/docs/collector.os.md
@@ -38,4 +38,19 @@ windows_os_install_time_timestamp_seconds 1.6725312e+09
 _This collector does not yet have useful queries, we would appreciate your help adding them!_
 
 ## Alerting examples
-_This collector does not yet have alerting examples, we would appreciate your help adding them!_
+
+#### Average CPU utilization over 1 hour exceeds 80% (New CPU metric)
+```yaml
+# Alerts if Agent/Host is down for 5min
+- alert: HypervHostDown
+    expr: up{app="hyper-v"} == 0
+    for: 5m
+    labels:
+        severity: critical
+    annotations:
+        summary: Hyper-V host {{ $labels.instance }} is down
+        description: |
+        Hyper-V host {{ $labels.instance }} has been unreachable for more than 5 minutes.
+        Job: {{ $labels.job }}
+```
+


### PR DESCRIPTION
#### What this PR does / why we need it

This PR adds alerting examples to the CPU collector, OS collector and mscluster collector.

The new alerting examples include:
- High CPU utilization
- Low free space on CSV
- Target down

#### Which issue this PR fixes

#### Special notes for your reviewer
- This PR depends on #2301 for the CSV metrics

#### Particularly user-facing changes

- Added three alerting rule examples to the CPU collector, OS collector and mscluster collector.

#### Checklist

Complete these before marking the PR as `ready to review`:

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes and the area they affect
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR