### PR TITLE
mscluster: rename `windows_hyperv_hypervisor_virtual_processor_time_total` -> `windows_hyperv_hypervisor_virtual_processor_mode_time_total`

### DIFF
--- a/docs/collector.hyperv.md
+++ b/docs/collector.hyperv.md
@@ -154,13 +154,11 @@ Some metrics explained: https://learn.microsoft.com/en-us/archive/blogs/chrisavi
 
 ### Hyper-V Hypervisor Virtual Processor
 
-| Name                                                                           | Description                                                                                                        | Type    | Labels              |
-|--------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|---------|---------------------|
-| `windows_hyperv_hypervisor_virtual_processor_time_total`                       | Time that processor spent in different modes (hypervisor, guest_run, guest_idle, remote)                           | counter | `vm`, `core`, `state` |
-| `windows_hyperv_hypervisor_virtual_processor_mode_time_total`                  | Time that processor spent in different modes (hypervisor, guest_run, guest_idle, remote) **(new name)**            | counter | `vm`, `core`, `state` |
-| `windows_hyperv_hypervisor_virtual_processor_total_run_time_total`             | Time that processor spent                                                                                          | counter | `vm`, `core` |
-| `windows_hyperv_hypervisor_virtual_processor_run_time_total`                   | Time that processor spent **(new name)**                                                                           | counter | `vm`, `core` |
-| `windows_hyperv_hypervisor_virtual_processor_cpu_wait_time_per_dispatch_total` | The average time (in nanoseconds) spent waiting for a virtual processor to be dispatched onto a logical processor. | counter | `vm`, `core` |
+| Name                                                                           | Description                                                                                                        | Type    | Labels                |
+|--------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|---------|-----------------------|
+| `windows_hyperv_hypervisor_virtual_processor_mode_time_total`                  | Time that processor spent in different modes (hypervisor, guest_run, guest_idle, remote)                           | counter | `vm`, `core`, `state` |
+| `windows_hyperv_hypervisor_virtual_processor_run_time_total`                   | Time that processor spent                                                                                          | counter | `vm`, `core`          |
+| `windows_hyperv_hypervisor_virtual_processor_cpu_wait_time_per_dispatch_total` | The average time (in nanoseconds) spent waiting for a virtual processor to be dispatched onto a logical processor. | counter | `vm`, `core`          |
 
 ### Hyper-V Virtual Network Adapter
 

--- a/internal/collector/hyperv/hyperv_hypervisor_virtual_processor.go
+++ b/internal/collector/hyperv/hyperv_hypervisor_virtual_processor.go
@@ -61,7 +61,7 @@ func (c *Collector) buildHypervisorVirtualProcessor() error {
 
 	c.hypervisorVirtualProcessorTimeTotal = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, Name, "hypervisor_virtual_processor_time_total"),
-		"Time that processor spent in different modes (hypervisor, guest_run, guest_idle, remote)",
+		"DEPRECATED: use hypervisor_virtual_processor_mode_time_total. Time that processor spent in different modes (hypervisor, guest_run, guest_idle, remote)",
 		[]string{"vm", "core", "state"},
 		nil,
 	)
@@ -75,7 +75,7 @@ func (c *Collector) buildHypervisorVirtualProcessor() error {
 	// end same metric
 	c.hypervisorVirtualProcessorTotalRunTimeTotal = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, Name, "hypervisor_virtual_processor_total_run_time_total"),
-		"Time that processor spent",
+		"DEPRECATED: use hypervisor_virtual_processor_run_time_total. Time that processor spent",
 		[]string{"vm", "core"},
 		nil,
 	)


### PR DESCRIPTION
#### What this PR does / why we need it

This PR improves the naming clarity of Hyper-V Hypervisor Virtual Processor metrics by introducing more descriptive metric names while maintaining backward compatibility with the existing metrics.

**Changes:**
- Added new metric `windows_hyperv_hypervisor_virtual_processor_mode_time_total` as a clearer replacement for `windows_hyperv_hypervisor_virtual_processor_time_total`
- Added new metric `windows_hyperv_hypervisor_virtual_processor_run_time_total` as a clearer replacement for `windows_hyperv_hypervisor_virtual_processor_total_run_time_total`
- old metrics are kept for compatibility
- Updated collector documentation

**Benefits:**
- Improved metric naming consistency and clarity for users

#### Which issue this PR fixes

*(optional)*

#### Special notes for your reviewer

- The old metric names continue to be exported alongside the new names
- The documentation has been updated

#### Particularly user-facing changes

- New metrics available: `windows_hyperv_hypervisor_virtual_processor_mode_time_total` and `windows_hyperv_hypervisor_virtual_processor_run_time_total`

#### Checklist

- [x] DCO signed
- [x] The PR title: `hyperv: improve virtual processor metrics naming for better clarity`
- [x] The PR body reflects the changes introduced