### PR TITLE
pdh/registry: fix panic when T is a struct type

### DIFF
--- a/internal/pdh/registry/collector.go
+++ b/internal/pdh/registry/collector.go
@@ -53,7 +53,7 @@ func NewCollector[T any](object string, _ []string) (*Collector, error) {
 		counters:       make(map[string]Counter),
 	}
 
-	valueType := reflect.TypeFor[T]().Elem()
+	valueType := reflect.TypeFor[T]()
 
 	if f, ok := valueType.FieldByName("Name"); ok {
 		if f.Type.Kind() == reflect.String {

--- a/internal/pdh/registry/perflib_test.go
+++ b/internal/pdh/registry/perflib_test.go
@@ -21,6 +21,22 @@ import (
 	"testing"
 )
 
+// TestNewCollectorStructTypeParam guards against a regression where
+// reflect.TypeFor[T]().Elem() panicked when T is a plain struct (not a pointer).
+// See https://github.com/prometheus-community/windows_exporter/issues/2365
+func TestNewCollectorStructTypeParam(t *testing.T) {
+	type systemCounterValues struct {
+		Name string
+
+		ProcessorQueueLength float64 `perfdata:"Processor Queue Length"`
+	}
+
+	_, err := NewCollector[systemCounterValues]("System", nil)
+	if err != nil {
+		t.Skipf("skipping: failed to create collector: %v", err)
+	}
+}
+
 func BenchmarkQueryPerformanceData(b *testing.B) {
 	for b.Loop() {
 		_, _ = QueryPerformanceData("Global", "")


### PR DESCRIPTION
#### What this PR does / why we need it

Removes .Elem() call on reflect.TypeFor[T]() that caused a panic when T is a plain struct, introduced by the v2.6.0 modernize linter suggestion.

#### Which issue this PR fixes

- fixes #2365 

#### Special notes for your reviewer

#### Particularly user-facing changes

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes and the area they affect
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
