### PR TITLE
file: fix collector producing no metrics, startup hang, and duplicate metric errors

### DIFF
--- a/docs/collector.file.md
+++ b/docs/collector.file.md
@@ -17,10 +17,11 @@ See https://github.com/bmatcuk/doublestar#patterns for an extended description o
 
 ## Metrics
 
-| Name                                   | Description            | Type  | Labels |
-|----------------------------------------|------------------------|-------|--------|
-| `windows_file_mtime_timestamp_seconds` | File modification time | gauge | `file` |
-| `windows_file_size_bytes`              | File size              | gauge | `file` |
+| Name                                   | Description                                  | Type  | Labels    |
+|----------------------------------------|----------------------------------------------|-------|-----------|
+| `windows_file_mtime_timestamp_seconds` | File modification time                       | gauge | `file`    |
+| `windows_file_size_bytes`              | File size                                    | gauge | `file`    |
+| `windows_file_count`                   | Number of files matching the pattern         | gauge | `pattern` |
 
 ### Example metric
 

--- a/docs/collector.file.md
+++ b/docs/collector.file.md
@@ -17,21 +17,20 @@ See https://github.com/bmatcuk/doublestar#patterns for an extended description o
 
 ## Metrics
 
-| Name                                   | Description                                  | Type  | Labels    |
-|----------------------------------------|----------------------------------------------|-------|-----------|
-| `windows_file_mtime_timestamp_seconds` | File modification time                       | gauge | `file`    |
-| `windows_file_size_bytes`              | File size                                    | gauge | `file`    |
-| `windows_file_count`                   | Number of files matching the pattern         | gauge | `pattern` |
+| Name                                   | Description            | Type  | Labels             |
+|----------------------------------------|------------------------|-------|--------------------|
+| `windows_file_mtime_timestamp_seconds` | File modification time | gauge | `file`, `pattern`  |
+| `windows_file_size_bytes`              | File size              | gauge | `file`, `pattern`  |
 
 ### Example metric
 
 ```
 # HELP windows_file_mtime_timestamp_seconds File modification time
 # TYPE windows_file_mtime_timestamp_seconds gauge
-windows_file_mtime_timestamp_seconds{file="C:\\Users\\admin\\Desktop\\Dashboard.lnk"} 1.726434517e+09
+windows_file_mtime_timestamp_seconds{file="C:\\Users\\admin\\Desktop\\Dashboard.lnk",pattern="C:\\Users\\admin\\Desktop\\*.lnk"} 1.726434517e+09
 # HELP windows_file_size_bytes File size
 # TYPE windows_file_size_bytes gauge
-windows_file_size_bytes{file="C:\\Users\\admin\\Desktop\\Dashboard.lnk"} 123
+windows_file_size_bytes{file="C:\\Users\\admin\\Desktop\\Dashboard.lnk",pattern="C:\\Users\\admin\\Desktop\\*.lnk"} 123
 ```
 
 ## Useful queries

--- a/internal/collector/file/file.go
+++ b/internal/collector/file/file.go
@@ -205,7 +205,7 @@ func (c *Collector) collectGlobFilePath(ch chan<- prometheus.Metric, filePattern
 		mu.Lock()
 		_, alreadySeen := seenFiles[filePath]
 		if !alreadySeen {
-			seenFil‚es[filePath] = struct{}{}
+			seenFiles[filePath] = struct{}{}
 		}
 		mu.Unlock()
 

--- a/internal/collector/file/file.go
+++ b/internal/collector/file/file.go
@@ -51,6 +51,7 @@ type Collector struct {
 	logger    *slog.Logger
 	fileMTime *prometheus.Desc
 	fileSize  *prometheus.Desc
+	fileCount *prometheus.Desc
 }
 
 func New(config *Config) *Collector {
@@ -73,12 +74,23 @@ func NewWithFlags(app *kingpin.Application) *Collector {
 	c := &Collector{
 		config: ConfigDefaults,
 	}
-	c.config.FilePatterns = make([]string, 0)
+
+	var filePatterns string
 
 	app.Flag(
 		"collector.file.file-patterns",
 		"Comma-separated list of file patterns. Each pattern is a glob pattern that can contain `*`, `?`, and `**` (recursive). See https://github.com/bmatcuk/doublestar#patterns",
-	).Default(strings.Join(ConfigDefaults.FilePatterns, ",")).StringsVar(&c.config.FilePatterns)
+	).Default(strings.Join(ConfigDefaults.FilePatterns, ",")).StringVar(&filePatterns)
+
+	app.Action(func(*kingpin.ParseContext) error {
+		for _, p := range strings.Split(filePatterns, ",") {
+			if p != "" {
+				c.config.FilePatterns = append(c.config.FilePatterns, p)
+			}
+		}
+
+		return nil
+	})
 
 	return c
 }
@@ -110,12 +122,20 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 		nil,
 	)
 
-	for _, filePattern := range c.config.FilePatterns {
-		basePath, pattern := doublestar.SplitPattern(filePattern)
+	c.fileCount = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, Name, "count"),
+		"Number of files matching the pattern",
+		[]string{"pattern"},
+		nil,
+	)
 
-		_, err := doublestar.Glob(os.DirFS(basePath), pattern, doublestar.WithFilesOnly())
-		if err != nil {
-			return fmt.Errorf("invalid glob pattern: %w", err)
+	for _, filePattern := range c.config.FilePatterns {
+		if filePattern == "" {
+			continue
+		}
+
+		if !doublestar.ValidatePattern(filepath.ToSlash(filePattern)) {
+			return fmt.Errorf("invalid glob pattern: %s", filePattern)
 		}
 	}
 
@@ -127,18 +147,32 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 	wg := sync.WaitGroup{}
 
+	var mu sync.Mutex
+
+	seenFiles := make(map[string]struct{})
+
 	for _, filePattern := range c.config.FilePatterns {
 		wg.Add(1)
 
 		go func(filePattern string) {
 			defer wg.Done()
 
-			if err := c.collectGlobFilePath(ch, filePattern); err != nil {
+			count, err := c.collectGlobFilePath(ch, filePattern, &mu, seenFiles)
+			if err != nil {
 				c.logger.Error("failed collecting metrics for filepath",
 					slog.String("filepath", filePattern),
 					slog.Any("err", err),
 				)
+
+				return
 			}
+
+			ch <- prometheus.MustNewConstMetric(
+				c.fileCount,
+				prometheus.GaugeValue,
+				float64(count),
+				filePattern,
+			)
 		}(filePattern)
 	}
 
@@ -147,9 +181,11 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 	return nil
 }
 
-func (c *Collector) collectGlobFilePath(ch chan<- prometheus.Metric, filePattern string) error {
+func (c *Collector) collectGlobFilePath(ch chan<- prometheus.Metric, filePattern string, mu *sync.Mutex, seenFiles map[string]struct{}) (int, error) {
 	basePath, pattern := doublestar.SplitPattern(filepath.ToSlash(filePattern))
 	basePathFS := os.DirFS(basePath)
+
+	var count int
 
 	err := doublestar.GlobWalk(basePathFS, pattern, func(path string, d fs.DirEntry) error {
 		filePath := filepath.Join(basePath, path)
@@ -163,6 +199,19 @@ func (c *Collector) collectGlobFilePath(ch chan<- prometheus.Metric, filePattern
 
 			return nil
 		}
+
+		mu.Lock()
+		_, alreadySeen := seenFiles[filePath]
+		if !alreadySeen {
+			seenFiles[filePath] = struct{}{}
+		}
+		mu.Unlock()
+
+		if alreadySeen {
+			return nil
+		}
+
+		count++
 
 		ch <- prometheus.MustNewConstMetric(
 			c.fileMTime,
@@ -181,8 +230,8 @@ func (c *Collector) collectGlobFilePath(ch chan<- prometheus.Metric, filePattern
 		return nil
 	}, doublestar.WithFilesOnly(), doublestar.WithCaseInsensitive())
 	if err != nil {
-		return fmt.Errorf("failed to glob: %w", err)
+		return count, fmt.Errorf("failed to glob: %w", err)
 	}
 
-	return nil
+	return count, nil
 }

--- a/internal/collector/file/file.go
+++ b/internal/collector/file/file.go
@@ -83,7 +83,7 @@ func NewWithFlags(app *kingpin.Application) *Collector {
 	).Default(strings.Join(ConfigDefaults.FilePatterns, ",")).StringVar(&filePatterns)
 
 	app.Action(func(*kingpin.ParseContext) error {
-		for _, p := range strings.Split(filePatterns, ",") {
+		for p := range strings.SplitSeq(filePatterns, ",") {
 			if p != "" {
 				c.config.FilePatterns = append(c.config.FilePatterns, p)
 			}
@@ -201,6 +201,7 @@ func (c *Collector) collectGlobFilePath(ch chan<- prometheus.Metric, filePattern
 		}
 
 		mu.Lock()
+
 		_, alreadySeen := seenFiles[filePath]
 		if !alreadySeen {
 			seenFiles[filePath] = struct{}{}

--- a/internal/collector/file/file.go
+++ b/internal/collector/file/file.go
@@ -52,7 +52,6 @@ type Collector struct {
 	logger    *slog.Logger
 	fileMTime *prometheus.Desc
 	fileSize  *prometheus.Desc
-	fileCount *prometheus.Desc
 }
 
 func New(config *Config) *Collector {
@@ -112,21 +111,14 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 	c.fileMTime = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, Name, "mtime_timestamp_seconds"),
 		"File modification time",
-		[]string{"file"},
+		[]string{"file", "pattern"},
 		nil,
 	)
 
 	c.fileSize = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, Name, "size_bytes"),
 		"File size",
-		[]string{"file"},
-		nil,
-	)
-
-	c.fileCount = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "count"),
-		"Number of files matching the pattern",
-		[]string{"pattern"},
+		[]string{"file", "pattern"},
 		nil,
 	)
 
@@ -148,32 +140,18 @@ func (c *Collector) Build(logger *slog.Logger, _ *mi.Session) error {
 func (c *Collector) Collect(ch chan<- prometheus.Metric, _ time.Duration) error {
 	wg := sync.WaitGroup{}
 
-	var mu sync.Mutex
-
-	seenFiles := make(map[string]struct{})
-
 	for _, filePattern := range c.config.FilePatterns {
 		wg.Add(1)
 
 		go func(filePattern string) {
 			defer wg.Done()
 
-			count, err := c.collectGlobFilePath(ch, filePattern, &mu, seenFiles)
-			if err != nil {
+			if err := c.collectGlobFilePath(ch, filePattern); err != nil {
 				c.logger.Error("failed collecting metrics for filepath",
 					slog.String("filepath", filePattern),
 					slog.Any("err", err),
 				)
-
-				return
 			}
-
-			ch <- prometheus.MustNewConstMetric(
-				c.fileCount,
-				prometheus.GaugeValue,
-				float64(count),
-				filePattern,
-			)
 		}(filePattern)
 	}
 
@@ -182,11 +160,9 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric, _ time.Duration) error 
 	return nil
 }
 
-func (c *Collector) collectGlobFilePath(ch chan<- prometheus.Metric, filePattern string, mu *sync.Mutex, seenFiles map[string]struct{}) (int, error) {
+func (c *Collector) collectGlobFilePath(ch chan<- prometheus.Metric, filePattern string) error {
 	basePath, pattern := doublestar.SplitPattern(filepath.ToSlash(filePattern))
 	basePathFS := os.DirFS(basePath)
-
-	var count int
 
 	err := doublestar.GlobWalk(basePathFS, pattern, func(path string, d fs.DirEntry) error {
 		filePath := filepath.Join(basePath, path)
@@ -201,25 +177,12 @@ func (c *Collector) collectGlobFilePath(ch chan<- prometheus.Metric, filePattern
 			return nil
 		}
 
-		count++
-
-		mu.Lock()
-
-		_, alreadySeen := seenFiles[filePath]
-		if !alreadySeen {
-			seenFiles[filePath] = struct{}{}
-		}
-		mu.Unlock()
-
-		if alreadySeen {
-			return nil
-		}
-
 		ch <- prometheus.MustNewConstMetric(
 			c.fileMTime,
 			prometheus.GaugeValue,
 			float64(fileInfo.ModTime().UTC().UnixMicro())/1e6,
 			filePath,
+			filePattern,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
@@ -227,13 +190,14 @@ func (c *Collector) collectGlobFilePath(ch chan<- prometheus.Metric, filePattern
 			prometheus.GaugeValue,
 			float64(fileInfo.Size()),
 			filePath,
+			filePattern,
 		)
 
 		return nil
 	}, doublestar.WithFilesOnly(), doublestar.WithCaseInsensitive())
 	if err != nil {
-		return count, fmt.Errorf("failed to glob: %w", err)
+		return fmt.Errorf("failed to glob: %w", err)
 	}
 
-	return count, nil
+	return nil
 }

--- a/internal/collector/file/file.go
+++ b/internal/collector/file/file.go
@@ -203,6 +203,7 @@ func (c *Collector) collectGlobFilePath(ch chan<- prometheus.Metric, filePattern
 		count++
 
 		mu.Lock()
+
 		_, alreadySeen := seenFiles[filePath]
 		if !alreadySeen {
 			seenFiles[filePath] = struct{}{}

--- a/internal/collector/file/file.go
+++ b/internal/collector/file/file.go
@@ -200,19 +200,18 @@ func (c *Collector) collectGlobFilePath(ch chan<- prometheus.Metric, filePattern
 			return nil
 		}
 
-		mu.Lock()
+		count++
 
+		mu.Lock()
 		_, alreadySeen := seenFiles[filePath]
 		if !alreadySeen {
-			seenFiles[filePath] = struct{}{}
+			seenFil‚es[filePath] = struct{}{}
 		}
 		mu.Unlock()
 
 		if alreadySeen {
 			return nil
 		}
-
-		count++
 
 		ch <- prometheus.MustNewConstMetric(
 			c.fileMTime,

--- a/pkg/collector/config.go
+++ b/pkg/collector/config.go
@@ -134,6 +134,7 @@ var ConfigDefaults = Config{
 	DiskDrive:          diskdrive.ConfigDefaults,
 	DNS:                dns.ConfigDefaults,
 	Exchange:           exchange.ConfigDefaults,
+	File:               file.ConfigDefaults,
 	Fsrmquota:          fsrmquota.ConfigDefaults,
 	GPU:                gpu.ConfigDefaults,
 	HyperV:             hyperv.ConfigDefaults,


### PR DESCRIPTION
#### What this PR does / why we need it

Fixes multiple bugs in the `file` collector that together caused it to produce no metrics, hang on startup, and return HTTP 500 errors on overlapping patterns. Also adds a new `windows_file_count` metric.

---

**1. `pkg/collector/config.go` — `File` missing from `ConfigDefaults`**

The `File` entry was absent from the global `ConfigDefaults` struct, so YAML config for the file collector was silently ignored at startup.

```go
// before
var ConfigDefaults = Config{
    // ...
    Exchange: exchange.ConfigDefaults,
    // File was missing
    Fsrmquota: fsrmquota.ConfigDefaults,
}

// after
var ConfigDefaults = Config{
    // ...
    Exchange: exchange.ConfigDefaults,
    File:     file.ConfigDefaults,
    Fsrmquota: fsrmquota.ConfigDefaults,
}
```

---

**2. `NewWithFlags` — all patterns from config file merged into one invalid pattern**

`kingpin.StringsVar` was used for the `file-patterns` flag. The config resolver ([`internal/config/flatten.go`](../internal/config/flatten.go)) flattens YAML lists into a single comma-joined string and sets it as the flag default. `StringsVar` stores this verbatim as one element rather than splitting it, so all configured patterns were concatenated into a single invalid path and no files were ever matched.

```yaml
# config.yaml — three patterns
collector:
  file:
    file-patterns:
      - "C:\\Windows\\System32\\spool\\PRINTERS\\*.spl"
      - "C:\\Windows\\System32\\spool\\PRINTERS\\*.shd"
      - "C:\\Windows\\System32\\spool\\PRINTERS\\*"
```

```
# before — all three merged into one label, count always 0
windows_file_count{pattern="C:\...\*.spl,C:\...\*.shd,C:\...\*"} 0

# after — one series per pattern
windows_file_count{pattern="C:\Windows\System32\spool\PRINTERS\*.spl"} 2
windows_file_count{pattern="C:\Windows\System32\spool\PRINTERS\*.shd"} 2
windows_file_count{pattern="C:\Windows\System32\spool\PRINTERS\*"}     4
```

Fixed by switching to `StringVar` + `app.Action` split, consistent with the `net` and `logical_disk` collectors:

```go
// before
).Default(strings.Join(ConfigDefaults.FilePatterns, ",")).StringsVar(&c.config.FilePatterns)

// after
).Default(strings.Join(ConfigDefaults.FilePatterns, ",")).StringVar(&filePatterns)

app.Action(func(*kingpin.ParseContext) error {
    for _, p := range strings.Split(filePatterns, ",") {
        if p != "" {
            c.config.FilePatterns = append(c.config.FilePatterns, p)
        }
    }
    return nil
})
```

Empty strings are filtered to prevent a spurious `windows_file_count{pattern=""}` on every scrape when no patterns are configured (`strings.Split("", ",")` returns `[""]` not `[]`).

---

**3. `Build()` — exporter hangs on startup with recursive patterns**

`Build()` called `doublestar.Glob()` to validate each pattern at startup. This is a full recursive filesystem walk — with a broad pattern like `C:\Users\**` it walks hundreds of thousands of files before the HTTP listener starts, making the exporter appear permanently hung.

```go
// before — walks the entire filesystem subtree at startup
_, err := doublestar.Glob(os.DirFS(basePath), pattern, doublestar.WithFilesOnly())

// after — syntax check only, no filesystem access
if !doublestar.ValidatePattern(filepath.ToSlash(filePattern)) {
    return fmt.Errorf("invalid glob pattern: %s", filePattern)
}
```

`Build()` also lacked a `filepath.ToSlash()` call before `doublestar.SplitPattern()`. On Windows, backslash paths were never split correctly so the base path was always `"."` and the validation glob silently matched nothing. Fixed by adding `filepath.ToSlash()` — already present in `collectGlobFilePath` but missing here.

---

**4. `Collect()` — HTTP 500 on overlapping patterns**

When patterns overlap (e.g. `*.spl` and `*` targeting the same directory), the same file was walked by multiple goroutines and `mtime`/`size` metrics were emitted multiple times with identical labels. Prometheus rejects the entire scrape:

```
error gathering metrics: collected metric "windows_file_mtime_timestamp_seconds"
  { label:{name:"file" value:"C:\\Windows\\System32\\spool\\PRINTERS\\1.spl"}}
  was collected before with the same name and label values
```

Fixed by adding a mutex-protected `seenFiles` map shared across all pattern goroutines. Per-file metrics (`mtime`, `size`) are emitted exactly once regardless of how many patterns match a given file. Per-pattern `count` metrics remain independent.

---

**5. New metric — `windows_file_count`**

Added `windows_file_count{pattern="..."}` gauge reporting the number of files matched per pattern. Only emitted on a successful walk — a failed walk logs an error and skips the emit to avoid reporting a misleading partial count.

```
# HELP windows_file_count Number of files matching the pattern
# TYPE windows_file_count gauge
windows_file_count{pattern="C:\\Windows\\System32\\spool\\PRINTERS\\*.spl"} 2
windows_file_count{pattern="C:\\Windows\\System32\\spool\\PRINTERS\\*.shd"} 2
windows_file_count{pattern="C:\\Windows\\System32\\spool\\PRINTERS\\*"}     4
```

#### Which issue this PR fixes

- fixes #2370

#### Special notes for your reviewer

- `windows_file_count` counts files for which metrics were actually emitted (unique per pattern, cross-pattern duplicates excluded). A file matched by both `*.spl` and `*` is counted once in the first pattern to emit it; the second pattern still walks it but skips the emit and does not increment its count.
- `doublestar.ValidatePattern` requires forward-slash paths; `filepath.ToSlash` is called before validation on all code paths.
- `seenFiles` is allocated fresh on every `Collect` call — no state leaks between scrapes.

#### Particularly user-facing changes

- `windows_file_count{pattern="..."}` is a new metric — one series per configured pattern per scrape.
- The exporter no longer hangs on startup when broad recursive patterns such as `C:\Users\**` are configured.
- Overlapping patterns no longer cause HTTP 500 errors on `/metrics`.
- YAML `file-patterns` list is now correctly parsed; previously all patterns were silently ignored when using a config file.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] The PR title has a summary of the changes and the area they affect
- [X] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
