### PR TITLE
container: fix deserialize HNS response in GetHNSEndpointStats

### DIFF
--- a/internal/headers/hcn/hcn.go
+++ b/internal/headers/hcn/hcn.go
@@ -75,13 +75,21 @@ func GetHNSEndpointStats(endpointID string) (EndpointStats, error) {
 		return EndpointStats{}, err
 	}
 
-	var stats EndpointStats
+	var response struct {
+		Success bool          `json:"Success"`
+		Error   string        `json:"Error"`
+		Output  EndpointStats `json:"Output"`
+	}
 
-	if err := json.Unmarshal([]byte(result), &stats); err != nil {
+	if err := json.Unmarshal([]byte(result), &response); err != nil {
 		return EndpointStats{}, fmt.Errorf("failed to unmarshal JSON %s: %w", result, err)
 	}
 
-	return stats, nil
+	if !response.Success {
+		return EndpointStats{}, fmt.Errorf("HNSCall failed: %s", response.Error)
+	}
+
+	return response.Output, nil
 }
 
 func hnsCall(method, path, body *uint16) (string, error) {


### PR DESCRIPTION
#### What this PR does / why we need it

 The HNS API (HNSCall GET /endpointstats/<id>) returns a wrapped response:
 {"Success":true,"Output":{"BytesReceived":...}}

 GetHNSEndpointStats() was deserializing directly into EndpointStats,
 missing the Output wrapper. Go's json.Unmarshal silently ignored the
 unknown fields, producing a zero-valued struct. This caused all
 container network metrics to always report 0.

 The fix unwraps the response, matching the pattern already
 used by ListEndpoints() in the same file.
 
#### Which issue this PR fixes

 - Fixes: https://github.com/prometheus-community/windows_exporter/issues/2378

#### Special notes for your reviewer

#### Particularly user-facing changes

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes and the area they affect
- [ ] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
