### PR TITLE
logical_disk: append trailing backslash to drive roots for SHCreateItemFromParsingName

### DIFF
--- a/internal/collector/logical_disk/logical_disk.go
+++ b/internal/collector/logical_disk/logical_disk.go
@@ -835,6 +835,15 @@ func (c *Collector) workerBitlocker(ctx context.Context, initErrCh chan<- error)
 			}
 
 			status, err := func(path string) (int, error) {
+				// SHCreateItemFromParsingName requires a trailing backslash to correctly
+				// identify volume roots (e.g. "C:\" instead of "C:") and mount point
+				// directories (e.g. "D:\MOUNT1\" instead of "D:\MOUNT1"). Without it,
+				// drive-root paths silently fail and mount-point paths return a default
+				// property value of 0 (reported as "disabled").
+				if !strings.HasSuffix(path, `\`) {
+					path += `\`
+				}
+
 				item, err := shell32.SHCreateItemFromParsingName(path)
 				if err != nil {
 					return -1, fmt.Errorf("SHCreateItemFromParsingName failed: %w", err)

--- a/internal/collector/logical_disk/logical_disk.go
+++ b/internal/collector/logical_disk/logical_disk.go
@@ -834,6 +834,11 @@ func (c *Collector) workerBitlocker(ctx context.Context, initErrCh chan<- error)
 				continue
 			}
 
+			// TEMP DIAGNOSTIC: query both the bare path and the backslashed path
+			// to determine whether the trailing backslash actually changes the
+			// result of SHCreateItemFromParsingName/GetProperty. REMOVE BEFORE MERGE.
+			c.bitlockerProbe(&pkey, path)
+
 			status, err := func(path string) (int, error) {
 				// SHCreateItemFromParsingName requires a trailing backslash to correctly
 				// identify volume roots (e.g. "C:\" instead of "C:") and mount point
@@ -866,4 +871,44 @@ func (c *Collector) workerBitlocker(ctx context.Context, initErrCh chan<- error)
 			}{err: err, status: status}
 		}
 	}
+}
+
+// bitlockerProbe is a TEMPORARY diagnostic helper. It queries the BitLocker
+// property for both the raw path and the path with a trailing backslash and
+// logs both results, so we can determine whether the trailing backslash
+// actually affects SHCreateItemFromParsingName/GetProperty. REMOVE BEFORE MERGE.
+func (c *Collector) bitlockerProbe(pkey *propsys.PROPERTYKEY, path string) {
+	query := func(p string) (int, error) {
+		item, err := shell32.SHCreateItemFromParsingName(p)
+		if err != nil {
+			return -1, err
+		}
+
+		defer item.Release()
+
+		var v ole.VARIANT
+
+		if err := item.GetProperty(pkey, &v); err != nil {
+			return -1, err
+		}
+
+		val := int(v.Val)
+
+		return val, v.Clear()
+	}
+
+	bare := strings.TrimSuffix(path, `\`)
+	withSlash := bare + `\`
+
+	bareVal, bareErr := query(bare)
+	slashVal, slashErr := query(withSlash)
+
+	c.logger.Info("bitlocker backslash probe",
+		slog.String("bare_path", bare),
+		slog.Int("bare_status", bareVal),
+		slog.Any("bare_err", bareErr),
+		slog.String("slash_path", withSlash),
+		slog.Int("slash_status", slashVal),
+		slog.Any("slash_err", slashErr),
+	)
 }

--- a/internal/collector/logical_disk/logical_disk.go
+++ b/internal/collector/logical_disk/logical_disk.go
@@ -834,21 +834,7 @@ func (c *Collector) workerBitlocker(ctx context.Context, initErrCh chan<- error)
 				continue
 			}
 
-			// TEMP DIAGNOSTIC: query both the bare path and the backslashed path
-			// to determine whether the trailing backslash actually changes the
-			// result of SHCreateItemFromParsingName/GetProperty. REMOVE BEFORE MERGE.
-			c.bitlockerProbe(&pkey, path)
-
 			status, err := func(path string) (int, error) {
-				// SHCreateItemFromParsingName requires a trailing backslash to correctly
-				// identify volume roots (e.g. "C:\" instead of "C:") and mount point
-				// directories (e.g. "D:\MOUNT1\" instead of "D:\MOUNT1"). Without it,
-				// drive-root paths silently fail and mount-point paths return a default
-				// property value of 0 (reported as "disabled").
-				if !strings.HasSuffix(path, `\`) {
-					path += `\`
-				}
-
 				item, err := shell32.SHCreateItemFromParsingName(path)
 				if err != nil {
 					return -1, fmt.Errorf("SHCreateItemFromParsingName failed: %w", err)
@@ -871,44 +857,4 @@ func (c *Collector) workerBitlocker(ctx context.Context, initErrCh chan<- error)
 			}{err: err, status: status}
 		}
 	}
-}
-
-// bitlockerProbe is a TEMPORARY diagnostic helper. It queries the BitLocker
-// property for both the raw path and the path with a trailing backslash and
-// logs both results, so we can determine whether the trailing backslash
-// actually affects SHCreateItemFromParsingName/GetProperty. REMOVE BEFORE MERGE.
-func (c *Collector) bitlockerProbe(pkey *propsys.PROPERTYKEY, path string) {
-	query := func(p string) (int, error) {
-		item, err := shell32.SHCreateItemFromParsingName(p)
-		if err != nil {
-			return -1, err
-		}
-
-		defer item.Release()
-
-		var v ole.VARIANT
-
-		if err := item.GetProperty(pkey, &v); err != nil {
-			return -1, err
-		}
-
-		val := int(v.Val)
-
-		return val, v.Clear()
-	}
-
-	bare := strings.TrimSuffix(path, `\`)
-	withSlash := bare + `\`
-
-	bareVal, bareErr := query(bare)
-	slashVal, slashErr := query(withSlash)
-
-	c.logger.Info("bitlocker backslash probe",
-		slog.String("bare_path", bare),
-		slog.Int("bare_status", bareVal),
-		slog.Any("bare_err", bareErr),
-		slog.String("slash_path", withSlash),
-		slog.Int("slash_status", slashVal),
-		slog.Any("slash_err", slashErr),
-	)
 }

--- a/internal/headers/shell32/shell32.go
+++ b/internal/headers/shell32/shell32.go
@@ -52,8 +52,13 @@ func SHCreateItemFromParsingName(path string) (*IShellItem2, error) {
 		uintptr(unsafe.Pointer(iidIShellItem2)),
 		uintptr(unsafe.Pointer(&result)),
 	)
-	if hr != 0 {
-		return nil, fmt.Errorf("syscall failed: %w", err)
+
+	// procSHCreateItemFromParsingName.Call returns an HRESULT as its first value.
+	// Only the sign bit indicates failure (the FAILED macro); success codes such
+	// as S_OK (0) and S_FALSE (1) must not be treated as errors. The HRESULT, not
+	// GetLastError, carries the COM error information.
+	if int32(hr) < 0 {
+		return nil, fmt.Errorf("SHCreateItemFromParsingName failed: %w", ole.NewError(hr))
 	}
 
 	if result == nil {
@@ -64,15 +69,20 @@ func SHCreateItemFromParsingName(path string) (*IShellItem2, error) {
 }
 
 func (item *IShellItem2) GetProperty(key *propsys.PROPERTYKEY, v *ole.VARIANT) error {
-	hr, _, err := syscall.SyscallN(
+	hr, _, _ := syscall.SyscallN(
 		item.lpVtbl.GetProperty,
 		uintptr(unsafe.Pointer(item)),
 		uintptr(unsafe.Pointer(key)),
 		uintptr(unsafe.Pointer(v)),
 	)
 
-	if hr != 0 {
-		return fmt.Errorf("GetProperty failed: %w", err)
+	// GetProperty is a COM method whose return value is an HRESULT. Only the sign
+	// bit indicates failure (the FAILED macro); success codes such as S_OK (0)
+	// and S_FALSE (1) must not be treated as errors. The third return value of
+	// SyscallN is GetLastError, which COM methods do not set, so it would report
+	// stale, unrelated errors (e.g. "Too many posts were made to a semaphore").
+	if int32(hr) < 0 {
+		return fmt.Errorf("GetProperty failed: %w", ole.NewError(hr))
 	}
 
 	return nil


### PR DESCRIPTION
#### What this PR does / why we need it

Fixes two related defects in the `logical_disk` `bitlocker_status` sub-collector.

**1. Trailing backslash for volume root paths**
`SHCreateItemFromParsingName` needs a trailing `\` for volume roots. Without it, the Shell treats `C:` as a relative path instead of the volume root, so the `System.Volume.BitLockerProtection` property isn't populated. This caused encrypted drives to be reported as `disabled` (default value `0`), or dropped from metrics entirely. Mount points like `D:\MOUNT1` had the same issue. Fix: ensure all volume paths end with a trailing backslash.

Reference: [Microsoft — Fully Qualified vs. Relative Paths](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#fully-qualified-vs-relative-paths)

**2. Report the real COM HRESULT instead of stale `GetLastError`**
The COM wrappers in `internal/headers/shell32/shell32.go` reported the syscall's third return value (`GetLastError`), which COM methods don't set — surfacing misleading errors like `"Too many posts were made to a semaphore."` and `"The operation completed successfully."`. They also used `hr != 0`, wrongly treating success codes like `S_FALSE` (1) as failures. Fix: detect failure with `int32(hr) < 0` (`FAILED(hr)`) and report the actual HRESULT via `ole.NewError(hr)`.

#### Which issue this PR fixes

- fixes [BitLocker Sub Collector Questions #2290](https://github.com/prometheus-community/windows_exporter/issues/2290)

#### Particularly user-facing changes

BitLocker status metrics now correctly report encryption/protection state for drive roots (`C:\`, `D:\`) and mount points — previously missing or wrongly reported as `disabled`. Genuine failures now log the real COM HRESULT. Verified on Windows 11: reports `waiting_for_activation` for C:, matching `manage-bde -status` and `Get-BitLockerVolume`.

#### Checklist

- [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- The PR title has a summary of the changes and the area they affect
- The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR