### PR TITLE
Update README to clarify installer behavior wrt firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The latest release can be downloaded from the [releases page](https://github.com
 All binaries and installation packages are signed with an self-signed certificate. The public key can be found [here](https://github.com/prometheus-community/windows_exporter/blob/master/installer/codesign.cer).
 Once import into the trusted root certificate store, the binaries and installation packages will be trusted.
 
-Each release provides a .msi installer. The installer will setup the windows_exporter as a Windows service, as well as create an exception in the Windows Firewall.
+Each release provides a .msi installer. The installer will setup the windows_exporter as a Windows service, and may create an exception in the Windows Firewall (see example below).
 
 If the installer is run without any parameters, the exporter will run with default settings for enabled collectors, ports, etc.
 


### PR DESCRIPTION
Clarified that the installer MAY create a Windows Firewall exception, instead of WILL.

Firewall exception was created by default until a couple years ago. Seemingly the README wasn't updated then, and still stated that the installer WILL create an exception. The rest of the document doesn't clear it up definitively, even though there is an example where the appropriate argument is passed -- I refer to it in my patch.