### PR TITLE
mscluster: use AllocatedSize for virtual disk storage efficiency

### DIFF
--- a/docs/collector.mscluster.md
+++ b/docs/collector.mscluster.md
@@ -185,8 +185,9 @@ Matching is case-sensitive.
 | `mscluster_virtualdisk_info`                              | Virtual disk information (value is always 1)                                                   | gauge | `name`, `unique_id` |
 | `mscluster_virtualdisk_health_status`                     | Health status of the virtual disk. 0: Healthy, 1: Warning, 2: Unhealthy, 5: Unknown            | gauge | `name`, `unique_id` |
 | `mscluster_virtualdisk_size_bytes`                        | Total size of the virtual disk in bytes                                                        | gauge | `name`, `unique_id` |
+| `mscluster_virtualdisk_allocated_size_bytes`              | Allocated size of the virtual disk in bytes (capacity actually provisioned, excludes thin-provisioned unused capacity) | gauge | `name`, `unique_id` |
 | `mscluster_virtualdisk_footprint_on_pool_bytes`           | Physical storage consumed by the virtual disk on the storage pool in bytes                     | gauge | `name`, `unique_id` |
-| `mscluster_virtualdisk_storage_efficiency_percent`        | Storage efficiency percentage (Size / FootprintOnPool * 100)                                   | gauge | `name`, `unique_id` |
+| `mscluster_virtualdisk_storage_efficiency_percent`        | Storage efficiency percentage (AllocatedSize / FootprintOnPool * 100)                          | gauge | `name`, `unique_id` |
 
 ### Example metric
 Query the state of all cluster resource owned by node1

--- a/internal/collector/mscluster/mscluster_virtualdisk.go
+++ b/internal/collector/mscluster/mscluster_virtualdisk.go
@@ -34,6 +34,7 @@ type collectorVirtualDisk struct {
 	virtualDiskInfo              *prometheus.Desc
 	virtualDiskHealthStatus      *prometheus.Desc
 	virtualDiskSize              *prometheus.Desc
+	virtualDiskAllocatedSize     *prometheus.Desc
 	virtualDiskFootprintOnPool   *prometheus.Desc
 	virtualDiskStorageEfficiency *prometheus.Desc
 }
@@ -44,12 +45,13 @@ type msftVirtualDisk struct {
 	UniqueId        string `mi:"UniqueId"`
 	HealthStatus    uint16 `mi:"HealthStatus"`
 	Size            uint64 `mi:"Size"`
+	AllocatedSize   uint64 `mi:"AllocatedSize"`
 	FootprintOnPool uint64 `mi:"FootprintOnPool"`
 	// OperationalStatus []uint16 `mi:"OperationalStatus"`  Not supported my mi query: https://github.com/prometheus-community/windows_exporter/pull/2296#issuecomment-3736584632
 }
 
 func (c *Collector) buildVirtualDisk() error {
-	wmiSelect := "FriendlyName,UniqueId,HealthStatus,Size,FootprintOnPool"
+	wmiSelect := "FriendlyName,UniqueId,HealthStatus,Size,AllocatedSize,FootprintOnPool"
 
 	virtualDiskMIQuery, err := mi.NewQuery(fmt.Sprintf("SELECT %s FROM MSFT_VirtualDisk", wmiSelect))
 	if err != nil {
@@ -79,6 +81,13 @@ func (c *Collector) buildVirtualDisk() error {
 		nil,
 	)
 
+	c.virtualDiskAllocatedSize = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, nameVirtualDisk, "allocated_size_bytes"),
+		"Allocated size of the virtual disk in bytes (data actually provisioned, excludes thin-provisioned unused capacity)",
+		[]string{"name", "unique_id"},
+		nil,
+	)
+
 	c.virtualDiskFootprintOnPool = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, nameVirtualDisk, "footprint_on_pool_bytes"),
 		"Physical storage consumed by the virtual disk on the storage pool in bytes",
@@ -88,7 +97,7 @@ func (c *Collector) buildVirtualDisk() error {
 
 	c.virtualDiskStorageEfficiency = prometheus.NewDesc(
 		prometheus.BuildFQName(types.Namespace, nameVirtualDisk, "storage_efficiency_percent"),
-		"Storage efficiency percentage (Size / FootprintOnPool * 100)",
+		"Storage efficiency percentage (AllocatedSize / FootprintOnPool * 100)",
 		[]string{"name", "unique_id"},
 		nil,
 	)
@@ -135,6 +144,14 @@ func (c *Collector) collectVirtualDisk(ch chan<- prometheus.Metric, maxScrapeDur
 		)
 
 		ch <- prometheus.MustNewConstMetric(
+			c.virtualDiskAllocatedSize,
+			prometheus.GaugeValue,
+			float64(vdisk.AllocatedSize),
+			vdisk.FriendlyName,
+			vdisk.UniqueId,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
 			c.virtualDiskFootprintOnPool,
 			prometheus.GaugeValue,
 			float64(vdisk.FootprintOnPool),
@@ -142,10 +159,14 @@ func (c *Collector) collectVirtualDisk(ch chan<- prometheus.Metric, maxScrapeDur
 			vdisk.UniqueId,
 		)
 
-		// Calculate storage efficiency (avoid division by zero)
+		// Calculate storage efficiency (avoid division by zero).
+		// AllocatedSize (not Size) is the correct numerator: Size is the
+		// thin-provisioned ceiling, while AllocatedSize reflects the capacity
+		// actually provisioned. Using Size inflates the ratio on thin-provisioned
+		// disks (e.g. S2D FTT2 CSVs).
 		var storageEfficiency float64
 		if vdisk.FootprintOnPool > 0 {
-			storageEfficiency = float64(vdisk.Size) / float64(vdisk.FootprintOnPool) * 100
+			storageEfficiency = float64(vdisk.AllocatedSize) / float64(vdisk.FootprintOnPool) * 100
 		} else {
 			storageEfficiency = 0
 		}


### PR DESCRIPTION
#### What this PR does / why we need it

`storage_efficiency_percent` used `Size` (the thin-provisioned ceiling) as the numerator, which massively inflated the ratio on thin-provisioned disks. On an S2D FTT2 CSV this reported ~5807% instead of the correct ~33%.

Use `AllocatedSize` (capacity actually provisioned) instead, read from the same `MSFT_VirtualDisk` query. Also expose the new `mscluster_virtualdisk_allocated_size_bytes` metric.

Thick/Fixed disks are unaffected since `Size == AllocatedSize` there.

#### Which issue this PR fixes


- fixes #2392

#### Special notes for your reviewer

Verified on a Windows Server 2025 S2D cluster:

| Disk | Provisioning | Size | AllocatedSize | FootprintOnPool | Old (Size/FP) | New (Alloc/FP) |
|------|--------------|------|---------------|-----------------|---------------|----------------|
| FTT2-CSV01–04 | Thin | 23.96 TB | 137.44 GB | 412.59 GB | ~5807% | ~33.3% |
| ClusterPerformanceHistory | Fixed | 25.77 GB | 25.77 GB | 78.92 GB | 32.65% | 32.65% |

The ~33% is physically correct: FTT2 is a three-way mirror, so `FootprintOnPool ≈ 3 × AllocatedSize`, giving a max possible efficiency of ~33% for 3-copy resiliency.

Note: the metric reflects physical storage efficiency including resiliency overhead, so a healthy 3-copy disk now legitimately reports ~33%. The docs example alert `... storage_efficiency_percent < 50` will match every 3-copy mirror by design.

#### Particularly user-facing changes

`mscluster_virtualdisk_storage_efficiency_percent` now reports realistic values for thin-provisioned virtual disks instead of percentages well over 100%. A new `mscluster_virtualdisk_allocated_size_bytes` metric is also exposed.

#### Checklist

Complete these before marking the PR as `ready to review`:

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes and the area they affect
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR