### PR TITLE
pdh: prevent registry deadlocks via exponential buffer growth

### DIFF
--- a/internal/pdh/registry/perflib.go
+++ b/internal/pdh/registry/perflib.go
@@ -243,9 +243,10 @@ func queryRawData(query string) ([]byte, error) {
 
 		switch {
 		case errors.Is(err, error(windows.ERROR_MORE_DATA)):
-			newBuffer := make([]byte, len(buffer)+16384)
-			copy(newBuffer, buffer)
-			buffer = newBuffer
+			// Exponential buffer growth prevents O(N) allocation spin-loops under heavy load.
+			// The previous copy() was removed because the buffer contents are
+			// incomplete/invalid and will be overwritten on the next API call.
+			buffer = make([]byte, len(buffer)*2)
 
 			continue
 		case errors.Is(err, error(windows.ERROR_BUSY)):


### PR DESCRIPTION
### Problem
When querying `HKEY_PERFORMANCE_DATA` via `RegQueryValueExW`, the exporter handles `ERROR_MORE_DATA` by expanding the buffer linearly (adding exactly 16KB) and copying the old buffer contents into the new one. Under heavy system load, Windows performance counter data can grow by megabytes dynamically. This traps the exporter in a severe `O(N)` allocation spin-loop. Furthermore, the `copy()` operation wastes massive amounts of CPU cycles copying incomplete/garbage data that the next Win32 API call will simply overwrite. This combination causes CPU thrashing, memory spikes, and registry scraping deadlocks.

### Fix
* Replaced the linear `+ 16384` buffer expansion with exponential `* 2` growth, allowing the exporter to find the required buffer size in `O(log N)` iterations.
* Removed the unnecessary `copy()` call, eliminating the `O(N)` CPU thrashing during reallocations.

### Verification
* Validated via `go test -v ./internal/pdh/registry/...`.
