### PR TITLE
logical_disk: fix BitLocker shell property handling

### DIFF
--- a/internal/headers/shell32/shell32.go
+++ b/internal/headers/shell32/shell32.go
@@ -52,8 +52,13 @@ func SHCreateItemFromParsingName(path string) (*IShellItem2, error) {
 		uintptr(unsafe.Pointer(iidIShellItem2)),
 		uintptr(unsafe.Pointer(&result)),
 	)
-	if hr != 0 {
-		return nil, fmt.Errorf("syscall failed: %w", err)
+
+	// procSHCreateItemFromParsingName.Call returns an HRESULT as its first value.
+	// Only the sign bit indicates failure (the FAILED macro); success codes such
+	// as S_OK (0) and S_FALSE (1) must not be treated as errors. The HRESULT, not
+	// GetLastError, carries the COM error information.
+	if int32(hr) < 0 {
+		return nil, fmt.Errorf("SHCreateItemFromParsingName failed: %w", ole.NewError(hr))
 	}
 
 	if result == nil {
@@ -64,15 +69,27 @@ func SHCreateItemFromParsingName(path string) (*IShellItem2, error) {
 }
 
 func (item *IShellItem2) GetProperty(key *propsys.PROPERTYKEY, v *ole.VARIANT) error {
-	hr, _, err := syscall.SyscallN(
+	hr, _, _ := syscall.SyscallN(
 		item.lpVtbl.GetProperty,
 		uintptr(unsafe.Pointer(item)),
 		uintptr(unsafe.Pointer(key)),
 		uintptr(unsafe.Pointer(v)),
 	)
 
-	if hr != 0 {
-		return fmt.Errorf("GetProperty failed: %w", err)
+	// GetProperty is a COM method whose return value is an HRESULT. Only the sign
+	// bit indicates failure (the FAILED macro); success codes such as S_OK (0)
+	// and S_FALSE (1) must not be treated as errors. The third return value of
+	// SyscallN is GetLastError, which COM methods do not set, so it would report
+	// stale, unrelated errors (e.g. "Too many posts were made to a semaphore").
+	if int32(hr) < 0 {
+		return fmt.Errorf("GetProperty failed: %w", ole.NewError(hr))
+	}
+
+	// A successful property lookup may still return VT_EMPTY when the Shell
+	// property is unavailable. Keep that distinct from a real numeric zero,
+	// which the BitLocker collector maps to the "disabled" state.
+	if v.VT == ole.VT_EMPTY {
+		v.Val = -1
 	}
 
 	return nil


### PR DESCRIPTION
#### What this PR does / why we need it

Fixes the remaining BitLocker status issue reported in #2290 and incorporates the COM/HRESULT fix from #2404 on top of current `master`.

`IShellItem2::GetProperty` and `SHCreateItemFromParsingName` return COM `HRESULT` values. The previous wrapper used `GetLastError`, which can contain stale and unrelated Win32 errors such as `The operation completed successfully` or `Too many posts were made to a semaphore`.

Additionally, a successful property lookup can return `VT_EMPTY`. In that case `VARIANT.Val` is zero, and the logical disk collector currently interprets zero as BitLocker `disabled`. This PR maps `VT_EMPTY` to `-1` so an unavailable property is kept distinct from a real BitLocker status value.

The collector already treats `-1` as unknown and does not publish the misleading `disabled` status.

Credit to @Dominik-esb for the investigation and original HRESULT changes in #2404.

#### Which issue this PR fixes

- ref #2290
- closes #2404

#### Particularly user-facing changes

BitLocker volumes whose Shell property is returned as `VT_EMPTY` are no longer reported as `disabled` solely because the empty `VARIANT` has a zero value.

#### Testing

Windows-specific behavior still needs validation on an affected system from #2290.

#### Checklist

- [x] DCO signed
- [x] The PR title has a summary of the changes and the area they affect
- [x] The PR body has a summary to reflect significant user-facing changes