### PR TITLE
mi: add support for uint16 array (UINT16A) properties

### DIFF
--- a/internal/mi/instance.go
+++ b/internal/mi/instance.go
@@ -98,13 +98,14 @@ func (instance *Instance) GetElement(elementName string) (*Element, error) {
 		return nil, fmt.Errorf("failed to convert element name %s to UTF-16: %w", elementName, err)
 	}
 
-	// MI_Value is a union whose largest members (MI_Datetime, the array
-	// descriptors) exceed a single machine word. Provide a full-width buffer so
-	// the provider cannot write past it and corrupt the stack when the element
-	// is an array or datetime. Word 0 holds the scalar/pointer/array-data; word
-	// 1 holds the array element count for array types.
+	// MI_Value is a union sized to its largest member. On 64-bit MI_Datetime is
+	// 36 bytes and the union rounds up to 40 bytes for 8-byte alignment, so a
+	// full MI_Value must be provided; the previous single-word buffer let the
+	// provider write past it and corrupt the stack for array or datetime
+	// elements. Word 0 holds the scalar/pointer/array-data; word 1 holds the
+	// array element count for array types.
 	var (
-		valueBuf  [4]uint64
+		valueBuf  [5]uint64
 		valueType ValueType
 	)
 

--- a/internal/mi/instance.go
+++ b/internal/mi/instance.go
@@ -98,8 +98,13 @@ func (instance *Instance) GetElement(elementName string) (*Element, error) {
 		return nil, fmt.Errorf("failed to convert element name %s to UTF-16: %w", elementName, err)
 	}
 
+	// MI_Value is a union whose largest members (MI_Datetime, the array
+	// descriptors) exceed a single machine word. Provide a full-width buffer so
+	// the provider cannot write past it and corrupt the stack when the element
+	// is an array or datetime. Word 0 holds the scalar/pointer/array-data; word
+	// 1 holds the array element count for array types.
 	var (
-		value     uintptr
+		valueBuf  [4]uint64
 		valueType ValueType
 	)
 
@@ -107,7 +112,7 @@ func (instance *Instance) GetElement(elementName string) (*Element, error) {
 		instance.ft.GetElement,
 		uintptr(unsafe.Pointer(instance)),
 		uintptr(unsafe.Pointer(elementNameUTF16)),
-		uintptr(unsafe.Pointer(&value)),
+		uintptr(unsafe.Pointer(&valueBuf)),
 		uintptr(unsafe.Pointer(&valueType)),
 		0,
 		0,
@@ -118,7 +123,8 @@ func (instance *Instance) GetElement(elementName string) (*Element, error) {
 	}
 
 	return &Element{
-		value:     value,
+		value:     uintptr(valueBuf[0]),
+		arrayLen:  uint32(valueBuf[1]),
 		valueType: valueType,
 	}, nil
 }

--- a/internal/mi/mi_test.go
+++ b/internal/mi/mi_test.go
@@ -37,6 +37,12 @@ type win32DiskDrive struct {
 	Capabilities []uint16 `mi:"Capabilities"`
 }
 
+// win32DiskDriveWrongType maps the uint16[] Capabilities property onto an
+// incompatible Go type to exercise the UINT16A type guard.
+type win32DiskDriveWrongType struct {
+	Capabilities []string `mi:"Capabilities"`
+}
+
 func Test_MI_Application_Initialize(t *testing.T) {
 	application, err := mi.ApplicationInitialize()
 	require.NoError(t, err)
@@ -407,6 +413,31 @@ func Test_MI_QueryUnmarshal_Uint16Array(t *testing.T) {
 	}
 
 	require.True(t, found, "expected at least one disk with a non-empty uint16[] Capabilities")
+
+	err = session.Close()
+	require.NoError(t, err)
+
+	err = application.Close()
+	require.NoError(t, err)
+}
+
+func Test_MI_QueryUnmarshal_Uint16Array_WrongType(t *testing.T) {
+	application, err := mi.ApplicationInitialize()
+	require.NoError(t, err)
+	require.NotEmpty(t, application)
+
+	session, err := application.NewSession(nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, session)
+
+	query, err := mi.NewQuery("SELECT Capabilities FROM Win32_DiskDrive")
+	require.NoError(t, err)
+
+	var disks []win32DiskDriveWrongType
+
+	// Unmarshalling a uint16[] into a []string field must error, not panic.
+	err = session.Query(&disks, mi.NamespaceRootCIMv2, query, -1)
+	require.Error(t, err)
 
 	err = session.Close()
 	require.NoError(t, err)

--- a/internal/mi/mi_test.go
+++ b/internal/mi/mi_test.go
@@ -31,6 +31,12 @@ type win32Process struct {
 	Name string `mi:"Name"`
 }
 
+// win32DiskDrive is used to exercise UINT16A (uint16[]) unmarshalling.
+// Win32_DiskDrive.Capabilities is a reliably-populated uint16[] on any host.
+type win32DiskDrive struct {
+	Capabilities []uint16 `mi:"Capabilities"`
+}
+
 func Test_MI_Application_Initialize(t *testing.T) {
 	application, err := mi.ApplicationInitialize()
 	require.NoError(t, err)
@@ -325,6 +331,82 @@ func Test_MI_QueryTimeout(t *testing.T) {
 
 	err = operation.Close()
 	require.NoError(t, err)
+
+	err = session.Close()
+	require.NoError(t, err)
+
+	err = application.Close()
+	require.NoError(t, err)
+}
+
+func Test_MI_Query_Uint16Array(t *testing.T) {
+	application, err := mi.ApplicationInitialize()
+	require.NoError(t, err)
+	require.NotEmpty(t, application)
+
+	session, err := application.NewSession(nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, session)
+
+	operation, err := session.QueryInstances(mi.OperationFlagsStandardRTTI, nil, mi.NamespaceRootCIMv2, mi.QueryDialectWQL, "SELECT Capabilities FROM Win32_DiskDrive")
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+
+	instance, _, err := operation.GetInstance()
+	require.NoError(t, err)
+	require.NotEmpty(t, instance)
+
+	element, err := instance.GetElement("Capabilities")
+	require.NoError(t, err)
+	require.NotEmpty(t, element)
+
+	value, err := element.GetValue()
+	require.NoError(t, err)
+
+	capabilities, ok := value.([]uint16)
+	require.True(t, ok, "Capabilities should unmarshal to []uint16")
+	require.NotEmpty(t, capabilities)
+
+	err = operation.Close()
+	require.NoError(t, err)
+
+	err = session.Close()
+	require.NoError(t, err)
+
+	err = application.Close()
+	require.NoError(t, err)
+}
+
+func Test_MI_QueryUnmarshal_Uint16Array(t *testing.T) {
+	application, err := mi.ApplicationInitialize()
+	require.NoError(t, err)
+	require.NotEmpty(t, application)
+
+	session, err := application.NewSession(nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, session)
+
+	query, err := mi.NewQuery("SELECT Capabilities FROM Win32_DiskDrive")
+	require.NoError(t, err)
+
+	var disks []win32DiskDrive
+
+	err = session.Query(&disks, mi.NamespaceRootCIMv2, query, -1)
+	require.NoError(t, err)
+	require.NotEmpty(t, disks)
+
+	// At least one disk drive should report non-empty capabilities.
+	found := false
+
+	for _, disk := range disks {
+		if len(disk.Capabilities) > 0 {
+			found = true
+
+			break
+		}
+	}
+
+	require.True(t, found, "expected at least one disk with a non-empty uint16[] Capabilities")
 
 	err = session.Close()
 	require.NoError(t, err)

--- a/internal/mi/session.go
+++ b/internal/mi/session.go
@@ -293,6 +293,10 @@ func (s *Session) QueryUnmarshal(dst any,
 				field.SetString(stringValue)
 			case ValueTypeREAL32, ValueTypeREAL64:
 				field.SetFloat(float64(element.value))
+			case ValueTypeUINT16A:
+				if field.Kind() == reflect.Slice {
+					field.Set(reflect.ValueOf(element.getUint16Array()))
+				}
 			default:
 				return fmt.Errorf("unsupported value type: %d", element.valueType)
 			}

--- a/internal/mi/session.go
+++ b/internal/mi/session.go
@@ -294,9 +294,11 @@ func (s *Session) QueryUnmarshal(dst any,
 			case ValueTypeREAL32, ValueTypeREAL64:
 				field.SetFloat(float64(element.value))
 			case ValueTypeUINT16A:
-				if field.Kind() == reflect.Slice {
-					field.Set(reflect.ValueOf(element.getUint16Array()))
+				if field.Type() != reflect.TypeOf([]uint16(nil)) {
+					return fmt.Errorf("cannot unmarshal UINT16A into field of type %s, expected []uint16", field.Type())
 				}
+
+				field.Set(reflect.ValueOf(element.getUint16Array()))
 			default:
 				return fmt.Errorf("unsupported value type: %d", element.valueType)
 			}

--- a/internal/mi/value.go
+++ b/internal/mi/value.go
@@ -66,6 +66,7 @@ const (
 
 type Element struct {
 	value     uintptr
+	arrayLen  uint32
 	valueType ValueType
 }
 
@@ -122,7 +123,24 @@ func (e *Element) GetValue() (any, error) {
 		}
 
 		return strArray, nil
+	case ValueTypeUINT16A:
+		return e.getUint16Array(), nil
 	default:
 		return nil, fmt.Errorf("unsupported value type: %d", e.valueType)
 	}
+}
+
+// getUint16Array reads a UINT16A element into a Go []uint16. The element's
+// value holds the pointer to the MI_Uint16 array and arrayLen its length.
+func (e *Element) getUint16Array() []uint16 {
+	if e.value == 0 || e.arrayLen == 0 {
+		return nil
+	}
+
+	src := unsafe.Slice((*uint16)(unsafe.Pointer(e.value)), e.arrayLen)
+
+	out := make([]uint16, e.arrayLen)
+	copy(out, src)
+
+	return out
 }


### PR DESCRIPTION
#### What this PR does / why we need it

The hand-written `mi` library could not read array-valued WMI properties. `Instance.GetElement` passed a single machine word (8 bytes) as the `MI_Value` out-parameter, but `MI_Value` is a union whose largest members (`MI_Datetime` and the array descriptors) are larger than that. When a queried element was an array, the provider wrote past the buffer and corrupted the stack, which manifested as a hang or scrape timeout.

This PR:

- Passes a full-width buffer to `MI_Instance_GetElement` so the provider can never overflow it.
- Captures the array element count alongside the value pointer on `Element`.
- Adds `UINT16A` (`uint16[]`) handling to both `Element.GetValue` and `Session.QueryUnmarshal`, unmarshalling into a Go `[]uint16`.

This unblocks array-valued properties such as `OperationalStatus` and `ThinProvisioningAlertThresholds` on `MSFT_VirtualDisk` / `MSFT_StoragePool`, which previously had to be dropped.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>` format)*:

Follow-up to the discussion in #2296: https://github.com/prometheus-community/windows_exporter/pull/2296#issuecomment-3736584632

#### Special notes for your reviewer

- Root cause was the undersized value buffer, not just a missing type case; the buffer fix is what prevents the hang described in #2296.
- Only scalar-word semantics are reused for existing types (word 0), so existing scalar/string queries are unaffected.
- Tests use `Win32_DiskDrive.Capabilities` (a reliably-populated `uint16[]` in `root/cimv2`), which runs on the fast provider and avoids the Storage-provider latency seen in #2296.
- Verified end-to-end on a Storage Spaces Direct cluster: `MSFT_StoragePool.OperationalStatus` now unmarshals correctly (`{2}` = OK) with no hang or timeout.

#### Particularly user-facing changes

None directly. This is an internal `mi` capability that enables future collectors to expose `uint16[]` properties.

#### Checklist

- [x] DCO signed
- [x] The PR title has a summary of the changes and the area they affect
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR