### PR TITLE
mscluster: add storagepool metrics

### DIFF
--- a/docs/collector.mscluster.md
+++ b/docs/collector.mscluster.md
@@ -5,14 +5,14 @@ The MSCluster_Cluster class is a dynamic WMI class that represents a cluster.
 |||
 -|-
 Metric name prefix  | `mscluster`
-Classes             | `MSCluster_Cluster`,`MSCluster_Network`,`MSCluster_Node`,`MSCluster_Resource`,`MSCluster_ResourceGroup`,`MSCluster_DiskPartition`,`MSFT_VirtualDisk`
+Classes             | `MSCluster_Cluster`,`MSCluster_Network`,`MSCluster_Node`,`MSCluster_Resource`,`MSCluster_ResourceGroup`,`MSCluster_DiskPartition`,`MSFT_VirtualDisk`,`MSFT_StoragePool`
 Enabled by default? | No
 
 ## Flags
 
 ### `--collectors.mscluster.enabled`
 Comma-separated list of collectors to use, for example:
-`--collectors.mscluster.enabled=cluster,network,node,resource,resouregroup,shared_volumes,virtualdisk`.
+`--collectors.mscluster.enabled=cluster,network,node,resource,resouregroup,shared_volumes,virtualdisk,storagepool`.
 Matching is case-sensitive.
 
 ## Metrics
@@ -188,6 +188,15 @@ Matching is case-sensitive.
 | `mscluster_virtualdisk_allocated_size_bytes`              | Allocated size of the virtual disk in bytes (capacity actually provisioned, excludes thin-provisioned unused capacity) | gauge | `name`, `unique_id` |
 | `mscluster_virtualdisk_footprint_on_pool_bytes`           | Physical storage consumed by the virtual disk on the storage pool in bytes                     | gauge | `name`, `unique_id` |
 | `mscluster_virtualdisk_storage_efficiency_percent`        | Storage efficiency percentage (AllocatedSize / FootprintOnPool * 100)                          | gauge | `name`, `unique_id` |
+
+### Storage Pool
+
+| Name                                          | Description                                                                         | Type  | Labels              |
+|-----------------------------------------------|-------------------------------------------------------------------------------------|-------|---------------------|
+| `mscluster_storagepool_info`                  | Storage pool information (value is always 1)                                        | gauge | `name`, `unique_id` |
+| `mscluster_storagepool_health_status`         | Health status of the storage pool. 0: Healthy, 1: Warning, 2: Unhealthy, 5: Unknown | gauge | `name`, `unique_id` |
+| `mscluster_storagepool_size_bytes`            | Total size of the storage pool in bytes                                             | gauge | `name`, `unique_id` |
+| `mscluster_storagepool_allocated_size_bytes`  | Allocated size of the storage pool in bytes                                         | gauge | `name`, `unique_id` |
 
 ### Example metric
 Query the state of all cluster resource owned by node1

--- a/docs/collector.mscluster.md
+++ b/docs/collector.mscluster.md
@@ -197,6 +197,8 @@ Matching is case-sensitive.
 | `mscluster_storagepool_health_status`         | Health status of the storage pool. 0: Healthy, 1: Warning, 2: Unhealthy, 5: Unknown | gauge | `name`, `unique_id` |
 | `mscluster_storagepool_size_bytes`            | Total size of the storage pool in bytes                                             | gauge | `name`, `unique_id` |
 | `mscluster_storagepool_allocated_size_bytes`  | Allocated size of the storage pool in bytes                                         | gauge | `name`, `unique_id` |
+| `mscluster_storagepool_operational_status`    | Operational status codes reported for the storage pool (one series per status value) | gauge | `name`, `unique_id`, `status` |
+| `mscluster_storagepool_thin_provisioning_alert_thresholds` | Thin provisioning alert thresholds configured for the storage pool, in percent (one series per configured threshold) | gauge | `name`, `unique_id`, `threshold` |
 
 ### Example metric
 Query the state of all cluster resource owned by node1

--- a/internal/collector/mscluster/mscluster.go
+++ b/internal/collector/mscluster/mscluster.go
@@ -41,6 +41,7 @@ const (
 	subCollectorResourceGroup = "resourcegroup"
 	subCollectorSharedVolumes = "shared_volumes"
 	subCollectorVirtualDisk   = "virtualdisk"
+	subCollectorStoragePool   = "storagepool"
 )
 
 type Config struct {
@@ -57,6 +58,7 @@ var ConfigDefaults = Config{
 		subCollectorResourceGroup,
 		subCollectorSharedVolumes,
 		subCollectorVirtualDisk,
+		subCollectorStoragePool,
 	},
 }
 
@@ -69,6 +71,7 @@ type Collector struct {
 	collectorResourceGroup
 	collectorSharedVolumes
 	collectorVirtualDisk
+	collectorStoragePool
 
 	config    Config
 	miSession *mi.Session
@@ -175,6 +178,12 @@ func (c *Collector) Build(_ *slog.Logger, miSession *mi.Session) error {
 		}
 	}
 
+	if slices.Contains(c.config.CollectorsEnabled, subCollectorStoragePool) {
+		if err := c.buildStoragePool(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to build storagepool collector: %w", err))
+		}
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -185,10 +194,10 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric, maxScrapeDuration time.
 		return nil
 	}
 
-	errCh := make(chan error, 7)
+	errCh := make(chan error, 8)
 
 	wg := sync.WaitGroup{}
-	wg.Add(7)
+	wg.Add(8)
 
 	go func() {
 		defer wg.Done()
@@ -261,6 +270,16 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric, maxScrapeDuration time.
 		if slices.Contains(c.config.CollectorsEnabled, subCollectorVirtualDisk) {
 			if err := c.collectVirtualDisk(ch, maxScrapeDuration); err != nil {
 				errCh <- fmt.Errorf("failed to collect virtualdisk metrics: %w", err)
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		if slices.Contains(c.config.CollectorsEnabled, subCollectorStoragePool) {
+			if err := c.collectStoragePool(ch, maxScrapeDuration); err != nil {
+				errCh <- fmt.Errorf("failed to collect storagepool metrics: %w", err)
 			}
 		}
 	}()

--- a/internal/collector/mscluster/mscluster_storagepool.go
+++ b/internal/collector/mscluster/mscluster_storagepool.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package mscluster
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus-community/windows_exporter/internal/mi"
+	"github.com/prometheus-community/windows_exporter/internal/types"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const nameStoragePool = Name + "_storagepool"
+
+type collectorStoragePool struct {
+	storagePoolMIQuery mi.Query
+
+	storagePoolInfo          *prometheus.Desc
+	storagePoolHealthStatus  *prometheus.Desc
+	storagePoolSize          *prometheus.Desc
+	storagePoolAllocatedSize *prometheus.Desc
+}
+
+// msftStoragePool represents the MSFT_StoragePool WMI class
+type msftStoragePool struct {
+	FriendlyName  string `mi:"FriendlyName"`
+	UniqueId      string `mi:"UniqueId"`
+	HealthStatus  uint16 `mi:"HealthStatus"`
+	Size          uint64 `mi:"Size"`
+	AllocatedSize uint64 `mi:"AllocatedSize"`
+	// OperationalStatus []uint16 `mi:"OperationalStatus"`  Not supported by mi query: https://github.com/prometheus-community/windows_exporter/pull/2296#issuecomment-3736584632
+	// ThinProvisioningAlertThresholds []uint16 `mi:"ThinProvisioningAlertThresholds"`  Not supported by mi query (array), see OperationalStatus above.
+}
+
+func (c *Collector) buildStoragePool() error {
+	wmiSelect := "FriendlyName,UniqueId,HealthStatus,Size,AllocatedSize"
+
+	storagePoolMIQuery, err := mi.NewQuery(fmt.Sprintf("SELECT %s FROM MSFT_StoragePool", wmiSelect))
+	if err != nil {
+		return fmt.Errorf("failed to create WMI query: %w", err)
+	}
+
+	c.storagePoolMIQuery = storagePoolMIQuery
+
+	c.storagePoolInfo = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, nameStoragePool, "info"),
+		"Storage pool information (value is always 1)",
+		[]string{"name", "unique_id"},
+		nil,
+	)
+
+	c.storagePoolHealthStatus = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, nameStoragePool, "health_status"),
+		"Health status of the storage pool. 0: Healthy, 1: Warning, 2: Unhealthy, 5: Unknown",
+		[]string{"name", "unique_id"},
+		nil,
+	)
+
+	c.storagePoolSize = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, nameStoragePool, "size_bytes"),
+		"Total size of the storage pool in bytes",
+		[]string{"name", "unique_id"},
+		nil,
+	)
+
+	c.storagePoolAllocatedSize = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, nameStoragePool, "allocated_size_bytes"),
+		"Allocated size of the storage pool in bytes",
+		[]string{"name", "unique_id"},
+		nil,
+	)
+
+	var dst []msftStoragePool
+
+	if err := c.miSession.Query(&dst, mi.NamespaceRootStorage, c.storagePoolMIQuery, 0); err != nil {
+		return fmt.Errorf("WMI query failed: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Collector) collectStoragePool(ch chan<- prometheus.Metric, maxScrapeDuration time.Duration) error {
+	var dst []msftStoragePool
+
+	if err := c.miSession.Query(&dst, mi.NamespaceRootStorage, c.storagePoolMIQuery, maxScrapeDuration); err != nil {
+		return fmt.Errorf("WMI query failed: %w", err)
+	}
+
+	for _, pool := range dst {
+		ch <- prometheus.MustNewConstMetric(
+			c.storagePoolInfo,
+			prometheus.GaugeValue,
+			1.0,
+			pool.FriendlyName,
+			pool.UniqueId,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.storagePoolHealthStatus,
+			prometheus.GaugeValue,
+			float64(pool.HealthStatus),
+			pool.FriendlyName,
+			pool.UniqueId,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.storagePoolSize,
+			prometheus.GaugeValue,
+			float64(pool.Size),
+			pool.FriendlyName,
+			pool.UniqueId,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.storagePoolAllocatedSize,
+			prometheus.GaugeValue,
+			float64(pool.AllocatedSize),
+			pool.FriendlyName,
+			pool.UniqueId,
+		)
+	}
+
+	return nil
+}

--- a/internal/collector/mscluster/mscluster_storagepool.go
+++ b/internal/collector/mscluster/mscluster_storagepool.go
@@ -19,6 +19,7 @@ package mscluster
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/prometheus-community/windows_exporter/internal/mi"
@@ -31,10 +32,12 @@ const nameStoragePool = Name + "_storagepool"
 type collectorStoragePool struct {
 	storagePoolMIQuery mi.Query
 
-	storagePoolInfo          *prometheus.Desc
-	storagePoolHealthStatus  *prometheus.Desc
-	storagePoolSize          *prometheus.Desc
-	storagePoolAllocatedSize *prometheus.Desc
+	storagePoolInfo                            *prometheus.Desc
+	storagePoolHealthStatus                    *prometheus.Desc
+	storagePoolSize                            *prometheus.Desc
+	storagePoolAllocatedSize                   *prometheus.Desc
+	storagePoolOperationalStatus               *prometheus.Desc
+	storagePoolThinProvisioningAlertThresholds *prometheus.Desc
 }
 
 // msftStoragePool represents the MSFT_StoragePool WMI class
@@ -44,12 +47,13 @@ type msftStoragePool struct {
 	HealthStatus  uint16 `mi:"HealthStatus"`
 	Size          uint64 `mi:"Size"`
 	AllocatedSize uint64 `mi:"AllocatedSize"`
-	// OperationalStatus []uint16 `mi:"OperationalStatus"`  Not supported by mi query: https://github.com/prometheus-community/windows_exporter/pull/2296#issuecomment-3736584632
-	// ThinProvisioningAlertThresholds []uint16 `mi:"ThinProvisioningAlertThresholds"`  Not supported by mi query (array), see OperationalStatus above.
+	// OperationalStatus and ThinProvisioningAlertThresholds are uint16 arrays and require the mi UINT16A support from #2490.
+	OperationalStatus               []uint16 `mi:"OperationalStatus"`
+	ThinProvisioningAlertThresholds []uint16 `mi:"ThinProvisioningAlertThresholds"`
 }
 
 func (c *Collector) buildStoragePool() error {
-	wmiSelect := "FriendlyName,UniqueId,HealthStatus,Size,AllocatedSize"
+	wmiSelect := "FriendlyName,UniqueId,HealthStatus,Size,AllocatedSize,OperationalStatus,ThinProvisioningAlertThresholds"
 
 	storagePoolMIQuery, err := mi.NewQuery(fmt.Sprintf("SELECT %s FROM MSFT_StoragePool", wmiSelect))
 	if err != nil {
@@ -83,6 +87,20 @@ func (c *Collector) buildStoragePool() error {
 		prometheus.BuildFQName(types.Namespace, nameStoragePool, "allocated_size_bytes"),
 		"Allocated size of the storage pool in bytes",
 		[]string{"name", "unique_id"},
+		nil,
+	)
+
+	c.storagePoolOperationalStatus = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, nameStoragePool, "operational_status"),
+		"Operational status codes reported for the storage pool (one series per status value).",
+		[]string{"name", "unique_id", "status"},
+		nil,
+	)
+
+	c.storagePoolThinProvisioningAlertThresholds = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, nameStoragePool, "thin_provisioning_alert_thresholds"),
+		"Thin provisioning alert thresholds configured for the storage pool, in percent (one series per configured threshold).",
+		[]string{"name", "unique_id", "threshold"},
 		nil,
 	)
 
@@ -134,6 +152,28 @@ func (c *Collector) collectStoragePool(ch chan<- prometheus.Metric, maxScrapeDur
 			pool.FriendlyName,
 			pool.UniqueId,
 		)
+
+		for _, status := range pool.OperationalStatus {
+			ch <- prometheus.MustNewConstMetric(
+				c.storagePoolOperationalStatus,
+				prometheus.GaugeValue,
+				1.0,
+				pool.FriendlyName,
+				pool.UniqueId,
+				strconv.Itoa(int(status)),
+			)
+		}
+
+		for _, threshold := range pool.ThinProvisioningAlertThresholds {
+			ch <- prometheus.MustNewConstMetric(
+				c.storagePoolThinProvisioningAlertThresholds,
+				prometheus.GaugeValue,
+				1.0,
+				pool.FriendlyName,
+				pool.UniqueId,
+				strconv.Itoa(int(threshold)),
+			)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
#### What this PR does / why we need it

Adds a `storagepool` sub-collector to the `mscluster` collector, exposing metrics for Windows Failover Cluster / Storage Spaces Direct storage pools from the `MSFT_StoragePool` WMI class (`root/Microsoft/Windows/Storage`):

- `windows_mscluster_storagepool_info` — pool information (always 1), labelled with friendly name and unique id.
- `windows_mscluster_storagepool_health_status` — 0: Healthy, 1: Warning, 2: Unhealthy, 5: Unknown.
- `windows_mscluster_storagepool_size_bytes` — total pool size.
- `windows_mscluster_storagepool_allocated_size_bytes` — allocated pool size.
- `windows_mscluster_storagepool_operational_status` — operational status codes (one series per value).
- `windows_mscluster_storagepool_thin_provisioning_alert_thresholds` — configured thin-provisioning alert thresholds in percent (one series per value).

This complements the existing `virtualdisk` sub-collector for storage pool capacity planning and health alerting.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>` format)*:

#### Special notes for your reviewer

- **The `operational_status` and `thin_provisioning_alert_thresholds` metrics read `uint16[]` WMI properties and therefore depend on the `mi` UINT16A support in #2490!** 

- Follow-up to the discussion in #2296: https://github.com/prometheus-community/windows_exporter/pull/2296#issuecomment-3736584632
- Requires Windows Server with Failover Clustering / Storage Spaces. Enable via `--collectors.enabled=mscluster --collector.mscluster.enabled=storagepool`.
- Verified on a Storage Spaces Direct cluster: scalar metrics and `operational_status` (`{2}` = OK) confirmed; no hang or timeout (few pool instances).

#### Particularly user-facing changes

- New `storagepool` sub-collector under `mscluster`, enabled by default within the `mscluster` collector's sub-collector list. Documentation added in `docs/collector.mscluster.md`.

#### Checklist

- [x] DCO signed
- [x] The PR title has a summary of the changes and the area they affect
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR