### PR TITLE
os: add WMI health metric

### DIFF
--- a/docs/collector.os.md
+++ b/docs/collector.os.md
@@ -19,6 +19,7 @@ None
 | `windows_os_hostname`                        | Labelled system hostname information as provided by ComputerSystem.DNSHostName and ComputerSystem.Domain                                                       | gauge | `domain`, `fqdn`, `hostname`                                                                                    |
 | `windows_os_info`                            | Contains full product name & version in labels. Note that the `major_version` for Windows 11 is "10"; a build number greater than 22000 represents Windows 11. | gauge | `product`, `version`, `major_version`, `minor_version`, `build_number`, `revision`, `installation_type`         |
 | `windows_os_install_time_timestamp_seconds`  | Unix timestamp of OS installation time                                                                                                                         | gauge | None                                                                                                            |
+| `windows_os_wmi_health`                      | WMI health status. 1 if WMI is healthy and responding, 0 if WMI is broken or not responding                                                                    | gauge | None                                                                                                            |
 
 ### Example metric
 
@@ -32,7 +33,45 @@ windows_os_info{build_number="19045",installation_type="Client",major_version="1
 # HELP windows_os_install_time_timestamp_seconds Unix timestamp of OS installation time
 # TYPE windows_os_install_time_timestamp_seconds gauge
 windows_os_install_time_timestamp_seconds 1.6725312e+09
+# HELP windows_os_wmi_health WMI health status. 1 if WMI is healthy and responding, 0 if WMI is broken or not responding
+# TYPE windows_os_wmi_health gauge
+windows_os_wmi_health 1
 ```
+
+### `windows_os_wmi_health`
+
+`windows_os_wmi_health` reports whether the exporter can complete a minimal WMI query
+(`SELECT CSName FROM Win32_OperatingSystem`). It is `1` when the query succeeds and `0`
+when it fails or does not complete within the scrape timeout.
+
+WMI can stop responding while the host and the exporter otherwise keep running. Every
+WMI-backed collector then goes quiet, which from the scraped metrics alone is
+indistinguishable from the corresponding feature not being installed. This metric
+separates the two cases.
+
+On a Hyper-V cluster node a `0` is a serious condition. Management tooling that relies on
+WMI, such as Failover Cluster Manager, will generally fail to connect to the host as well,
+and in practice recovering the WMI service often requires rebooting the host.
+
+Example alert:
+
+```yaml
+- alert: WindowsWMIUnhealthy
+  expr: windows_os_wmi_health == 0
+  for: 5m
+  labels:
+    severity: critical
+  annotations:
+    summary: WMI is not responding on {{ $labels.instance }}
+    description: |
+      A minimal WMI query has failed for more than 5 minutes. WMI-backed collectors
+      will be reporting no data. On a cluster node, Failover Cluster Manager is likely
+      unable to connect to this host.
+```
+
+Note that the query runs against `root/cimv2`. A failure of that namespace indicates a
+broad WMI problem; it does not by itself prove that every other namespace is affected.
+
 
 ## Useful queries
 _This collector does not yet have useful queries, we would appreciate your help adding them!_

--- a/internal/collector/os/os.go
+++ b/internal/collector/os/os.go
@@ -45,11 +45,15 @@ var ConfigDefaults = Config{}
 type Collector struct {
 	config Config
 
+	miSession *mi.Session
+	miQuery   mi.Query
+
 	installTimeTimestamp float64
 
 	hostname      *prometheus.Desc
 	osInformation *prometheus.Desc
 	installTime   *prometheus.Desc
+	wmiHealth     *prometheus.Desc
 }
 
 func New(config *Config) *Collector {
@@ -76,7 +80,20 @@ func (c *Collector) Close() error {
 	return nil
 }
 
-func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
+func (c *Collector) Build(_ *slog.Logger, miSession *mi.Session) error {
+	if miSession == nil {
+		return errors.New("miSession is nil")
+	}
+
+	c.miSession = miSession
+
+	miQuery, err := mi.NewQuery("SELECT CSName FROM Win32_OperatingSystem")
+	if err != nil {
+		return fmt.Errorf("failed to create WMI query: %w", err)
+	}
+
+	c.miQuery = miQuery
+
 	productName, revision, installationType, err := c.getWindowsVersion()
 	if err != nil {
 		return fmt.Errorf("failed to get Windows version: %w", err)
@@ -123,8 +140,15 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 	)
 
 	c.installTime = prometheus.NewDesc(
-		prometheus.BuildFQName(types.Namespace, Name, "install_time_timestamp_seconds"),
+		prometheus.BuildFQName(types.Namespace, Name, "install_time_timestamp"),
 		"Unix timestamp of OS installation time",
+		nil,
+		nil,
+	)
+
+	c.wmiHealth = prometheus.NewDesc(
+		prometheus.BuildFQName(types.Namespace, Name, "wmi_health"),
+		"WMI health status. 1 if WMI is healthy and responding, 0 if WMI is broken or not responding",
 		nil,
 		nil,
 	)
@@ -134,7 +158,7 @@ func (c *Collector) Build(_ *slog.Logger, _ *mi.Session) error {
 
 // Collect sends the metric values for each metric
 // to the provided prometheus Metric channel.
-func (c *Collector) Collect(ch chan<- prometheus.Metric, _ time.Duration) error {
+func (c *Collector) Collect(ch chan<- prometheus.Metric, maxScrapeDuration time.Duration) error {
 	errs := make([]error, 0)
 
 	ch <- prometheus.MustNewConstMetric(
@@ -152,6 +176,8 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric, _ time.Duration) error 
 	if err := c.collectHostname(ch); err != nil {
 		errs = append(errs, fmt.Errorf("failed to collect hostname metrics: %w", err))
 	}
+
+	c.collectWMIHealth(ch, maxScrapeDuration)
 
 	return errors.Join(errs...)
 }
@@ -233,4 +259,28 @@ func (c *Collector) getInstallTime() (float64, error) {
 	}
 
 	return float64(installDate), nil
+}
+
+// win32OperatingSystem is a struct for the Win32_OperatingSystem WMI class.
+// Only CSName is needed to verify WMI is working.
+type win32OperatingSystem struct {
+	CSName string `mi:"CSName"`
+}
+
+// collectWMIHealth queries WMI to check if it's healthy.
+// If the query succeeds, it reports 1 (healthy), otherwise 0 (unhealthy).
+func (c *Collector) collectWMIHealth(ch chan<- prometheus.Metric, maxScrapeDuration time.Duration) {
+	var dst []win32OperatingSystem
+
+	healthValue := 1.0
+
+	if err := c.miSession.Query(&dst, mi.NamespaceRootCIMv2, c.miQuery, maxScrapeDuration); err != nil {
+		healthValue = 0.0
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.wmiHealth,
+		prometheus.GaugeValue,
+		healthValue,
+	)
 }

--- a/tools/e2e-output.txt
+++ b/tools/e2e-output.txt
@@ -289,6 +289,8 @@ windows_exporter_collector_timeout{collector="udp"} 0
 # TYPE windows_os_info gauge
 # HELP windows_os_install_time_timestamp_seconds Unix timestamp of OS installation time
 # TYPE windows_os_install_time_timestamp_seconds gauge
+# HELP windows_os_wmi_health WMI health status. 1 if WMI is healthy and responding, 0 if WMI is broken or not responding
+# TYPE windows_os_wmi_health gauge
 # HELP windows_pagefile_free_bytes Number of bytes that can be mapped into the operating system paging files without causing any other pages to be swapped out
 # TYPE windows_pagefile_free_bytes gauge
 # HELP windows_pagefile_limit_bytes Number of bytes that can be stored in the operating system paging files. 0 (zero) indicates that there are no paging files


### PR DESCRIPTION
#### What this PR does / why we need it

WMI can stop responding while the host and the exporter otherwise keep running. 

This is a recurring problem on Hyper-V cluster nodes. When WMI stops responding there, Failover Cluster Manager generally cannot connect to the host either, and recovering usually requires a reboot.

This PR adds `windows_os_wmi_health`, a gauge that reports `1` when a minimal `SELECT CSName FROM Win32_OperatingSystem` query succeeds and `0` when it fails.

#### Which issue this PR fixes

None.

#### Special notes for reviewer

This check may be somewhat specific to how we operate our Hyper-V clusters, but I think other Hyper-V admins would benefit from it too.

#### Particularly user-facing changes

Adds `windows_os_wmi_health` (gauge, no labels). 

#### Checklist

- [x] DCO signed
- [x] The PR title has a summary of the changes and the area they affect
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
